### PR TITLE
docs: use `powershell` not `pwsh` in run-chaos.ps1

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -17,10 +17,10 @@ already built (`-DCMAKE_BUILD_TYPE=Debug`).
 # 1. Open Discord + sign in (if testing 'discord' host)
 # 2. Open Chrome on chat.openai.com / chatgpt.com + sign in (if testing 'gpt')
 # 3. Run the sweep
-pwsh tools/run-chaos.ps1 -Tag channeltraits
+powershell -ExecutionPolicy Bypass -File tools\run-chaos.ps1 -Tag channeltraits
 
 # Subset run — skip auth-dependent hosts
-pwsh tools/run-chaos.ps1 -Tag dev -Hosts notepad,notepadpp,chrome
+powershell -ExecutionPolicy Bypass -File tools\run-chaos.ps1 -Tag dev -Hosts notepad,notepadpp,chrome
 ```
 
 ### Parameters

--- a/tools/run-chaos.ps1
+++ b/tools/run-chaos.ps1
@@ -40,14 +40,16 @@
     -OutDir        Where report-*.xml + perf-*.csv land. Default: repo root.
 
 .USAGE
-    # Full sweep, tag "channeltraits"
-    pwsh tools/run-chaos.ps1 -Tag channeltraits
+    # Full sweep, tag "channeltraits".
+    # Use `powershell` (Windows PowerShell 5.1, built-in) — `pwsh` only
+    # exists if PowerShell 7+ is separately installed.
+    powershell -ExecutionPolicy Bypass -File tools\run-chaos.ps1 -Tag channeltraits
 
     # Quick local-only run (skip discord/gpt — no login required)
-    pwsh tools/run-chaos.ps1 -Tag dev -Hosts notepad,notepadpp,chrome
+    powershell -ExecutionPolicy Bypass -File tools\run-chaos.ps1 -Tag dev -Hosts notepad,notepadpp,chrome
 
     # Single-host smoke test
-    pwsh tools/run-chaos.ps1 -Tag smoke -Hosts notepad
+    powershell -ExecutionPolicy Bypass -File tools\run-chaos.ps1 -Tag smoke -Hosts notepad
 
 .OUTPUTS
     For each host: report-{Tag}-{host}.xml, perf-{Tag}-{host}.csv,


### PR DESCRIPTION
## Summary

Trivial doc fix. `pwsh` is the PS 7+ binary which only exists if separately installed. Windows hosts always have `powershell` (built-in PS 5.1) and the script declares `#Requires -Version 5.1` — the recommended invocation should match.

Updated:
- `tools/README.md` — all 3 example commands.
- `tools/run-chaos.ps1` `.USAGE` comment block — same examples + a one-line note explaining the choice.

Also added `-ExecutionPolicy Bypass -File` to the recommended form so first-time users on a default ExecutionPolicy=Restricted host don't get blocked.

## Why now

Caught immediately on first attempt to use the harness — `pwsh : The term 'pwsh' is not recognized`. Future PRs that bake the harness into their workflow shouldn't trip on this.