### PR TITLE
Sprint 2 D0-D1: Chrome 5.3 fix + commit-undo diagnostic infra

### DIFF
--- a/src/app/system/HookEngine.cpp
+++ b/src/app/system/HookEngine.cpp
@@ -931,7 +931,29 @@ bool HookEngine::ProcessKeyDown(DWORD vkCode, DWORD /*scanCode*/, DWORD /*flags*
         // Checking counter alone would permanently disable commit-undo.  The 100ms
         // threshold covers DispatchSendInput Sleep (10-20ms) + Qt processing (~30ms)
         // with margin, while allowing replay at normal typing speed (>100ms between keys).
-        if (synthEventsPending_ > 0 && (GetTickCount() - lastRealSynthTime_) < kSynthSettleMs) {
+        //
+        // Sprint 2 D1/2026-05-05: tone modifiers (Telex s/f/r/x/j; VNI 1-5) are
+        // EXEMPT from the synth guard. Reason: by definition they only modify the
+        // previous word — no other linguistic meaning. ReplaceComposition's diff
+        // (prev=committed, new=committed-with-tone) computes BS correctly relative
+        // to the post-drain screen state, and SendInput appends our events AFTER
+        // any pending synth, so screen-engine sync is preserved across the gap.
+        // Without this exemption, chaos 5.3 (`viejtnam BS×4 s` on non-EditMsg apps
+        // like Chrome) cancels the replay and produces `việts` instead of `viết`.
+        // See docs/baselines/perf-baseline-d12-chrome-cross-app.md and the
+        // S2D0_ChromeBug53_* engine-isolation tests.
+        const auto methodForTone = currentMethod_.load(std::memory_order_acquire);
+        const bool isTelexTone =
+            (methodForTone == InputMethod::Telex || methodForTone == InputMethod::Combined) &&
+            (vkCode == 'S' || vkCode == 'F' || vkCode == 'R' ||
+             vkCode == 'X' || vkCode == 'J');
+        const bool isVniTone =
+            (methodForTone == InputMethod::VNI || methodForTone == InputMethod::Combined) &&
+            vkCode >= '1' && vkCode <= '5' &&
+            !(GetKeyState(VK_SHIFT) & 0x8000);
+        const bool isToneModifier = isTelexTone || isVniTone;
+        if (synthEventsPending_ > 0 && (GetTickCount() - lastRealSynthTime_) < kSynthSettleMs
+            && !isToneModifier) {
             HOOK_LOG(L"  commit-undo: cancel Primed — synthPending=%d, vk=0x%02X",
                      synthEventsPending_.load(), vkCode);
             CancelCommitUndo();

--- a/src/app/system/HookEngine.cpp
+++ b/src/app/system/HookEngine.cpp
@@ -1711,8 +1711,10 @@ static void AppendVkEvent(std::vector<INPUT>& events, WORD wVk, WORD wScan) {
 void HookEngine::TrackedSendInput(INPUT* events, UINT count) noexcept {
     synthEventsPending_ += static_cast<int>(count);
     UINT sent = SendInput(count, events, sizeof(INPUT));
-    if (sent < count)
+    if (sent < count) {
         synthEventsPending_ -= static_cast<int>(count - sent);
+        HOOK_LOG(L"  TrackedSendInput: PARTIAL sent=%u of %u (renderer drop?)", sent, count);
+    }
 }
 
 void HookEngine::SendBackspaceEvents(size_t count) {
@@ -1978,6 +1980,10 @@ void HookEngine::DispatchSendInput(std::vector<INPUT>& bsEvents, std::vector<INP
     sending_ = true;
     const bool electronApp = isElectronApp_.load(std::memory_order_acquire);
     const bool consoleApp = isConsoleApp_.load(std::memory_order_acquire);
+    HOOK_LOG(L"  DispatchSendInput: path=%s BS=%zu chars=%zu electron=%d console=%d",
+             (electronApp || consoleApp) ? L"split" : L"batch",
+             bsEvents.size() / 2, charEvents.size() / 2,
+             electronApp ? 1 : 0, consoleApp ? 1 : 0);
     if (electronApp || consoleApp) {
         // Split: VK_BACK and VK_PACKET travel on separate internal paths in
         // Electron/Console apps — batching risks out-of-order processing ("nuốt chữ").
@@ -2826,9 +2832,9 @@ void HookEngine::ReplaceComposition(const std::wstring& newText, DWORD reinjectV
             newWidths.push_back(enc.count);
         }
 
-        HOOK_LOG(L"  ReplaceComposition[encoded]: prev='%s' new='%s' common=%zu BS=%zu encodedLen=%zu",
+        HOOK_LOG(L"  ReplaceComposition[encoded]: prev='%s' new='%s' common=%zu BS=%zu encodedLen=%zu reinjectVk=0x%02X",
                  previousComposition_.c_str(), newText.c_str(), commonLen, backspaceCount,
-                 encodedToSend.size());
+                 encodedToSend.size(), reinjectVk);
 
         {
             bool needEmpty = (backspaceCount > 0 && needBaitChar_.load(std::memory_order_acquire));
@@ -2871,9 +2877,9 @@ void HookEngine::ReplaceComposition(const std::wstring& newText, DWORD reinjectV
     size_t backspaceCount = previousComposition_.size() - commonLen;
     std::wstring toSend = newText.substr(commonLen);
 
-    HOOK_LOG(L"  ReplaceComposition: prev='%s' new='%s' common=%zu BS=%zu send='%s'",
+    HOOK_LOG(L"  ReplaceComposition: prev='%s' new='%s' common=%zu BS=%zu send='%s' reinjectVk=0x%02X",
              previousComposition_.c_str(), newText.c_str(), commonLen, backspaceCount,
-             toSend.c_str());
+             toSend.c_str(), reinjectVk);
 
     // ── Async-render apps (Win11 new Notepad) ──
     // WinUI 3 RichEditBox renders on the compositor thread async to input. SendInput

--- a/tests/TelexEngineTest.cpp
+++ b/tests/TelexEngineTest.cpp
@@ -267,6 +267,55 @@ TEST_F(TelexEngineTest, D12_5_Truongw_NoTone) {
     EXPECT_EQ(engine_->Peek(), L"trương");
 }
 
+// --- Sprint 2 D0: 5.3 Chrome bug — engine-layer isolation test ---
+//
+// Repro for chaos 5.3 "vieejt nam BS×4 s" → expected "viết" but Chrome
+// produces "việts". Per Sprint 2 D0 hook-log analysis, the failure is
+// in HookEngine's commit-undo "Primed → cancel on synthPending" state
+// machine: under chaos 1ms inter-key, 's' arrives before the BS#4 synth
+// events drain → Primed canceled → engine never gets "việt" replayed →
+// 's' processed fresh → screen shows "việts".
+//
+// This test ISOLATES the engine layer: pushes the equivalent post-replay
+// sequence ("viejt" then "s") directly. No hook, no commit, no synthetic
+// events.
+//
+//   PASS → engine is clean. Bug is purely in HookEngine commit-undo
+//          replay. Sprint 2 fix lives in HookEngine, not TypingEngine.
+//   FAIL → engine itself can't do the tone replacement. Fix needed in
+//          TypingEngine tone-replacement logic.
+//
+// Reference: docs/baselines/perf-baseline-d12-chrome-cross-app.md
+// HookEngine state-machine site: HookEngine.cpp "commit-undo: cancel Primed"
+
+TEST_F(TelexEngineTest, S2D0_ChromeBug53_VieejtPlusS_ToneReplace) {
+    // Per HookEngine::ReplayCommittedChars (HookEngine.cpp:1621): replay pushes
+    // the ORIGINAL user keystrokes from CommitEntry::history into the engine —
+    // not the composed Unicode chars. So a committed 'việt' from input 'vieejt'
+    // replays as PushChar('v'),('i'),('e'),('e'),('j'),('t').
+    //
+    // This test feeds the post-replay-equivalent sequence: 'vieejt' then 's'.
+
+    TypeString(*engine_, L"vieejt");
+    EXPECT_EQ(engine_->Peek(), L"việt") << "Baseline 'vieejt' → 'việt' must hold";
+
+    // Bug repro: 's' after 'việt' should replace j-tone (nặng) with
+    // s-tone (sắc), preserving the ê circumflex → 'viết'.
+    engine_->PushChar(L's');
+    EXPECT_EQ(engine_->Peek(), L"viết")
+        << "After 'vieejt'+'s', engine should replace nặng with sắc → 'viết'.\n"
+        << "PASS means bug is purely in HookEngine commit-undo state machine.\n"
+        << "FAIL means TypingEngine tone-replacement logic is also broken.";
+}
+
+// Sanity check: the simpler path (forward typing without replay) for the same
+// final word — verifies the engine CAN produce 'viết' when 's' is the only
+// tone modifier on the syllable. This locks in what 'right' looks like.
+TEST_F(TelexEngineTest, S2D0_ChromeBug53_Sanity_VieetsForward) {
+    TypeString(*engine_, L"vieets");
+    EXPECT_EQ(engine_->Peek(), L"viết");
+}
+
 // ============================================================================
 // STROKE TESTS (dd→đ)
 // ============================================================================

--- a/tools/NextKeyTestRunner/corpus/chaos-5.3-only.toml
+++ b/tools/NextKeyTestRunner/corpus/chaos-5.3-only.toml
@@ -1,0 +1,43 @@
+# Chaos 5.3 only -- single-case corpus for Sprint 2 Chrome diagnostic capture.
+# Used to localize the cross-app `viejtnam\b\b\b\bs` -> `việts` (Chrome) vs
+# `viết` (Notepad) divergence. Pair with a Debug build of NextKeyApp so
+# HOOK_LOG writes NexusKey_hook.log next to the EXE; that log is what the
+# diagnostic step reads.
+#
+# Run with foreground = Chrome (address bar / textarea) from build folder:
+#   NextKeyTestRunner.exe --corpus ../tools/NextKeyTestRunner/corpus/chaos-5.3-only.toml \
+#       --hook-log Debug/NexusKey_hook.log
+#
+# Repeat the case 3x so a single run captures both stable-corruption and
+# flip-prone runs without restarting the runner. Each case writes its own
+# row in perf.csv / report.xml.
+#
+# What the new HOOK_LOG fields tell us:
+#   - AppDetect: console=? electron=? editMsg=?  -- which classification fires for chrome.exe
+#   - ReplaceComposition: ... reinjectVk=0xNN     -- whether 's' (0x53) prepends to batch
+#   - DispatchSendInput: path=split|batch BS=N chars=M  -- which output strategy chosen
+#   - TrackedSendInput: PARTIAL sent=...          -- whether Chrome renderer drops events
+
+[[tests]]
+name = "5.3-cross-word-bs-vieejt-nam-bs4-s-run1"
+target_app = "chrome"
+keys = 'vieejt nam\b\b\b\bs'
+expected = "viết"
+inter_key_us = 1000
+budget_p99_us = 1500
+
+[[tests]]
+name = "5.3-cross-word-bs-vieejt-nam-bs4-s-run2"
+target_app = "chrome"
+keys = 'vieejt nam\b\b\b\bs'
+expected = "viết"
+inter_key_us = 1000
+budget_p99_us = 1500
+
+[[tests]]
+name = "5.3-cross-word-bs-vieejt-nam-bs4-s-run3"
+target_app = "chrome"
+keys = 'vieejt nam\b\b\b\bs'
+expected = "viết"
+inter_key_us = 1000
+budget_p99_us = 1500


### PR DESCRIPTION
## Summary

Fix chaos case 5.3 (`viejtnam BS×4 s` → expected `viết`) on **non-EditMsg apps** (Chrome address bar / textarea, plain `<input>` / `<textarea>`). Sprint 1 D12 closed 5.3 on Win11 New Notepad via the EditMsg path; this PR closes it on the SendInput / PASSTHRU path that Chrome uses.

## Root cause

Hook log analysis (Sprint 2 D0) showed all 4 hypotheses in `docs/baselines/perf-baseline-d12-chrome-cross-app.md` § "Suspected mechanism" were wrong. The actual bug is in `HookEngine.cpp:935` `commit-undo: cancel Primed`:

- After BS#4 (commit-undo trigger), HookEngine enters Primed state expecting the next key to drive replay.
- Under chaos 1ms inter-key, the `s` arrives **before** BS#4's injected synth events drain through the LL hook → `synthEventsPending > 0`.
- Synth guard cancels Primed → `ReplayCommittedChars` never runs → engine processes `s` on empty state → `previousComposition_` set to `s` → app receives just `s` → screen shows `việts`.

Engine layer is clean: `TelexEngineTest.S2D0_ChromeBug53_*` (added in this PR) feed the equivalent post-replay sequence and PASS at HEAD.

## Fix

Tone modifiers (Telex `s/f/r/x/j`; VNI `1-5`) are EXEMPT from the synth guard. Reasoning:

- They have no other linguistic meaning — by definition only modify the previous word.
- `ReplaceComposition`'s diff (prev=committed, new=committed-with-tone) computes BS correctly relative to the post-drain screen state.
- `SendInput` appends events AFTER any pending synth in the queue, so screen-engine sync is preserved across the gap.

23 LOC change at `HookEngine.cpp:935` (1 logic check + comment explaining why).

## Verification (Win11 Debug build)

- **chaos-5.3-only.toml on Chrome address bar**: 0/3 → **3/3 PASS**
- **chaos.toml full corpus on Win11 New Notepad**: **11/11 PASS** (Sprint 1 D12 RichEditD2DPT win preserved)
- **L1 hook timing**: max p99 16ms (case 1.1, historical), all others ≤12ms — within envelope

## Linux

- **D7 audit script** (`tools/audit/check_hook_thread_no_mutex.sh`): PASS
- **GTest cross-platform**: **1405 / 1405 PASS** (1403 baseline + 2 new S2D0 isolation tests)

## Commits

- `fdbcc39` Sprint 2 D0: Chrome 5.3 diagnostic logging + chaos-5.3-only corpus
- `bbb1de6` Sprint 2 D0.1: engine-isolation tests prove Chrome 5.3 is hook-only
- `cee91e9` Sprint 2 D1: exempt tone modifiers from commit-undo synth guard

## Diagnostic infra (kept for future host classes)

The 3 HOOK_LOG additions in D0 stay in the tree — useful for future `IOutputInjector` (Sprint 2 T3) work:

- `TrackedSendInput: PARTIAL sent=N of M` — renderer event drop detector
- `DispatchSendInput: path=split|batch BS=N chars=M electron=N console=N` — output strategy log
- `ReplaceComposition: ... reinjectVk=0xNN` — verify VK prepend to batch

## Test plan

- [ ] CI: D7 audit + Linux GTest pass
- [ ] Manual: Chrome `chaos-5.3-only.toml` reproduces 3/3 PASS
- [ ] Manual: Notepad full `chaos.toml` reproduces 11/11 PASS (no Sprint 1 regression)