### PR TITLE
feat: Add English-only applications exclusion feature

### DIFF
--- a/Sources/OpenKey/engine/SmartSwitchKey.h
+++ b/Sources/OpenKey/engine/SmartSwitchKey.h
@@ -35,4 +35,34 @@ int getAppInputMethodStatus(const string& bundleId, const int& currentInputMetho
  */
 void setAppInputMethodStatus(const string& bundleId, const int& language);
 
+/**
+ * Initialize English-only apps list from saved data
+ */
+void initEnglishOnlyApps(const Byte* pData, const int& size);
+
+/**
+ * Convert all English-only apps data to save on disk
+ */
+void getEnglishOnlyAppsSaveData(vector<Byte>& outData);
+
+/**
+ * Check if an app is in English-only list
+ */
+bool isEnglishOnlyApp(const string& bundleId);
+
+/**
+ * Add an app to English-only list
+ */
+void addEnglishOnlyApp(const string& bundleId);
+
+/**
+ * Remove an app from English-only list
+ */
+void removeEnglishOnlyApp(const string& bundleId);
+
+/**
+ * Get all apps in English-only list
+ */
+void getAllEnglishOnlyApps(vector<string>& apps);
+
 #endif /* SmartSwitchKey_h */

--- a/Sources/OpenKey/win32/OpenKey/OpenKey/AppDelegate.cpp
+++ b/Sources/OpenKey/win32/OpenKey/OpenKey/AppDelegate.cpp
@@ -12,6 +12,7 @@ You can fork, modify, improve this program. If you
 redistribute your new version, it MUST be open source.
 -----------------------------------------------------------*/
 #include "AppDelegate.h"
+#include "ExcludedAppsDialog.h"
 
 static AppDelegate* _instance;
 
@@ -51,11 +52,13 @@ int vRunAsAdmin = 0;
 int vCheckNewVersion = 0;
 //beta feature
 int vFixChromiumBrowser = 0; //new on version 2.0
+int vExcludeApps = 1; //enable/disable exclude apps feature
 
 bool AppDelegate::isDialogMsg(MSG & msg) const {
 	return (mainDialog != NULL && IsDialogMessage(mainDialog->getHwnd(), &msg)) ||
 		(macroDialog != NULL && IsDialogMessage(macroDialog->getHwnd(), &msg)) || 
 		(convertDialog != NULL && IsDialogMessage(convertDialog->getHwnd(), &msg)) || 
+		(excludedAppsDialog != NULL && IsDialogMessage(excludedAppsDialog->getHwnd(), &msg)) ||
 		(aboutDialog != NULL && IsDialogMessage(aboutDialog->getHwnd(), &msg));
 }
 
@@ -155,9 +158,12 @@ void AppDelegate::closeDialog(BaseDialog * dialog) {
 	} else if (macroDialog == dialog) {
 		delete macroDialog;
 		macroDialog = NULL;
-	} else if (convertDialog == dialog) {
+	} 	else if (convertDialog == dialog) {
 		delete convertDialog;
 		convertDialog = NULL;
+	} else if (excludedAppsDialog == dialog) {
+		delete excludedAppsDialog;
+		excludedAppsDialog = NULL;
 	}
 }
 
@@ -265,6 +271,15 @@ void AppDelegate::onQuickConvert() {
 			LoadString(hInstance, IDS_STRING_CONVERT_COMPLETED, msg, 256);
 			MessageBox(NULL, msg, _T("OpenKey"), MB_OK);
 		}
+	}
+}
+
+void AppDelegate::onManageExcludedApps() {
+	if (excludedAppsDialog == NULL) {
+		excludedAppsDialog = new ExcludedAppsDialog(hInstance, IDD_DIALOG_EXCLUDED_APPS);
+		excludedAppsDialog->show();
+	} else {
+		excludedAppsDialog->bringOnTop();
 	}
 }
 

