### PR TITLE
post-T3 cleanup: comments + header order + D4 SPIKE markers + TODO

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,6 +1,53 @@
 # TODO
 
-## 🔴 synthEventsPending_ counter broken on injector hot path (2026-05-05, found in D4 audit)
+## ✅ Post-T3 cleanup PR — first batch landed (2026-05-05)
+
+Mechanical / low-risk items addressed in the post-T3 cleanup branch:
+
+- M1 stale comments at HookEngine.cpp:1503 + :2867 — refreshed to reference `IsSyncReplaceChannel()` / `SplitDispatchInjector` instead of the deleted `useEditMsgPath_` / `isElectronApp_` / `isConsoleApp_` flags.
+- L1 header include order in `Win32SendInputInjector.cpp`, `SplitDispatchInjector.cpp`, `RichEditEmReplaceSelInjector.cpp` — STL group now precedes project-internal `Internal.h` per Rule 1.2.
+- M4 memory ordering doc — `OnSynthDispatched` now carries an inline rationale for `memory_order_relaxed` (same-thread invariant: every increment + decrement runs on the LL hook thread).
+- Pre-T3 Critical (D4 SPIKE markers) — three commented `lock_guard<recursive_mutex>` lines updated to "REGRESSION TRAP — DO NOT UNCOMMENT" with cross-references to the audit script. Audit Check 1 comment block updated to explain the trap rather than the original "Phase B in-progress" wording.
+- Pre-T3 Minor 3 (misleading comment) — `HookEngine.cpp:802` "pure memory read, no syscall" split into fast-path (atomic) + slow-path (TOML reload + brief stateMutex_) wording, with a forward reference to the open Pre-T3 Minor 2 audit task.
+
+`tools/audit/check_hook_thread_no_mutex.sh` PASS — all 4 checks green after the changes. Linux GTest 1405 / 1405 PASS.
+
+---
+
+## 🟡 Items deferred from this cleanup PR (need their own session)
+
+These need investigation, design work, or 3-collaborator decisions and were intentionally NOT addressed in the mechanical batch:
+
+### Pre-T3 Minor 1 — `LowLevelMouseProc` race on `cachedFocusedHwnd_`
+Investigation needed: read the exact write set in the mouse callback, decide between (a) atomic migration, (b) defer to `MainThreadWorker`, or (c) document as benign. Detailed in the §"Review (2026-05-05)" section below.
+
+### Pre-T3 Minor 2 — `QuickSyncFromSharedState` acquires `stateMutex_` on hook hot path (Rule #11.3 violation)
+Highest-impact open audit item. Slow-path TOML reload + lock acquire on every keystroke when configGeneration bumps. Fix likely needs RCU re-publish via `MainThreadWorker` (Sprint 1 D6 `config_` pattern). Detailed below.
+
+### M2 — Constants naming convention (`kFoo` vs `UPPER_SNAKE`)
+Codebase-wide pattern uses `kFoo` for file-scope `static constexpr`; Rule 9.1 prescribes `UPPER_SNAKE`. Need 3-collaborator decision: update Rule 9.1 to formalize the k-prefix convention, or rename ~10 codebase constants. Recommendation: update the rule.
+
+### M3 — Dual-route `TrackedSendInput` (HookEngine member + `Internal::` free function)
+Both bump `synthEventsPending_` via different mechanisms; no double-counting today but the dual presence is confusing for future readers. Suggested fix: route the 4 VB6/clipboard sites + reinjectVk through `Internal::TrackedSendInput`, then delete `HookEngine::TrackedSendInput` member. ~5 call sites, non-trivial.
+
+### ChannelTraits + `isElectronApp_` / `needBaitChar_` deletion
+Gotcha G6 (Sprint 2 D4 mid-sprint discovery) — both flags retain live policy readers in `HandleAlphaKey` passthrough/reinjectVk gates. Cleanly lifting them requires a `ChannelTraits` query method on `IOutputInjector` (interface design needs its own commit). Captured in `docs/baselines/perf-baseline-t3-final.md` deferred-items list.
+
+### Typing bug — `cafcs → các` (spell-check tone-replacement)
+Investigation-first item: needs `nexuskey-typing-bugs` skill trace through `PushChar` + `Validate` pipeline before fix. Hypotheses captured in the dedicated section below.
+
+### `--host-class` matrix harness (Sprint 2 D6 deferred)
+Sprint 2 plan §D6 Tasks 32-33 — `NextKeyTestRunner` flag for forced host-class override. Marginal value given existing 132-case natural coverage; reopen as one focused task if QA later needs forced-cell testing.
+
+---
+
+## ✅ ~~synthEventsPending_ counter broken on injector hot path~~ — FIXED in Sprint 2 D5 (`2f1b400`)
+
+Resolved by `Internal::g_synthCounterCallback` + `HookEngine::OnSynthDispatched` bridge. Win32 / Split paths now correctly bump the counter; RichEdit (sent message, no hook echo) correctly does not. Test contract captured in `Win32SendInputInjectorTest.ReplaceNotifiesSynthCounterByEventCount` and the partial-send compensating-delta tests. Original entry preserved below for the post-mortem trail.
+
+---
+
+## 🔴 ~~synthEventsPending_ counter broken on injector hot path~~ (2026-05-05, found in D4 audit) — RESOLVED in D5
 
 **Severity:** medium-high. Synth-guard mechanism is silently no-op for the most common dispatch path.
 
