### PR TITLE
refactor: ChannelTraits — lift isElectronApp_ + needBaitChar_ onto IOutputInjector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,6 +445,7 @@ if(WIN32)
         tests/output/RichEditEmReplaceSelInjectorTest.cpp
         tests/output/SplitDispatchInjectorTest.cpp
         tests/output/OutputInjectorFactoryTest.cpp
+        tests/output/InjectorTraitsTest.cpp
         src/app/output/Internal.cpp
         src/app/output/Win32SendInputInjector.cpp
         src/app/output/RichEditEmReplaceSelInjector.cpp

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,41 @@
 # TODO
 
+## ✅ ChannelTraits cleanup landed (2026-05-05)
+
+Both `isElectronApp_` and `needBaitChar_` atomic flags moved from
+HookEngine onto `IOutputInjector` as virtual trait methods. Source of
+truth now lives with the dispatch channel that picked the trait, not
+duplicated in HookEngine.
+
+Implementation:
+- `IOutputInjector` gained `HasMultiProcessRenderer()` and
+  `NeedsBaitCharPrefix()` virtual methods (default `false`).
+- `Win32SendInputInjector` overrides `NeedsBaitCharPrefix()` to expose
+  its constructor-supplied bait flag.
+- `SplitDispatchInjector` gained a 3rd constructor parameter
+  (`hasMultiProcessRenderer`) so the factory can distinguish Electron
+  (multi-process renderer = true) from Console (= false). Both injectors
+  override both trait methods.
+- `OutputInjectorFactory::Create` propagates `WindowClassification`:
+  Electron branch passes `hasMultiProcessRenderer=true`, Console branch
+  passes `false`, Win32 branch inherits the default.
+- `HookEngine::HandleAlphaKey` (passthrough + reinjectVk gates) now
+  reads via one `injector_.load()` snapshot + 2 virtual calls instead
+  of 2 separate atomic loads. `HookEngine::OnFocusChanged` no longer
+  publishes the 2 deleted flags; the `WindowClassification → factory`
+  path is now the single propagation channel.
+- Audit script `ATOMIC_BOOLS` list trimmed to drop the deleted names.
+- `tests/output/InjectorTraitsTest.cpp` (new, Win32 build) covers each
+  injector's trait response across all flag combinations + the factory
+  propagation contract end-to-end.
+
+Gates: Linux GTest 1409 / 1409 PASS, audit 5 / 5 PASS, build clean.
+Windows chaos run pending — should show no behavioural delta (the
+trait values are derived from the same `WindowClassification` inputs
+that previously fed the deleted atomic stores).
+
+---
+
 ## ✅ Pre-T3 Minor 2 fix landed (2026-05-05)
 
 `QuickSyncFromSharedState` hot path is now lock-free. The `stateMutex_`
@@ -58,8 +94,12 @@ Codebase-wide pattern uses `kFoo` for file-scope `static constexpr`; Rule 9.1 pr
 ### M3 — Dual-route `TrackedSendInput` (HookEngine member + `Internal::` free function)
 Both bump `synthEventsPending_` via different mechanisms; no double-counting today but the dual presence is confusing for future readers. Suggested fix: route the 4 VB6/clipboard sites + reinjectVk through `Internal::TrackedSendInput`, then delete `HookEngine::TrackedSendInput` member. ~5 call sites, non-trivial.
 