--- a/Sources/OpenKey/win32/OpenKey/OpenKey/AppDelegate.h
+++ b/Sources/OpenKey/win32/OpenKey/OpenKey/AppDelegate.h
@@ -22,9 +22,9 @@ class BaseDialog;
 class AppDelegate {
 private:
 	HINSTANCE hInstance;
-	BaseDialog* mainDialog = NULL, *aboutDialog = NULL, *macroDialog = NULL, *convertDialog = NULL;
+	BaseDialog* mainDialog = NULL, *aboutDialog = NULL, *macroDialog = NULL, *convertDialog = NULL, *excludedAppsDialog = NULL;
 private:
-	bool isDialogMsg(MSG &msg) const;
+	bool isDialogMsg(MSG & msg) const;
 	void checkUpdate();
 public:
 	AppDelegate();
@@ -44,6 +44,7 @@ public: //event
 	void onMacroTable();
 	void onConvertTool();
 	void onQuickConvert();
+	void onManageExcludedApps();
 
 	void onInputType(const int& type);
 	void onTableCode(const int& code);

--- a/Sources/OpenKey/win32/OpenKey/OpenKey/ExcludedAppsDialog.cpp
+++ b/Sources/OpenKey/win32/OpenKey/OpenKey/ExcludedAppsDialog.cpp
@@ -1,0 +1,133 @@
+/*----------------------------------------------------------
+OpenKey - The Cross platform Open source Vietnamese Keyboard application.
+
+Copyright (C) 2019 Mai Vu Tuyen
+Contact: maivutuyen.91@gmail.com
+Github: https://github.com/tuyenvm/OpenKey
+Fanpage: https://www.facebook.com/OpenKeyVN
+
+This file is belong to the OpenKey project, Win32 version
+which is released under GPL license.
+You can fork, modify, improve this program. If you
+redistribute your new version, it MUST be open source.
+-----------------------------------------------------------*/
+#include "ExcludedAppsDialog.h"
+#include "AppDelegate.h"
+#include <CommCtrl.h>
+
+extern void saveEnglishOnlyAppsData();
+
+ExcludedAppsDialog::ExcludedAppsDialog(const HINSTANCE& hInstance, const int& resourceId)
+	: BaseDialog(hInstance, resourceId) {
+}
+
+ExcludedAppsDialog::~ExcludedAppsDialog() {
+}
+
+void ExcludedAppsDialog::initDialog() {
+	HINSTANCE hIns = GetModuleHandle(NULL);
+	SET_DIALOG_ICON(IDI_APP_ICON);
+	
+	// Get dialog controls
+	hListView = GetDlgItem(hDlg, IDC_LIST_EXCLUDED_APPS);
+	hBtnAdd = GetDlgItem(hDlg, IDC_BUTTON_ADD_CURRENT_APP);
+	hBtnDelete = GetDlgItem(hDlg, IDC_BUTTON_DELETE_APP);
+	hBtnClose = GetDlgItem(hDlg, IDOK);
+	
+	// Initialize ListView
+	LVCOLUMN lvc;
+	lvc.mask = LVCF_FMT | LVCF_WIDTH | LVCF_TEXT | LVCF_SUBITEM;
+	lvc.fmt = LVCFMT_LEFT;
+	lvc.cx = 300;
+	lvc.pszText = (LPWSTR)_T("Ứng dụng");
+	ListView_InsertColumn(hListView, 0, &lvc);
+	
+	// Enable full row select
+	ListView_SetExtendedListViewStyle(hListView, LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES);
+	
+	fillData();
+}
+
+void ExcludedAppsDialog::fillData() {
+	refreshList();
+}
+
+void ExcludedAppsDialog::refreshList() {
+	ListView_DeleteAllItems(hListView);
+	
+	vector<string> apps;
+	getAllEnglishOnlyApps(apps);
+	
+	LVITEM lvi;
+	lvi.mask = LVIF_TEXT;
+	lvi.iSubItem = 0;
+	
+	for (int i = 0; i < apps.size(); i++) {
+		lvi.iItem = i;
+		lvi.pszText = (LPWSTR)utf8ToWideString(apps[i]).c_str();
+		ListView_InsertItem(hListView, &lvi);
+	}
+}
+
+void ExcludedAppsDialog::onAddCurrentApp() {
+	string& currentApp = OpenKeyHelper::getFrontMostAppExecuteName();
+	
+	if (currentApp.compare("OpenKey64.exe") == 0 ||  currentApp.compare("OpenKey32.exe") == 0) {
+		MessageBox(hDlg, _T("Không thể thêm OpenKey vào danh sách loại trừ!"), _T("OpenKey"), MB_OK | MB_ICONWARNING);
+		return;
+	}
+	
+	if (isEnglishOnlyApp(currentApp)) {
+		MessageBox(hDlg, _T("Ứng dụng này đã có trong danh sách!"), _T("OpenKey"), MB_OK | MB_ICONINFORMATION);
+		return;
+	}
+	
+	addEnglishOnlyApp(currentApp);
+	saveEnglishOnlyAppsData();
+	refreshList();
+}
+
+void ExcludedAppsDialog::onDeleteSelected() {
+	int selectedIndex = ListView_GetNextItem(hListView, -1, LVNI_SELECTED);
+	
+	if (selectedIndex < 0) {
+		MessageBox(hDlg, _T("Vui lòng chọn một ứng dụng để xóa!"), _T("OpenKey"), MB_OK | MB_ICONINFORMATION);
+		return;
+	}
+	
+	WCHAR appName[256];
+	ListView_GetItemText(hListView, selectedIndex, 0, appName, 256);
+	
+	int size_needed = WideCharToMultiByte(CP_UTF8, 0, appName, (int)lstrlen(appName), NULL, 0, NULL, NULL);
+	std::string strTo(size_needed, 0);
+	WideCharToMultiByte(CP_UTF8, 0, appName, (int)lstrlen(appName), &strTo[0], size_needed, NULL, NULL);
+	
+	removeEnglishOnlyApp(strTo);
+	saveEnglishOnlyAppsData();
+	refreshList();
+}
+
+INT_PTR ExcludedAppsDialog::eventProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam) {
+	switch (uMsg) {
+	case WM_INITDIALOG:
+		this->hDlg = hDlg;
+		initDialog();
+		return TRUE;
+		
+	case WM_COMMAND:
+		switch (LOWORD(wParam)) {
+		case IDC_BUTTON_ADD_CURRENT_APP:
+			onAddCurrentApp();
+			break;
+		case IDC_BUTTON_DELETE_APP:
+			onDeleteSelected();
+			break;
+		case IDOK:
+		case IDCANCEL:
+			AppDelegate::getInstance()->closeDialog(this);
+			break;
+		}
+		break;
+	}
+	return FALSE;
+}