@@ -60,14 +107,15 @@ Option 4 is cleanest semantically; option 2 is least invasive. Pick during D5 al
 
 ---
 
-## Review (2026-05-05) — Pre-T3 Code Review Followups
+## Review (2026-05-05) — Pre-T3 Code Review Followups (partial — Critical + Minor 3 LANDED post-T3 cleanup PR)
 
 Code review on Main `003a059` (post governance + T3 design merge, before T3
-implementation D0 commit). Findings to address as a single follow-up batch
-**after T3 ships** (per project owner decision: complete T3 first, then
-review + fix together to avoid mid-sprint scope inflation).
+implementation D0 commit). Critical (D4 SPIKE marker clarify) + Minor 3
+(misleading comment) landed in the post-T3 cleanup PR. Minor 1 (mouse race)
+and Minor 2 (`QuickSyncFromSharedState` Rule #11.3 violation) deferred —
+both need investigation before fix.
 
-### 🔴 Critical — 3 commented `// std::lock_guard<std::recursive_mutex>` lines in hook callbacks
+### ✅ ~~🔴 Critical — 3 commented `// std::lock_guard<std::recursive_mutex>` lines in hook callbacks~~ — LANDED
 
 **Reviewer claim:** "Type `recursive_mutex` no longer exists since D11 changed
 `stateMutex_` to `std::mutex` — these dangling references should be deleted."
@@ -115,7 +163,7 @@ remove the lock. If it must access mutex-protected state, route via
 impact finding because Rule #11 violations directly degrade "Mượt" (the p99
 chaos jitter we've been chasing).
 
-### 🟡 Minor 3 — Misleading comment at `HookEngine.cpp` line 779 ("pure memory read, no syscall")
+### ✅ ~~🟡 Minor 3 — Misleading comment at `HookEngine.cpp` line 779 ("pure memory read, no syscall")~~ — LANDED
 
 The slow path of the sync triggered around that comment includes TOML
 reload, so the "no syscall" claim is wrong on the slow path.

--- a/src/app/output/RichEditEmReplaceSelInjector.cpp
+++ b/src/app/output/RichEditEmReplaceSelInjector.cpp
@@ -19,11 +19,13 @@
 //
 // Spec: docs/plans/sprint-2-output-injector.md §2.3
 #include "RichEditEmReplaceSelInjector.h"
-#include "Win32SendInputInjector.h"
-#include "Internal.h"
 
 #include <richedit.h>
+
 #include <string>
+
+#include "Internal.h"
+#include "Win32SendInputInjector.h"
 
 namespace NextKey::Output {
 

--- a/src/app/output/SplitDispatchInjector.cpp
+++ b/src/app/output/SplitDispatchInjector.cpp
@@ -9,9 +9,10 @@
 //
 // Spec: docs/plans/sprint-2-output-injector.md §2.4
 #include "SplitDispatchInjector.h"
-#include "Internal.h"
 
 #include <array>
+
+#include "Internal.h"
 
 namespace NextKey::Output {
 

--- a/src/app/output/Win32SendInputInjector.cpp
+++ b/src/app/output/Win32SendInputInjector.cpp
@@ -6,9 +6,10 @@
 //
 // Spec: docs/plans/sprint-2-output-injector.md §2.2
 #include "Win32SendInputInjector.h"
-#include "Internal.h"
 
 #include <array>
+
+#include "Internal.h"
 
 namespace NextKey::Output {
 

--- a/src/app/system/HookEngine.cpp
+++ b/src/app/system/HookEngine.cpp
@@ -689,16 +689,18 @@ LRESULT CALLBACK HookEngine::LowLevelKeyboardProc(int nCode, WPARAM wParam, LPAR
                      pKey->vkCode, pKey->scanCode, pKey->flags,
                      isDown ? L"DOWN" : (isUp ? L"UP" : L"OTHER"));
 
-            // State access below races with main-thread writers (OnFocusChanged,
-            // ApplyConfig, ToggleVietnameseMode, Reload* methods). Brief lock
-            // keeps the critical section on the hook thread — main thread holds
-            // this mutex only for fast state updates, never for Sciter/IO work.
-            // Sprint 1 D4 SPIKE (refactor/phase-1-single-owner): commented out
-            // to measure whether removing hook-thread mutex acquisition flips
-            // any chaos FAIL. Torn-read risk knowingly accepted FOR THE SPIKE
-            // ONLY. Phase B replaces this with atomic + RCU patterns. Restore
-            // OR replace per Phase B before merge — DO NOT ship with this line
-            // commented. See docs/plans/sprint-1-single-owner-refactor.md §A D4.
+            // REGRESSION TRAP — DO NOT UNCOMMENT
+            //
+            // Sprint 1 D4 originally took stateMutex_ here to guard the racing
+            // reads of `engine_`, `previousComposition_`, app-detect flags, etc.
+            // Phase B (D5-D11) replaced every reader/writer with std::atomic
+            // + RCU patterns; the lock is no longer needed and the type
+            // (`std::recursive_mutex`) was downgraded to `std::mutex` in D11
+            // — uncommenting this line triggers a compile error which IS the
+            // intentional regression trap. `tools/audit/check_hook_thread_no
+            // _mutex.sh` Check 1 verifies this line stays commented (one of
+            // 3 such lines across hook callbacks). If you're tempted to "clean
+            // up" the dangling reference, read the audit script first.
             // std::lock_guard<std::recursive_mutex> _lock(self->stateMutex_);
 
             if (isDown) {
@@ -725,13 +727,12 @@ void CALLBACK HookEngine::WinEventProc(HWINEVENTHOOK, DWORD event, HWND hwnd, LO
         HookEngine* self = s_instance.load(std::memory_order_relaxed);
         if (!self) return;
 
-        // Main-thread writer path — hook thread's callback reads the same state
-        // (engine_, previousComposition_, app-detect flags, currentExe_...).
-        // Lock must cover the engine_->Count() read below and the subsequent
-        // OnFocusChanged() which mutates extensively.
-        // Sprint 1 D4 SPIKE: see corresponding note above LowLevelKeyboardProc
-        // lock_guard. WinEventProc executes on the hook thread per the existing
-        // architecture — that's why this acquisition is on the hot path.
+        // REGRESSION TRAP — DO NOT UNCOMMENT (see LowLevelKeyboardProc above
+        // for the full rationale). WinEventProc runs on the hook thread per
+        // the existing architecture; Phase B replaced its mutex needs with
+        // atomic flags + RCU. Audit Check 1 enforces this line stays
+        // commented; uncommenting also fails to compile (recursive_mutex
+        // type removed in D11).
         // std::lock_guard<std::recursive_mutex> _lock(self->stateMutex_);
 
         if (event == EVENT_SYSTEM_MINIMIZEEND) {
@@ -758,11 +759,14 @@ LRESULT CALLBACK HookEngine::LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM 
         if (nCode == HC_ACTION && wParam == WM_LBUTTONDOWN) {
             HookEngine* self = s_instance.load(std::memory_order_relaxed);
             if (self) {
-                // Mouse callback runs on hook thread — ResetComposition + state
-                // writes below race with main-thread writers. Take the lock.
-                // Sprint 1 D4 SPIKE: see LowLevelKeyboardProc note. Mouse path
-                // includes a writer (ResetComposition); torn-read risk is
-                // higher here than the keyboard read paths.
+                // REGRESSION TRAP — DO NOT UNCOMMENT (see LowLevelKeyboardProc
+                // above for the full rationale). Mouse path includes a writer
+                // (ResetComposition); torn-read risk pre-Phase-B was higher
+                // here than the keyboard read paths. Phase B replaced this
+                // with atomic state — current cachedFocusedHwnd_ + Reset-
+                // Composition write set is captured as Pre-T3 review Minor
+                // 1 in docs/TODO.md (still-open audit). Audit Check 1
+                // enforces this line stays commented.
                 // std::lock_guard<std::recursive_mutex> _lock(self->stateMutex_);
                 HOOK_LOG(L"MOUSE click — resetting composition (engine count=%zu, prev='%s')",
                          self->engine_->Count(), self->previousComposition_.c_str());
@@ -795,8 +799,13 @@ static bool IsIncompatibleLayout(HKL hkl);
 // ═══════════════════════════════════════════════════════════
 
 bool HookEngine::ProcessKeyDown(DWORD vkCode, DWORD /*scanCode*/, DWORD /*flags*/) {
-    // 0. Sync from SharedState — pure memory read, no syscall.
-    //    Detects feature flag changes AND configGeneration bumps (triggers TOML reload).
+    // 0. Sync from SharedState. Fast path is a memory-mapped atomic read
+    //    (no syscall, ~10 ns); the slow path — taken when the writer's
+    //    configGeneration bumped — invokes TOML reload + can briefly hold
+    //    stateMutex_ on this thread. Pre-T3 review Minor 2 captures the
+    //    Rule #11.2/11.3 concern (mutex on hook hot path); see docs/TODO.md
+    //    for the audit task. Most calls hit the fast path; the slow-path
+    //    cost is bounded to 1 reload per generation bump.
     QuickSyncFromSharedState();
 
     // 0b. TSF app — let TSF DLL handle all input, hook does nothing
@@ -1500,7 +1509,7 @@ bool HookEngine::HandleAlphaKey(DWORD vkCode, bool shift, bool capsLock) {
     // returns 0ms today). Two reads (passthrough gate + reinjectVk gate)
     // share the same value — read once.
     const bool editMsgPath = IsSyncReplaceChannel();
-    //   - useEditMsgPath_ (Win11 New Notepad RichEditD2DPT, etc.): the host
+    //   - IsSyncReplaceChannel() (Win11 New Notepad RichEditD2DPT, etc.): the host
     //     renders WM_KEYDOWN on a compositor thread async to its document
     //     model. Letting physical keystrokes pass through means the app's
     //     text catches up to the engine state on the compositor's clock,
@@ -1772,6 +1781,16 @@ static void AppendVkEvent(std::vector<INPUT>& events, WORD wVk, WORD wScan) {
 // which has no HookEngine dependency, leaving the counter at 0 on the
 // hot path and silently disabling synth-guard everywhere. This callback
 // restores the pre-D2 behavior without re-coupling the layers.
+//
+// Memory ordering: relaxed is sufficient because every increment AND the
+// matching per-event decrement at LowLevelKeyboardProc:663 happen on the
+// same LL hook thread (SendInput fires the WH_KEYBOARD_LL callback
+// synchronously on the calling thread for own-injection events marked
+// with NEXUSKEY_EXTRA_INFO). No inter-thread visibility chain to
+// establish. The counter is a hint for the synth-guard heuristic, not a
+// synchronization primitive — readers at HookEngine.cpp:971/1074/1150/
+// 1497 also use implicit-default ordering on `synthEventsPending_ > 0`
+// comparisons, which is fine same-thread.
 void HookEngine::OnSynthDispatched(int delta) noexcept {
     auto* self = s_instance.load(std::memory_order_relaxed);
     if (!self) return;
@@ -2864,10 +2883,14 @@ void HookEngine::OnFocusChanged(HWND triggerHwnd) {
 /// deleting one extra character and permanently desyncing previousComposition_.
 ///
 /// Apps with skipEmptyChar_=true (block reinjectVk, skip U+202F bait):
-///   - Electron/Console: also get split dispatch (isElectronApp_/isConsoleApp_)
-///   - GPU-rendered apps (Zed): batch dispatch (single-process, no IPC reorder)
+///   - Electron/Console: also get split dispatch — selected by the factory
+///     (WindowClassification.isElectron / .isConsole → SplitDispatchInjector
+///     with sleepMs=6 / 5 respectively). Sprint 2 D3 lifted the dispatch
+///     branching out of HookEngine into the injector layer.
+///   - GPU-rendered apps (Zed): batch dispatch via Win32SendInputInjector
+///     (single-process, no IPC reorder).
 ///
-/// See OnFocusChanged() for the detection logic.
+/// See OnFocusChanged() for the detection logic + injector publish.
 void HookEngine::ReplaceComposition(const std::wstring& newText, DWORD reinjectVk) {
     HWND target = GetInputTarget();
     if (!target) {

--- a/tools/audit/check_hook_thread_no_mutex.sh
+++ b/tools/audit/check_hook_thread_no_mutex.sh
@@ -47,10 +47,19 @@ echo
 # ────────────────────────────────────────────────────────────────────────
 # Check 1: D4 SPIKE comment integrity
 # ────────────────────────────────────────────────────────────────────────
-# The 3 hook-thread lock_guard<recursive_mutex> lines at HookEngine.cpp
-# (originally lines 647 / 677 / 705 — line numbers drift with edits) are
-# expected to remain commented. If anyone uncomments them, Phase B's
-# atomic-only contract on the hook hot path is silently broken.
+# REGRESSION TRAP — Phase B Sprint 1 D11 downgraded `stateMutex_` from
+# `std::recursive_mutex` to `std::mutex`. The 3 commented lock_guard
+# lines in HookEngine.cpp (LowLevelKeyboardProc / WinEventProc /
+# LowLevelMouseProc) reference the old `recursive_mutex` type which no
+# longer exists, so any "cleanup" attempt that uncomments them triggers
+# a compile error. That is the intended trap.
+#
+# This check enforces the lines stay commented — verifying both that
+# someone hasn't uncommented (which would fail compile anyway) and that
+# someone hasn't deleted the trap entirely (which would lose the
+# regression marker for the eventual mutex removal). If a future
+# reviewer flags these as "dangling references", point them here and
+# at the in-source comments above each line.
 
 echo "Check 1: D4 SPIKE comment integrity (≥3 commented lock_guard lines)"
 spike_commented=$(grep -cE "^\s*//\s*std::lock_guard<std::recursive_mutex>" "$CPP")


### PR DESCRIPTION
## Summary

Mechanical / low-risk cleanup batch following the T3 IOutputInjector merge (PR #120). Comment refresh, header include order, D4 SPIKE regression-trap markers, plus a TODO.md sweep marking what's done vs deferred.

**No runtime behavior changes.** All gates green: Linux GTest 1405 / 1405, audit script `check_hook_thread_no_mutex.sh` PASS (4 / 4 checks).

## Items addressed

### M1 — stale comments in HookEngine.cpp
- Line 1503 (HandleAlphaKey passthrough block): `useEditMsgPath_` (deleted in T3 D4) → `IsSyncReplaceChannel()` proxy.
- Line 2867 (ReplaceComposition doc): explained that Electron / Console split dispatch is now selected by the factory via `WindowClassification.isElectron`/`.isConsole` → `SplitDispatchInjector`, instead of the deleted atomic flags.

### M4 — memory ordering doc for `OnSynthDispatched`
Added inline rationale for `memory_order_relaxed`: same-thread invariant. Every increment AND the matching per-event decrement at `LowLevelKeyboardProc:663` happen on the LL hook thread (SendInput fires WH_KEYBOARD_LL synchronously on the calling thread for own-injected events). No inter-thread visibility chain.

### L1 — header include order in 3 output/ files
`Win32SendInputInjector.cpp`, `SplitDispatchInjector.cpp`, `RichEditEmReplaceSelInjector.cpp` — STL group now precedes the project-internal `Internal.h`. Matches Rule 1.2 (own-header → system → STL → project).

### Pre-T3 Critical — D4 SPIKE marker comments
The 3 commented `lock_guard<recursive_mutex>` lines (LowLevelKeyboardProc / WinEventProc / LowLevelMouseProc) reworded as "REGRESSION TRAP — DO NOT UNCOMMENT" with cross-references to the audit script.

**Why the trap exists**: Phase B (Sprint 1 D11) downgraded `stateMutex_` from `recursive_mutex` to `mutex`, so the type no longer exists. Uncommenting these lines triggers a compile error — that IS the intended trap. The audit script Check 1 verifies the lines stay commented.

Original wording (\"Restore OR replace per Phase B before merge — DO NOT ship with this line commented\") was stale relative to Phase B having long shipped. Audit script Check 1 comment block also rewritten to explain the trap rationale to future reviewers who might try to \"clean up\".

### Pre-T3 Minor 3 — misleading comment at HookEngine.cpp:802
\"pure memory read, no syscall\" was correct for the fast path but wrong on the slow path (TOML reload + brief stateMutex_ acquire). Split into fast-path / slow-path wording with a forward reference to the still-open Pre-T3 Minor 2 audit task.

### docs/TODO.md sweep
- New ✅ \"Post-T3 cleanup PR — first batch landed\" section lists the 5 items addressed.
- New 🟡 \"Items deferred from this cleanup PR\" section explicitly lists what's NOT addressed and why each needs its own session.
- Old 🔴 synthEventsPending_ entry retained for the post-mortem trail; ✅ heading marks it as RESOLVED in T3 D5 (commit `2f1b400`).
- Pre-T3 Review section header updated: Critical + Minor 3 landed, Minor 1 + Minor 2 still open.

## Items intentionally deferred (need their own session)

Each requires investigation, design work, or 3-collaborator decisions out of scope for a mechanical batch:

| Item | Why deferred |
|---|---|
| Pre-T3 Minor 1 — `LowLevelMouseProc` race | Investigation needed: read exact write set, decide between atomic / `MainThreadWorker` / document-as-benign |
| Pre-T3 Minor 2 — `QuickSyncFromSharedState` Rule #11.3 violation | **Highest-impact open audit item**. Slow-path TOML reload + `stateMutex_` on hook hot path. Fix likely needs RCU re-publish via `MainThreadWorker` |
| M2 — Constants naming (`kFoo` vs `UPPER_SNAKE`) | Codebase-wide pattern uses `kFoo`; Rule 9.1 prescribes `UPPER_SNAKE`. Need 3-collaborator decision |
| M3 — Dual-route `TrackedSendInput` | Non-trivial: 4 VB6/clipboard sites + reinjectVk reroute, then delete member |
| ChannelTraits + `isElectronApp_` / `needBaitChar_` deletion | Gotcha G6 — needs interface design (own commit) |
| Typing bug `cafcs → các` | Investigation-first: trace `PushChar` + `Validate` pipeline before fix |
| `--host-class` matrix harness | Marginal value given existing 132-case natural coverage; reopen if QA later needs it |

## Test plan

- [x] Linux GTest 1405 / 1405 PASS (no regression)
- [x] Audit script `check_hook_thread_no_mutex.sh` PASS — Check 1 / 2 / 3 / 4 all green
- [x] No Windows re-run needed — comment-only changes + header reorder; no API surface or runtime path altered. Existing T3 unit + chaos suites cover the affected files
- [ ] Reviewer: verify no behavior assumption was missed (the 5 items are all comment / docs / structural)

## Linkback

- T3 baseline: [`docs/baselines/perf-baseline-t3-final.md`](../blob/post-t3-cleanup/docs/baselines/perf-baseline-t3-final.md)
- Open items: [`docs/TODO.md`](../blob/post-t3-cleanup/docs/TODO.md)
- Audit script: [`tools/audit/check_hook_thread_no_mutex.sh`](../blob/post-t3-cleanup/tools/audit/check_hook_thread_no_mutex.sh)