-### ChannelTraits + `isElectronApp_` / `needBaitChar_` deletion
-Gotcha G6 (Sprint 2 D4 mid-sprint discovery) — both flags retain live policy readers in `HandleAlphaKey` passthrough/reinjectVk gates. Cleanly lifting them requires a `ChannelTraits` query method on `IOutputInjector` (interface design needs its own commit). Captured in `docs/baselines/perf-baseline-t3-final.md` deferred-items list.
+### ~~ChannelTraits + `isElectronApp_` / `needBaitChar_` deletion~~ — LANDED
+Resolved via two virtual trait methods (`HasMultiProcessRenderer()` /
+`NeedsBaitCharPrefix()`) on `IOutputInjector`, plus a 3rd
+`SplitDispatchInjector` constructor param so Electron and Console can
+diverge on the multi-process trait. See "✅ ChannelTraits cleanup
+landed" entry at top of file.
 
 ### Typing bug — `cafcs → các` (spell-check tone-replacement)
 Investigation-first item: needs `nexuskey-typing-bugs` skill trace through `PushChar` + `Validate` pipeline before fix. Hypotheses captured in the dedicated section below.

--- a/src/app/output/IOutputInjector.h
+++ b/src/app/output/IOutputInjector.h
@@ -42,6 +42,36 @@ public:
     [[nodiscard]] virtual std::chrono::milliseconds SettleBudget() const noexcept {
         return std::chrono::milliseconds{100};
     }
+
+    // ─── Channel traits (post-T3 follow-up) ──────────────────────────
+    // Replaces HookEngine's duplicated isElectronApp_ / needBaitChar_
+    // atomic flags. Source of truth lives with the injector — the
+    // dispatch channel that picked the trait is also the one that knows
+    // its character. HookEngine reads via std::atomic_load(&injector_)
+    // → trait method (1 atomic load + 1 virtual call ~11 ns total,
+    // same overhead pattern as SettleBudget()).
+
+    // True iff this channel runs through a multi-process renderer where
+    // physical WM_KEYDOWN and synthetic VK_PACKET arrive out of order
+    // (Electron / Qt / WebView2). HookEngine uses this to block
+    // mid-word passthrough once a synth has fired in this word —
+    // without that gate the multi-process renderer reorders our
+    // injected chars/BS against the user's physical keystroke and the
+    // app text drifts. Default false (vanilla single-process renderer).
+    [[nodiscard]] virtual bool HasMultiProcessRenderer() const noexcept {
+        return false;
+    }
+
+    // True iff this channel needs a U+202F bait char prefix before
+    // backspaces to dismiss Chromium-style autocomplete suggestions
+    // (Chrome, Edge, WebView2, Excel, Outlook). Without it, BS land
+    // into the still-open suggest popup and get swallowed. HookEngine
+    // uses this to skip the game-compat reinjectVk path (the bait
+    // already keeps the renderer's suggest dismissed; an extra physical
+    // VK would race with the bait char). Default false.
+    [[nodiscard]] virtual bool NeedsBaitCharPrefix() const noexcept {
+        return false;
+    }
 };
 
 }  // namespace NextKey::Output

--- a/src/app/output/OutputInjectorFactory.cpp
+++ b/src/app/output/OutputInjectorFactory.cpp
@@ -42,13 +42,18 @@ std::shared_ptr<IOutputInjector> Create(
     if (c.isElectron) {
         // Electron-on-Chromium hosts (WebView2 / Tauri / Dorion) need the
         // bait prefix even though they go through the split channel.
+        // hasMultiProcessRenderer=true blocks mid-word passthrough in
+        // HookEngine — Electron's multi-process renderer reorders
+        // physical WM_KEYDOWN against synthetic VK_PACKET.
         return std::make_shared<SplitDispatchInjector>(
-            kElectronSleepMs, c.isChromium);
+            kElectronSleepMs, c.isChromium, /*hasMultiProcessRenderer=*/true);
     }
     if (c.isConsole) {
-        // Console hosts (CMD/PowerShell) never use Chromium suggest, so
-        // bait is unconditionally off here.
-        return std::make_shared<SplitDispatchInjector>(kConsoleSleepMs);
+        // Console hosts (CMD/PowerShell) never use Chromium suggest and
+        // are single-process renderers, so both traits are false here.
+        return std::make_shared<SplitDispatchInjector>(
+            kConsoleSleepMs, /*needsBaitCharPrefix=*/false,
+            /*hasMultiProcessRenderer=*/false);
     }
     return std::make_shared<Win32SendInputInjector>(c.isChromium);
 }