--- a/Sources/OpenKey/win32/OpenKey/OpenKey/ExcludedAppsDialog.h
+++ b/Sources/OpenKey/win32/OpenKey/OpenKey/ExcludedAppsDialog.h
@@ -1,0 +1,28 @@
+//English-only Apps Dialog Header
+#pragma once
+#include "BaseDialog.h"
+#include <vector>
+#include <string>
+
+using namespace std;
+
+class ExcludedAppsDialog : public BaseDialog {
+private:
+	HWND hListView;
+	HWND hBtnAdd;
+	HWND hBtnDelete;
+	HWND hBtnClose;
+	
+	void initDialog();
+	void refreshList();
+	void onAddCurrentApp();
+	void onDeleteSelected();
+	
+protected:
+	INT_PTR eventProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	
+public:
+	ExcludedAppsDialog(const HINSTANCE& hInstance, const int& resourceId);
+	virtual ~ExcludedAppsDialog();
+	virtual void fillData() override;
+};

--- a/Sources/OpenKey/win32/OpenKey/OpenKey/MainControlDialog.cpp
+++ b/Sources/OpenKey/win32/OpenKey/OpenKey/MainControlDialog.cpp
@@ -146,6 +146,12 @@ void MainControlDialog::initDialog() {
 
     checkTempOffOpenKey = GetDlgItem(hTabPage1, IDC_CHECK_TEMP_OFF_OPEN_KEY);
     createToolTip(checkTempOffOpenKey, IDS_STRING_TEMP_OFF_OPENKEY);
+    
+    checkExcludeApps = GetDlgItem(hTabPage1, IDC_CHECK_EXCLUDE_APPS);
+    createToolTip(checkExcludeApps, IDS_STRING_EXCLUDE_APPS);
+    
+    hBtnManageExcludedApps = GetDlgItem(hTabPage1, IDC_BUTTON_MANAGE_EXCLUDED_APPS);
+    createToolTip(hBtnManageExcludedApps, IDS_STRING_EXCLUDE_APPS);
 
     /*------------end tab 1----------------*/
 
@@ -241,6 +247,9 @@ INT_PTR MainControlDialog::eventProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM
             break;
         case IDC_BUTTON_GO_SOURCE_CODE:
             ShellExecute(NULL, _T("open"), _T("https://github.com/tuyenvm/OpenKey"), NULL, NULL, SW_SHOWNORMAL);
+            break;
+        case IDC_BUTTON_MANAGE_EXCLUDED_APPS:
+            AppDelegate::getInstance()->onManageExcludedApps();
             break;
         default:
             if (HIWORD(wParam) == CBN_SELCHANGE) {
@@ -365,6 +374,7 @@ void MainControlDialog::fillData() {
     SendMessage(checkCheckNewVersion, BM_SETCHECK, vCheckNewVersion ? 1 : 0, 0);
     SendMessage(checkUseClipboard, BM_SETCHECK, vSendKeyStepByStep ? 0 : 1, 0);
     SendMessage(checkFixChromium, BM_SETCHECK, vFixChromiumBrowser ? 1 : 0, 0);
+    SendMessage(checkExcludeApps, BM_SETCHECK, vExcludeApps ? 1 : 0, 0);
 
     EnableWindow(checkRestoreIfWrongSpelling, vCheckSpelling);
     EnableWindow(checkAllowZWJF, vCheckSpelling);
@@ -560,6 +570,10 @@ void MainControlDialog::onCheckboxClicked(const HWND& hWnd) {
     else if (hWnd == checkFixChromium) {
         val = (int)SendMessage(hWnd, BM_GETCHECK, 0, 0);
         APP_SET_DATA(vFixChromiumBrowser, val ? 1 : 0);
+    }
+    else if (hWnd == checkExcludeApps) {
+        val = (int)SendMessage(hWnd, BM_GETCHECK, 0, 0);
+        APP_SET_DATA(vExcludeApps, val ? 1 : 0);
     }
     SystemTrayHelper::updateData();
 }

--- a/Sources/OpenKey/win32/OpenKey/OpenKey/MainControlDialog.h
+++ b/Sources/OpenKey/win32/OpenKey/OpenKey/MainControlDialog.h
@@ -27,6 +27,7 @@ private:
 	HWND checkSmartSwitchKey, checkCapsFirstChar, checkQuickTelex, checkUseMacro, checkUseMacroInEnglish;
 	HWND checkCreateDesktopShortcut, checkCheckNewVersion, checkRunAsAdmin, checkSupportMetroApp, checkMacroAutoCaps;
 	HWND checkFixChromium, checkRememberTableCode, checkTempOffOpenKey, checkAllowOtherLanguages;
+	HWND checkExcludeApps, hBtnManageExcludedApps;
 	HWND hUpdateButton;
 private:
 	void initDialog();

--- a/Sources/OpenKey/win32/OpenKey/OpenKey/OpenKey.rc
+++ b/Sources/OpenKey/win32/OpenKey/OpenKey/OpenKey.rc
@@ -209,6 +209,9 @@ BEGIN
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,106,204,10
     CONTROL         "Tạm tắt OpenKey bằng phím Alt",IDC_CHECK_TEMP_OFF_OPEN_KEY,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,151,88,123,10
+    CONTROL         "Loại trừ ứng dụng",IDC_CHECK_EXCLUDE_APPS,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,124,70,10
+    PUSHBUTTON      "...",IDC_BUTTON_MANAGE_EXCLUDED_APPS,80,123,15,12
 END
 
 IDD_DIALOG_TAB_MACRO DIALOGEX 0, 0, 299, 177
@@ -282,6 +285,17 @@ BEGIN
                     "SysLink",WS_TABSTOP,117,94,101,10
     LTEXT           "Phien ban",IDC_STATIC_APP_VERSION_INFO,39,50,227,8
     PUSHBUTTON      "Mã nguồn...",IDC_BUTTON_GO_SOURCE_CODE,226,91,50,14
+END
+
+IDD_DIALOG_EXCLUDED_APPS DIALOGEX 0, 0, 350, 280
+STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Quản lý ứng dụng loại trừ - OpenKey"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    CONTROL         "",IDC_LIST_EXCLUDED_APPS,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_ALIGNLEFT | WS_BORDER | WS_TABSTOP,7,7,336,230
+    PUSHBUTTON      "Thêm ứng dụng hiện tại",IDC_BUTTON_ADD_CURRENT_APP,7,245,90,20
+    PUSHBUTTON      "Xóa",IDC_BUTTON_DELETE_APP,105,245,50,20
+    DEFPUSHBUTTON   "Đóng",IDOK,293,245,50,20
 END
 
 
@@ -363,6 +377,14 @@ BEGIN
         RIGHTMARGIN, 280
         TOPMARGIN, 9
         BOTTOMMARGIN, 112
+    END
+
+    IDD_DIALOG_EXCLUDED_APPS, DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 343
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 273
     END
 END
 #endif    // APSTUDIO_INVOKED
@@ -524,6 +546,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_STRING_FIX_CHROMIUM "Sửa lỗi bị đúp từ trên các trình duyệt Chromium bao gồm Google Chrome, Brave, Microsoft Edge. Tính năng này đang được thử nghiệm. Cần bật tính năng ""Sửa lỗi gợi ý"" để hỗ trợ tính năng này."
+    IDS_STRING_EXCLUDE_APPS "Tích chọn để kích hoạt tính năng loại trừ ứng dụng. Các ứng dụng trong danh sách sẽ luôn sử dụng tiếng Anh và không thể chuyển sang tiếng Việt. Nhấn nút ... để quản lý danh sách."
 END
 
 #endif    // English (United States) resources

--- a/Sources/OpenKey/win32/OpenKey/OpenKey/resource.h
+++ b/Sources/OpenKey/win32/OpenKey/OpenKey/resource.h
@@ -182,6 +182,13 @@
 #define IDS_STRING_START_CONSONANT      1066
 #define IDS_STRING_END_CONSONANT        1067
 #define IDC_CHECK_OTHER_LANGUAGES       1068
+#define IDC_CHECK_EXCLUDE_APPS          1069
+#define IDC_BUTTON_MANAGE_EXCLUDED_APPS 1070
+#define IDD_DIALOG_EXCLUDED_APPS        150
+#define IDC_LIST_EXCLUDED_APPS          1071
+#define IDC_BUTTON_ADD_CURRENT_APP      1072
+#define IDC_BUTTON_DELETE_APP           1073
+#define IDS_STRING_EXCLUDE_APPS         1074
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -189,9 +196,9 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
-#define _APS_NEXT_RESOURCE_VALUE        149
+#define _APS_NEXT_RESOURCE_VALUE        151
 #define _APS_NEXT_COMMAND_VALUE         32771
-#define _APS_NEXT_CONTROL_VALUE         1052
+#define _APS_NEXT_CONTROL_VALUE         1075
 #define _APS_NEXT_SYMED_VALUE           110
 #endif
 #endif


### PR DESCRIPTION
- Add SmartSwitchKey engine functions to manage excluded apps list
- Implement logic to block language switching for excluded apps
- Add ExcludedAppsDialog for managing excluded apps list
- Add checkbox and button in Main Control Dialog
- Force English mode and block hotkey for excluded applications
- Store excluded apps list in Windows Registry
- Play warning beep when attempting to switch in excluded apps