--- a/src/app/output/SplitDispatchInjector.h
+++ b/src/app/output/SplitDispatchInjector.h
@@ -18,9 +18,11 @@ namespace NextKey::Output {
 class SplitDispatchInjector final : public IOutputInjector {
 public:
     explicit SplitDispatchInjector(int sleepMsBetweenBatches,
-                                   bool needsBaitCharPrefix = false) noexcept
+                                   bool needsBaitCharPrefix = false,
+                                   bool hasMultiProcessRenderer = false) noexcept
         : sleepMs_(sleepMsBetweenBatches),
-          needsBaitCharPrefix_(needsBaitCharPrefix) {}
+          needsBaitCharPrefix_(needsBaitCharPrefix),
+          hasMultiProcessRenderer_(hasMultiProcessRenderer) {}
 
     bool Replace(std::size_t bsCount, std::wstring_view text) noexcept override;
     void SendKey(unsigned short vkCode) noexcept override;
@@ -29,6 +31,19 @@ public:
     // Empirical from current HookEngine kSynthSettleMs hardcode.
     std::chrono::milliseconds SettleBudget() const noexcept override {
         return std::chrono::milliseconds{100};
+    }
+
+    // Channel traits — both flags are dispatch-arm hints set by the
+    // factory based on WindowClassification. Console hosts construct
+    // with both false (single-process readline ingest); Electron hosts
+    // construct with hasMultiProcessRenderer=true (Discord/Slack/VSCode
+    // multi-process renderer race) and optionally needsBaitCharPrefix=
+    // true when the renderer is Chromium (WebView2 / Tauri / Dorion).
+    bool NeedsBaitCharPrefix() const noexcept override {
+        return needsBaitCharPrefix_;
+    }
+    bool HasMultiProcessRenderer() const noexcept override {
+        return hasMultiProcessRenderer_;
     }
 
 private:
@@ -40,6 +55,11 @@ private:
     // bait. Without it, BS land into a still-open suggest popup and
     // get swallowed.
     bool needsBaitCharPrefix_;
+    // True for Electron / Qt-on-Chromium hosts where physical
+    // WM_KEYDOWN and synthetic VK_PACKET arrive out of order. Console
+    // hosts (CMD/PowerShell) also use split dispatch but are NOT
+    // multi-process — flag is false there.
+    bool hasMultiProcessRenderer_;
 };
 
 }  // namespace NextKey::Output

--- a/src/app/output/Win32SendInputInjector.h
+++ b/src/app/output/Win32SendInputInjector.h
@@ -27,6 +27,15 @@ public:
         return std::chrono::milliseconds{30};
     }
 
+    // Channel trait — exposes the constructor-supplied bait flag.
+    // HookEngine uses this to skip game-compat reinjectVk for Chromium
+    // browsers (the bait char already handles suggest dismiss).
+    bool NeedsBaitCharPrefix() const noexcept override {
+        return needsBaitCharPrefix_;
+    }
+    // HasMultiProcessRenderer() inherits the base default (false) —
+    // Win32 batched dispatch is for vanilla single-process renderers.
+
 private:
     bool needsBaitCharPrefix_;
 };

--- a/src/app/system/HookEngine.cpp
+++ b/src/app/system/HookEngine.cpp
@@ -1517,17 +1517,25 @@ bool HookEngine::HandleAlphaKey(DWORD vkCode, bool shift, bool capsLock) {
     // encoded widths for correct backspace count.
     // Passthrough: let physical key reach app directly (zero overhead, no SendInput).
     // Blocked when ANY condition is true:
-    //   - hadSynthInWord_ && isElectronApp_: Electron/Qt multi-process architecture
-    //     where physical WM_KEYDOWN and synthetic VK_PACKET arrive out of order.
+    //   - hadSynthInWord_ && injector.HasMultiProcessRenderer(): Electron/Qt
+    //     multi-process architecture where physical WM_KEYDOWN and synthetic
+    //     VK_PACKET arrive out of order.
     //   - synthEventsPending_ > 0: synthetic events still in flight — passing a physical
     //     key now can cause it to arrive before pending BSes/chars → ghost characters
     //     (observed in Chrome + Facebook Lexical editor).
     //   - isOutlookApp_: Outlook 2016 RichEdit drops the last char of a word when
     //     physical Shift+letter precedes subsequent chars (e.g. "Anh em" → "An hem").
     //     SendInput VK_PACKET path avoids the quirk (issue #97).
-    const bool electronApp = isElectronApp_.load(std::memory_order_acquire);
+    //
+    // Post-T3 ChannelTraits cleanup: the multi-process-renderer and bait-prefix
+    // flags now live on the injector itself (single source of truth). One
+    // atomic_load(&injector_) snapshot covers both traits + the IsSyncReplace-
+    // Channel proxy reads injector_ separately (kept for callers outside this
+    // function; not worth threading the snapshot through public API).
+    auto inj = injector_.load(std::memory_order_acquire);
+    const bool electronApp = inj && inj->HasMultiProcessRenderer();
+    const bool baitChar = inj && inj->NeedsBaitCharPrefix();
     const bool outlookApp = isOutlookApp_.load(std::memory_order_acquire);
-    const bool baitChar = needBaitChar_.load(std::memory_order_acquire);
     const bool skipEmpty = skipEmptyChar_.load(std::memory_order_acquire);
     // Sprint 2 D4: editMsgPath via SettleBudget==0 proxy (RichEditEm only
     // returns 0ms today). Two reads (passthrough gate + reinjectVk gate)
@@ -2675,18 +2683,21 @@ void HookEngine::OnFocusChanged(HWND triggerHwnd) {
     // selection flows through WindowClassification.isConsole → factory →
     // SplitDispatchInjector. RichEdit/edit-msg policy now derived via
     // IsSyncReplaceChannel() proxy on the active injector.
+    // Post-T3 ChannelTraits cleanup deleted: needBaitChar_ + isElectronApp_
+    // stores. Both flags now live on the injector (NeedsBaitCharPrefix() /
+    // HasMultiProcessRenderer()) — see the WindowClassification publish
+    // block below for the propagation path.
     skipEmptyChar_.store(localSkipEmpty, std::memory_order_release);
-    needBaitChar_.store(localNeedBait, std::memory_order_release);
     useClipboardPaste_.store(localClipboard, std::memory_order_release);
     isOutlookApp_.store(localOutlook, std::memory_order_release);
-    isElectronApp_.store(localElectronApp, std::memory_order_release);
 
     // Sprint 2 D3: build the IOutputInjector for this classification and
     // RCU-publish to injector_. All four branches now live: RichEdit
     // (D2), Electron/Console (D3 SplitDispatch), and Win32 default with
-    // optional Chromium bait-char hint. The per-flag atomic stores above
-    // are kept for non-dispatch readers (passthrough policy at line ~1471,
-    // retry-loop gating at line ~2959) and are removed in D4.
+    // optional Chromium bait-char hint. Post-T3 ChannelTraits cleanup
+    // moved the multi-process-renderer + bait-prefix flags onto the
+    // injector itself; HookEngine reads via injector_->trait method on
+    // the hot path (HandleAlphaKey passthrough/reinjectVk gates).
     {
         NextKey::Output::WindowClassification c{};
         c.isRichEditD2DPT = localEditMsg;

--- a/src/app/system/HookEngine.h
+++ b/src/app/system/HookEngine.h
@@ -304,13 +304,12 @@ private:
     // selected via WindowClassification.isConsole → SplitDispatchInjector(5)
     // by the factory; no remaining HookEngine reader. Sprint 2 D4 deleted
     // useEditMsgPath_ — replaced by IsSyncReplaceChannel() (SettleBudget==0
-    // proxy). isElectronApp_ + needBaitChar_ kept (live policy readers in
-    // HandleAlphaKey passthrough/reinjectVk gates) — D5 may lift to
-    // ChannelTraits on IOutputInjector.
-    std::atomic<bool> isElectronApp_{false};  // cached: Electron/Qt but NOT console
+    // proxy). Post-T3 ChannelTraits cleanup deleted isElectronApp_ +
+    // needBaitChar_ — both flags moved onto IOutputInjector
+    // (HasMultiProcessRenderer() / NeedsBaitCharPrefix()). Single source
+    // of truth on the injector itself.
     std::unordered_set<std::wstring> webView2PositiveCache_;  // full exe path → known WebView2 host (positive-only; see IsWebView2App)
     std::atomic<bool> skipEmptyChar_{false};  // Skip U+202F for Qt/Electron and Console apps
-    std::atomic<bool> needBaitChar_{false};   // Apps with autocomplete/suggest need U+202F bait before BS
     std::atomic<bool> useClipboardPaste_{false};  // VB6 and legacy ANSI-internal apps need clipboard paste
     std::atomic<bool> isOutlookApp_{false};   // Outlook 2016 RichEdit drops trailing char of a word when physical Shift+letter precedes it — force SendInput path (issue #97)
     DWORD lastForegroundPid_ = 0;  // PID of last known foreground (updated by OnFocusChanged + timer)

--- a/tests/output/InjectorTraitsTest.cpp
+++ b/tests/output/InjectorTraitsTest.cpp
@@ -1,0 +1,160 @@
+// tests/output/InjectorTraitsTest.cpp
+//
+// Unit tests for IOutputInjector channel-trait queries (post-T3 follow-up:
+// "ChannelTraits + isElectronApp_ / needBaitChar_ deletion" per docs/TODO.md).
+//
+// HookEngine used to maintain duplicate atomic flags (isElectronApp_,
+// needBaitChar_) that mirrored the dispatch channel's character. After
+// this refactor the source of truth lives on the injector itself and
+// HookEngine reads via std::atomic_load(&injector_)->trait method,
+// removing the two duplicated atomic stores from OnFocusChanged and
+// the two atomic loads from HandleAlphaKey.
+//
+// Each test asserts the trait value an injector reports given its
+// constructor arguments. Factory tests assert the propagation path:
+// WindowClassification → Create() → constructed injector → trait query.
+//
+// Spec: docs/CODING_RULES (Rule #11 / Pillar #4: "Mở rộng không ảnh
+// hưởng perf" — channel-specific behaviour belongs with the channel,
+// not duplicated in HookEngine).
+#include "app/output/IOutputInjector.h"
+#include "app/output/Win32SendInputInjector.h"
+#include "app/output/SplitDispatchInjector.h"
+#include "app/output/RichEditEmReplaceSelInjector.h"
+#include "app/output/OutputInjectorFactory.h"
+
+#include <gtest/gtest.h>
+
+namespace NextKey::Output::Test {
+
+// ─── Win32SendInputInjector ──────────────────────────────────────────
+
+TEST(InjectorTraitsTest, Win32_NoBaitFlag_NeedsBaitCharPrefixIsFalse) {
+    Win32SendInputInjector inj(/*needsBaitCharPrefix=*/false);
+    EXPECT_FALSE(inj.NeedsBaitCharPrefix());
+}
+
+TEST(InjectorTraitsTest, Win32_BaitFlag_NeedsBaitCharPrefixIsTrue) {
+    Win32SendInputInjector inj(/*needsBaitCharPrefix=*/true);
+    EXPECT_TRUE(inj.NeedsBaitCharPrefix());
+}
+
+TEST(InjectorTraitsTest, Win32_HasMultiProcessRendererAlwaysFalse) {
+    // Win32 batched dispatch is for vanilla single-process renderers.
+    // The bait flag controls Chromium suggest-dismiss but the Chromium
+    // browser process model itself doesn't change Win32's
+    // single-channel synth/physical ordering.
+    Win32SendInputInjector noBait(false);
+    Win32SendInputInjector withBait(true);
+    EXPECT_FALSE(noBait.HasMultiProcessRenderer());
+    EXPECT_FALSE(withBait.HasMultiProcessRenderer());
+}
+
+// ─── SplitDispatchInjector ───────────────────────────────────────────
+
+TEST(InjectorTraitsTest, Split_Defaults_BothTraitsFalse) {
+    // Console-style construction (sleepMs only). No bait, no multi-proc.
+    SplitDispatchInjector inj(/*sleepMsBetweenBatches=*/5);
+    EXPECT_FALSE(inj.NeedsBaitCharPrefix());
+    EXPECT_FALSE(inj.HasMultiProcessRenderer());
+}
+
+TEST(InjectorTraitsTest, Split_BaitOnly_BaitTrueMultiProcFalse) {
+    SplitDispatchInjector inj(/*sleepMs=*/6,
+                              /*needsBaitCharPrefix=*/true);
+    EXPECT_TRUE(inj.NeedsBaitCharPrefix());
+    EXPECT_FALSE(inj.HasMultiProcessRenderer());
+}
+
+TEST(InjectorTraitsTest, Split_MultiProcOnly_BaitFalseMultiProcTrue) {
+    SplitDispatchInjector inj(/*sleepMs=*/6,
+                              /*needsBaitCharPrefix=*/false,
+                              /*hasMultiProcessRenderer=*/true);
+    EXPECT_FALSE(inj.NeedsBaitCharPrefix());
+    EXPECT_TRUE(inj.HasMultiProcessRenderer());
+}
+
+TEST(InjectorTraitsTest, Split_BothFlags_BothTraitsTrue) {
+    // Electron-on-Chromium (Discord/Slack/VSCode/WebView2) — split
+    // dispatch + Chromium suggest dismiss + multi-process renderer race.
+    SplitDispatchInjector inj(/*sleepMs=*/6,
+                              /*needsBaitCharPrefix=*/true,
+                              /*hasMultiProcessRenderer=*/true);
+    EXPECT_TRUE(inj.NeedsBaitCharPrefix());
+    EXPECT_TRUE(inj.HasMultiProcessRenderer());
+}
+
+// ─── RichEditEmReplaceSelInjector ────────────────────────────────────
+
+TEST(InjectorTraitsTest, RichEdit_BothTraitsFalseByDefault) {
+    // Win11 New Notepad RichEditD2DPT — sent-message replacement,
+    // single-process renderer, no Chromium suggest layer.
+    RichEditEmReplaceSelInjector inj;
+    EXPECT_FALSE(inj.NeedsBaitCharPrefix());
+    EXPECT_FALSE(inj.HasMultiProcessRenderer());
+}
+
+// ─── Factory propagation ─────────────────────────────────────────────
+
+TEST(InjectorTraitsTest, Factory_DefaultClassification_NoTraits) {
+    WindowClassification c{};
+    auto inj = Create(c);
+    ASSERT_NE(inj, nullptr);
+    EXPECT_FALSE(inj->NeedsBaitCharPrefix());
+    EXPECT_FALSE(inj->HasMultiProcessRenderer());
+}
+
+TEST(InjectorTraitsTest, Factory_Chromium_BaitTrueOnWin32) {
+    WindowClassification c{};
+    c.isChromium = true;
+    auto inj = Create(c);
+    ASSERT_NE(inj, nullptr);
+    EXPECT_TRUE(inj->NeedsBaitCharPrefix())
+        << "isChromium classification must propagate as bait-prefix trait";
+    EXPECT_FALSE(inj->HasMultiProcessRenderer())
+        << "vanilla Chromium browsers stay on Win32 single channel";
+}
+
+TEST(InjectorTraitsTest, Factory_Electron_MultiProcTrueBaitFalseByDefault) {
+    WindowClassification c{};
+    c.isElectron = true;
+    auto inj = Create(c);
+    ASSERT_NE(inj, nullptr);
+    EXPECT_FALSE(inj->NeedsBaitCharPrefix())
+        << "non-Chromium Electron variants don't need the bait prefix";
+    EXPECT_TRUE(inj->HasMultiProcessRenderer())
+        << "Electron classification must propagate as multi-process trait";
+}
+
+TEST(InjectorTraitsTest, Factory_ElectronChromium_BothTraitsTrue) {
+    WindowClassification c{};
+    c.isElectron = true;
+    c.isChromium = true;
+    auto inj = Create(c);
+    ASSERT_NE(inj, nullptr);
+    EXPECT_TRUE(inj->NeedsBaitCharPrefix());
+    EXPECT_TRUE(inj->HasMultiProcessRenderer());
+}
+
+TEST(InjectorTraitsTest, Factory_Console_BothTraitsFalse) {
+    // CMD / PowerShell — split dispatch (5 ms) for ingest pacing, but
+    // single-process renderer and no Chromium suggest layer.
+    WindowClassification c{};
+    c.isConsole = true;
+    auto inj = Create(c);
+    ASSERT_NE(inj, nullptr);
+    EXPECT_FALSE(inj->NeedsBaitCharPrefix());
+    EXPECT_FALSE(inj->HasMultiProcessRenderer())
+        << "Console hosts use split-dispatch but are NOT multi-process renderers";
+}
+
+TEST(InjectorTraitsTest, Factory_RichEdit_BothTraitsFalse) {
+    WindowClassification c{};
+    c.isRichEditD2DPT = true;
+    auto inj = Create(c);
+    ASSERT_NE(inj, nullptr);
+    EXPECT_FALSE(inj->NeedsBaitCharPrefix());
+    EXPECT_FALSE(inj->HasMultiProcessRenderer());
+}
+
+}  // namespace NextKey::Output::Test

--- a/tools/audit/check_hook_thread_no_mutex.sh
+++ b/tools/audit/check_hook_thread_no_mutex.sh
@@ -139,7 +139,10 @@ done
 # WindowClassification.isConsole → SplitDispatchInjector(5ms) by the factory.
 # Sprint 2 D4 deleted: useEditMsgPath_ — replaced by HookEngine::IsSync-
 # ReplaceChannel() proxy on injector_->SettleBudget()==0.
-ATOMIC_BOOLS="vietnameseMode_|isTsfApp_|isExcludedApp_|isElectronApp_|skipEmptyChar_|needBaitChar_|useClipboardPaste_|isOutlookApp_|macroEnabled_|macroInEnglish_|autoCaps_|autoCapsMacro_|tempOffMacroByEsc_|tempOffByAlt_"
+# Post-T3 ChannelTraits cleanup deleted: isElectronApp_ + needBaitChar_ —
+# both flags moved onto IOutputInjector (HasMultiProcessRenderer() /
+# NeedsBaitCharPrefix()) so the dispatch channel owns its own character.
+ATOMIC_BOOLS="vietnameseMode_|isTsfApp_|isExcludedApp_|skipEmptyChar_|useClipboardPaste_|isOutlookApp_|macroEnabled_|macroInEnglish_|autoCaps_|autoCapsMacro_|tempOffMacroByEsc_|tempOffByAlt_"
 ATOMIC_DWORD="excludedPid_"
 ATOMIC_ENUM="currentMethod_"
 ATOMIC_RCU="config_"


### PR DESCRIPTION
## Summary

- Two atomic flags (`isElectronApp_`, `needBaitChar_`) that previously duplicated dispatch-channel state in HookEngine are lifted onto `IOutputInjector` as virtual trait methods.
- Source of truth now lives with the dispatch channel that picked the trait — adding a new channel only requires overriding the trait methods, not editing HookEngine's classifier.
- Closes the "ChannelTraits + isElectronApp_/needBaitChar_ deletion" item from `docs/TODO.md` (Gotcha G6 from Sprint 2 D4 retained policy readers).

## Interface

```cpp
class IOutputInjector {
    // ... existing Replace, SendKey, SettleBudget ...

    // True iff this channel runs through a multi-process renderer where
    // physical WM_KEYDOWN and synthetic VK_PACKET arrive out of order.
    [[nodiscard]] virtual bool HasMultiProcessRenderer() const noexcept { return false; }

    // True iff this channel needs a U+202F bait char prefix before BS
    // to dismiss Chromium-style autocomplete suggestions.
    [[nodiscard]] virtual bool NeedsBaitCharPrefix() const noexcept { return false; }
};
```

## Trait matrix

| Injector | `NeedsBaitCharPrefix` | `HasMultiProcessRenderer` |
|---|---|---|
| `Win32SendInputInjector(needsBait)` | from ctor | (default false) |
| `SplitDispatchInjector(sleepMs, needsBait, multiProc)` | from ctor | from ctor |
| `RichEditEmReplaceSelInjector` | (default false) | (default false) |

Factory propagation (`OutputInjectorFactory::Create`):
- `c.isElectron=true` → `SplitDispatchInjector(6, c.isChromium, true)` — Electron-on-Chromium gets bait + multi-proc race trait.
- `c.isConsole=true` → `SplitDispatchInjector(5, false, false)` — Console uses split for ingest pacing but is single-process renderer.
- `c.isChromium=true` (default branch) → `Win32SendInputInjector(true)` — Chromium browsers use vanilla Win32 + bait.

## HookEngine impact

- `HandleAlphaKey` reads via one `injector_.load()` snapshot + 2 virtual calls (~11 ns total) instead of 2 separate atomic loads. Same overhead pattern as the existing `IsSyncReplaceChannel()` / `SettleBudget()` proxy.
- `OnFocusChanged` no longer publishes the 2 deleted flags; the `WindowClassification → factory → injector` path is now the single propagation channel.
- 2 atomic field declarations deleted from `HookEngine.h`.
- Audit script `ATOMIC_BOOLS` list trimmed to drop the deleted names.

## Test plan

- [x] Linux build clean — interface header compiles; the existing test target rebuilds without warnings.
- [x] Linux GTest 1409 / 1409 PASS (no behavioural regression in cross-platform code).
- [x] Audit `check_hook_thread_no_mutex.sh` 5 / 5 PASS — `ATOMIC_BOOLS` regex no longer references the deleted names; all remaining atomic fields still satisfy the `.load()` / `.store()` discipline.
- [ ] **Windows MSVC build** — `tests/output/InjectorTraitsTest.cpp` (new, 13 cases) runs alongside existing `OutputInjectorFactoryTest` / `Win32SendInputInjectorTest` / `SplitDispatchInjectorTest` / `RichEditEmReplaceSelInjectorTest`. All Win32-only, not exercised on Linux.
- [ ] **Windows chaos run** — standard 5-host corpus (Chrome, Notepad, Notepad++, Discord, ChatGPT). Expected: no behavioural delta vs Pre-T3 Minor 2 baseline. Trait values derive from the same `WindowClassification` inputs that previously fed the deleted atomic stores.

## Risk

Low. The data flow is preserved end-to-end — `WindowClassification` populated by the same OnFocusChanged classifier, factory still constructs the same injector subclass, and the trait values are mechanically derived from the same `localElectronApp` / `localNeedBait` locals that previously fed the deleted `.store()` calls. The one subtle change: the 2 atomic stores happened in a fixed order, whereas now both traits are baked into the `injector_` shared_ptr at construction time and published atomically with one store. Hot-path readers always see a consistent pair.