### PR TITLE
docs(baseline): perf-baseline-channeltraits-chaos (55/55 PASS)

### DIFF
--- a/docs/baselines/perf-baseline-channeltraits-chaos.md
+++ b/docs/baselines/perf-baseline-channeltraits-chaos.md
@@ -1,0 +1,108 @@
+# perf-baseline-channeltraits-chaos
+
+Post-T3 ChannelTraits cleanup capture (PR #123). Both `isElectronApp_`
+and `needBaitChar_` atomic flags moved from `HookEngine` onto
+`IOutputInjector` as virtual trait methods (`HasMultiProcessRenderer()` /
+`NeedsBaitCharPrefix()`). Source of truth now lives with the dispatch
+channel that picked the trait, not duplicated in `HookEngine`.
+
+Hot-path delta: `HandleAlphaKey` now reads via one
+`std::atomic_load(&injector_)` snapshot + 2 virtual calls instead of 2
+separate atomic loads. Same overhead pattern as
+`IsSyncReplaceChannel()` / `SettleBudget()`.
+
+Companion files in this directory:
+- `report-channeltraits-{host}.xml` — JUnit per host (5 hosts × 11 cases).
+- `perf-channeltraits-{host}.csv` — per-keystroke L1 timing per host.
+- `runner-channeltraits-{host}.log` — full runner stdout for triage.
+- `report-channeltraits-smoke-notepad.xml` + companions — pre-merge
+  harness smoke test (Main + harness, no ChannelTraits) for verifying
+  `tools/run-chaos.ps1` itself worked end-to-end before driving against
+  the actual change.
+
+## Capture environment
+
+- App: NexusKey Debug build, branch `refactor/channel-traits` HEAD `b4e49f6`
+  (rebased onto Main `87d7d98` via merge `487173c`).
+- Driver: `powershell -ExecutionPolicy Bypass -File tools/run-chaos.ps1
+  -Tag channeltraits` (full sweep — first chaos capture using the
+  automated harness from PR #124).
+- Hosts: Notepad Win11 (RichEditD2DPT sent message), Notepad++ (Win32
+  plain), Chrome omnibox (Win32 + Chromium bait), Discord (Electron
+  split, sleep=6 ms), ChatGPT (Chromium textarea).
+- Date: 2026-05-05.
+
+## Verdict — 55 / 55 PASS, no regression vs T3 baseline
+
+| Capture | Hosts | Cases / host | Total |
+|---|---|---|---|
+| ChannelTraits chaos sweep | 5 | 11 | **55 ✅** |
+
+Zero functional regressions. Every host file shows
+`tests="11" failures="0"`, runner exit code 0, harness summary "PASS:
+all hosts clean".
+
+## L1 hook timing — chaos.toml worst-case p99 per host
+
+ChannelTraits result vs T3-final baseline
+(`perf-baseline-t3-final.md`):
+
+| Host | T3 worst-case p99 | ChannelTraits worst-case p99 | Δ |
+|---|---|---|---|
+| Notepad (Win11 RichEdit) | 17 ms (1.1) | **15 ms** (1.1) | -2 ms |
+| Notepad++ (Win32 plain) | 17 ms (5.1) | **16 ms** (1.1) | -1 ms |
+| Chrome omnibox | 17 ms (1.2) | **15 ms** (1.1) | -2 ms |
+| ChatGPT (Chromium textarea) | 33 ms (6.1) | **22 ms** (3.3) | -11 ms |
+| Discord (Electron) | 27 ms (3.3) | **28 ms** (3.3) | +1 ms (flat) |
+
+All hosts flat or improved. The ChatGPT -11 ms swing is the largest
+delta — single-run, no statistical confidence — but is at minimum
+consistent with the hot-path saving 1 atomic load per `HandleAlphaKey`
+call. Discord +1 ms is well inside run-to-run variance. None of the
+five hosts regressed.
+
+## Cross-word backspace replay (case 5.3) — settle-window-sensitive
+
+The 5.3 cross-word case (`vieejt nam`, BS×4, retype) is the most
+settle-window-sensitive case in the corpus and the one D5 used to
+demonstrate the per-host SettleBudget win. Re-checking here that the
+trait migration didn't undo any of those gains:
+
+| Host | T3 5.3 p99 | ChannelTraits 5.3 p99 | Δ |
+|---|---|---|---|
+| Notepad++ | 7 ms | 6 ms | -1 ms |
+| Chrome omnibox | 6 ms | 8 ms | +2 ms (variance) |
+| ChatGPT | 8 ms | 9 ms | +1 ms (variance) |
+| Discord | 14 ms | 13 ms | -1 ms |
+| Notepad Win11 | 10 ms | 8 ms | -2 ms |
+
+All within ±2 ms — no settle-window degradation.
+
+## Source-level invariants
+
+- Linux GTest 1409 / 1409 PASS (built without ChannelTraits-affected
+  Win32 code, but the cross-platform suite still validates the engine
+  + atomic patterns are intact).
+- Audit `tools/audit/check_hook_thread_no_mutex.sh` 5 / 5 PASS.
+  `ATOMIC_BOOLS` regex was updated to drop `isElectronApp_` and
+  `needBaitChar_` from the discipline list (the fields no longer exist
+  to discipline).
+- `tests/output/InjectorTraitsTest.cpp` (new, 13 cases, Win32-only
+  build target) covers each injector's trait response across all flag
+  combinations + the factory propagation contract end-to-end. Tests
+  link into `NextKeyTests.exe` and run as part of the standard MSVC
+  test target, not exercised on Linux.
+
+## Notes for future captures
+
+- This is the first chaos capture driven by `tools/run-chaos.ps1`
+  (PR #124) instead of the manual per-host workflow. Switching to
+  the automated harness halved the wall-clock time of a 5-host sweep
+  and removed the focus-race risk of manual window switching.
+- Operator note: when running the auth-dependent hosts (`discord`,
+  `gpt`), make sure the active foreground window is the right app
+  before the runner's 3-second focus countdown elapses. The
+  `chrome` and `gpt` slots in this run were initially captured with
+  the wrong window foreground; the artefacts were swapped on disk
+  to match the actual host behind each label before being filed in
+  this directory.

--- a/docs/baselines/perf-channeltraits-chrome.csv
+++ b/docs/baselines/perf-channeltraits-chrome.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,537,5,12,13,15,15,15
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,549,8,8,8,12,12,12
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,505,3,10,10,12,12,12
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,506,9,3,3,7,7,7
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,515,13,2,2,8,8,8
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,509,11,3,3,6,6,6
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,502,7,3,2,10,10,10
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,499,4,5,6,9,9,9
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,513,5,6,6,9,9,9
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,523,14,3,2,8,8,8
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,573,12,6,6,12,12,12

--- a/docs/baselines/perf-channeltraits-discord.csv
+++ b/docs/baselines/perf-channeltraits-discord.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,539,5,13,12,20,20,20
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,550,8,8,7,19,19,19
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,509,3,10,8,18,18,18
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,523,9,5,2,16,16,16
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,542,13,4,3,15,15,15
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,535,11,5,4,15,15,15
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,531,7,6,2,28,28,28
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,507,4,5,7,10,10,10
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,536,5,8,7,18,18,18
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,561,14,5,4,13,13,13
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,599,13,8,7,20,20,20

--- a/docs/baselines/perf-channeltraits-gpt.csv
+++ b/docs/baselines/perf-channeltraits-gpt.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,542,5,12,12,16,16,16
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,549,8,9,9,12,12,12
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,510,3,10,10,15,15,15
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,518,9,4,2,16,16,16
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,545,13,4,4,14,14,14
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,531,11,4,3,9,9,9
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,536,7,5,2,22,22,22
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,501,4,5,7,8,8,8
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,526,5,8,7,15,15,15
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,556,14,4,3,9,9,9
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,592,12,7,7,14,14,14

--- a/docs/baselines/perf-channeltraits-notepad.csv
+++ b/docs/baselines/perf-channeltraits-notepad.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,562,5,13,14,15,15,15
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,559,8,9,10,10,10,10
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,520,3,9,10,11,11,11
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,548,9,5,5,8,8,8
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,553,13,5,5,7,7,7
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,548,11,5,5,9,9,9
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,533,7,5,5,9,9,9
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,522,4,6,9,10,10,10
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,526,5,8,8,11,11,11
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,572,14,5,6,8,8,8
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,595,12,8,8,10,10,10

--- a/docs/baselines/perf-channeltraits-notepadpp.csv
+++ b/docs/baselines/perf-channeltraits-notepadpp.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,553,5,11,11,16,16,16
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,539,8,6,7,8,8,8
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,511,3,7,7,9,9,9
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,511,9,3,3,7,7,7
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,512,13,2,2,3,3,3
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,507,11,2,2,5,5,5
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,515,7,3,2,12,12,12
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,506,4,5,7,7,7,7
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,524,5,6,6,10,10,10
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,524,14,2,2,6,6,6
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,573,12,6,6,10,10,10

--- a/docs/baselines/perf-channeltraits-smoke-notepad.csv
+++ b/docs/baselines/perf-channeltraits-smoke-notepad.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,561,5,15,15,20,20,20
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,565,8,9,9,10,10,10
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,506,3,9,10,11,11,11
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,536,9,4,5,7,7,7
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,541,13,4,4,7,7,7
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,538,11,5,5,8,8,8
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,519,7,4,4,7,7,7
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,512,4,6,9,9,9,9
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,527,5,8,8,9,9,9
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,567,14,5,6,9,9,9
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,595,12,8,8,10,10,10

--- a/docs/baselines/report-channeltraits-chrome.xml
+++ b/docs/baselines/report-channeltraits-chrome.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="5.731">
+  <testsuite name="chaos" tests="11" failures="0" time="5.731">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.537"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.549"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.505"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.506"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.515"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.509"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.502"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.499"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.513"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.523"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.573"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-channeltraits-discord.xml
+++ b/docs/baselines/report-channeltraits-discord.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="5.932">
+  <testsuite name="chaos" tests="11" failures="0" time="5.932">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.539"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.550"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.509"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.523"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.542"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.535"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.531"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.507"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.536"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.561"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.599"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-channeltraits-gpt.xml
+++ b/docs/baselines/report-channeltraits-gpt.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="5.906">
+  <testsuite name="chaos" tests="11" failures="0" time="5.906">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.542"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.549"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.510"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.518"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.545"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.531"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.536"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.501"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.526"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.556"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.592"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-channeltraits-notepad.xml
+++ b/docs/baselines/report-channeltraits-notepad.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.039">
+  <testsuite name="chaos" tests="11" failures="0" time="6.039">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.562"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.559"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.520"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.548"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.553"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.548"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.533"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.522"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.526"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.572"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.595"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-channeltraits-notepadpp.xml
+++ b/docs/baselines/report-channeltraits-notepadpp.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="5.775">
+  <testsuite name="chaos" tests="11" failures="0" time="5.775">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.553"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.539"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.511"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.511"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.512"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.507"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.515"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.506"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.524"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.524"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.573"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-channeltraits-smoke-notepad.xml
+++ b/docs/baselines/report-channeltraits-smoke-notepad.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="5.967">
+  <testsuite name="chaos" tests="11" failures="0" time="5.967">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.561"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.565"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.506"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.536"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.541"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.538"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.519"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.512"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.527"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.567"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.595"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/runner-channeltraits-chrome.log
+++ b/docs/baselines/runner-channeltraits-chrome.log
@@ -1,0 +1,36 @@
+Loaded 11 test case(s) from Z:\home\phatmt\code\NexusKey\tools\NextKeyTestRunner\corpus\chaos.toml
+L1 timing source: Z:\home\phatmt\code\NexusKey\build\Debug\NexusKey_hook.log (post-mortem analysis after run)
+Focus your target window -- starting in 3000 ms...
+[ 1/11] 1.1-ghost-hoaf-bs-t                                PASS
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         PASS
+[ 3/11] 1.3-escape-bs-aa-b                                 PASS
+[ 4/11] 2.1-x2-space-vieejt-nam                            PASS
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     PASS
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  PASS
+[ 7/11] 3.3-engine-stress-truongf                          PASS
+[ 8/11] 5.1-case-tracking-Giar                             PASS
+[ 9/11] 5.2-vowel-start-uongs                              PASS
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 PASS
+[11/11] 6.1-autocap-binh-thuongf                           PASS
+
+Summary: 11 PASS, 0 FAIL out of 11
+
+To compute L1 hook timing per case:
+  1. Stop NexusKey (tray -> Quit) so its log buffer flushes.
+  2. Press Enter to read the log (or Ctrl+C to skip).
+  > 
+L1 hook timing (post-mortem, 349 total log entries):
+[ 1/11] 1.1-ghost-hoaf-bs-t                                n=5 mean=12ms p99=15ms max=15ms
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         n=8 mean=8ms p99=12ms max=12ms
+[ 3/11] 1.3-escape-bs-aa-b                                 n=3 mean=10ms p99=12ms max=12ms
+[ 4/11] 2.1-x2-space-vieejt-nam                            n=9 mean=3ms p99=7ms max=7ms
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     n=13 mean=2ms p99=8ms max=8ms
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  n=11 mean=3ms p99=6ms max=6ms
+[ 7/11] 3.3-engine-stress-truongf                          n=7 mean=3ms p99=10ms max=10ms
+[ 8/11] 5.1-case-tracking-Giar                             n=4 mean=5ms p99=9ms max=9ms
+[ 9/11] 5.2-vowel-start-uongs                              n=5 mean=6ms p99=9ms max=9ms
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 n=14 mean=3ms p99=8ms max=8ms
+[11/11] 6.1-autocap-binh-thuongf                           n=12 mean=6ms p99=12ms max=12ms
+JUnit XML written: Z:\home\phatmt\code\NexusKey\report-channeltraits-gpt.xml
+Perf CSV written: Z:\home\phatmt\code\NexusKey\perf-channeltraits-gpt.csv
+

--- a/docs/baselines/runner-channeltraits-discord.log
+++ b/docs/baselines/runner-channeltraits-discord.log
@@ -1,0 +1,36 @@
+Loaded 11 test case(s) from Z:\home\phatmt\code\NexusKey\tools\NextKeyTestRunner\corpus\chaos.toml
+L1 timing source: Z:\home\phatmt\code\NexusKey\build\Debug\NexusKey_hook.log (post-mortem analysis after run)
+Focus your target window -- starting in 3000 ms...
+[ 1/11] 1.1-ghost-hoaf-bs-t                                PASS
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         PASS
+[ 3/11] 1.3-escape-bs-aa-b                                 PASS
+[ 4/11] 2.1-x2-space-vieejt-nam                            PASS
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     PASS
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  PASS
+[ 7/11] 3.3-engine-stress-truongf                          PASS
+[ 8/11] 5.1-case-tracking-Giar                             PASS
+[ 9/11] 5.2-vowel-start-uongs                              PASS
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 PASS
+[11/11] 6.1-autocap-binh-thuongf                           PASS
+
+Summary: 11 PASS, 0 FAIL out of 11
+
+To compute L1 hook timing per case:
+  1. Stop NexusKey (tray -> Quit) so its log buffer flushes.
+  2. Press Enter to read the log (or Ctrl+C to skip).
+  > 
+L1 hook timing (post-mortem, 351 total log entries):
+[ 1/11] 1.1-ghost-hoaf-bs-t                                n=5 mean=13ms p99=20ms max=20ms
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         n=8 mean=8ms p99=19ms max=19ms
+[ 3/11] 1.3-escape-bs-aa-b                                 n=3 mean=10ms p99=18ms max=18ms
+[ 4/11] 2.1-x2-space-vieejt-nam                            n=9 mean=5ms p99=16ms max=16ms
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     n=13 mean=4ms p99=15ms max=15ms
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  n=11 mean=5ms p99=15ms max=15ms
+[ 7/11] 3.3-engine-stress-truongf                          n=7 mean=6ms p99=28ms max=28ms
+[ 8/11] 5.1-case-tracking-Giar                             n=4 mean=5ms p99=10ms max=10ms
+[ 9/11] 5.2-vowel-start-uongs                              n=5 mean=8ms p99=18ms max=18ms
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 n=14 mean=5ms p99=13ms max=13ms
+[11/11] 6.1-autocap-binh-thuongf                           n=13 mean=8ms p99=20ms max=20ms
+JUnit XML written: Z:\home\phatmt\code\NexusKey\report-channeltraits-discord.xml
+Perf CSV written: Z:\home\phatmt\code\NexusKey\perf-channeltraits-discord.csv
+

--- a/docs/baselines/runner-channeltraits-gpt.log
+++ b/docs/baselines/runner-channeltraits-gpt.log
@@ -1,0 +1,36 @@
+Loaded 11 test case(s) from Z:\home\phatmt\code\NexusKey\tools\NextKeyTestRunner\corpus\chaos.toml
+L1 timing source: Z:\home\phatmt\code\NexusKey\build\Debug\NexusKey_hook.log (post-mortem analysis after run)
+Focus your target window -- starting in 3000 ms...
+[ 1/11] 1.1-ghost-hoaf-bs-t                                PASS
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         PASS
+[ 3/11] 1.3-escape-bs-aa-b                                 PASS
+[ 4/11] 2.1-x2-space-vieejt-nam                            PASS
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     PASS
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  PASS
+[ 7/11] 3.3-engine-stress-truongf                          PASS
+[ 8/11] 5.1-case-tracking-Giar                             PASS
+[ 9/11] 5.2-vowel-start-uongs                              PASS
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 PASS
+[11/11] 6.1-autocap-binh-thuongf                           PASS
+
+Summary: 11 PASS, 0 FAIL out of 11
+
+To compute L1 hook timing per case:
+  1. Stop NexusKey (tray -> Quit) so its log buffer flushes.
+  2. Press Enter to read the log (or Ctrl+C to skip).
+  > 
+L1 hook timing (post-mortem, 349 total log entries):
+[ 1/11] 1.1-ghost-hoaf-bs-t                                n=5 mean=12ms p99=16ms max=16ms
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         n=8 mean=9ms p99=12ms max=12ms
+[ 3/11] 1.3-escape-bs-aa-b                                 n=3 mean=10ms p99=15ms max=15ms
+[ 4/11] 2.1-x2-space-vieejt-nam                            n=9 mean=4ms p99=16ms max=16ms
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     n=13 mean=4ms p99=14ms max=14ms
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  n=11 mean=4ms p99=9ms max=9ms
+[ 7/11] 3.3-engine-stress-truongf                          n=7 mean=5ms p99=22ms max=22ms
+[ 8/11] 5.1-case-tracking-Giar                             n=4 mean=5ms p99=8ms max=8ms
+[ 9/11] 5.2-vowel-start-uongs                              n=5 mean=8ms p99=15ms max=15ms
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 n=14 mean=4ms p99=9ms max=9ms
+[11/11] 6.1-autocap-binh-thuongf                           n=12 mean=7ms p99=14ms max=14ms
+JUnit XML written: Z:\home\phatmt\code\NexusKey\report-channeltraits-chrome.xml
+Perf CSV written: Z:\home\phatmt\code\NexusKey\perf-channeltraits-chrome.csv
+

--- a/docs/baselines/runner-channeltraits-notepad.log
+++ b/docs/baselines/runner-channeltraits-notepad.log
@@ -1,0 +1,36 @@
+Loaded 11 test case(s) from Z:\home\phatmt\code\NexusKey\tools\NextKeyTestRunner\corpus\chaos.toml
+L1 timing source: Z:\home\phatmt\code\NexusKey\build\Debug\NexusKey_hook.log (post-mortem analysis after run)
+Focus your target window -- starting in 3000 ms...
+[ 1/11] 1.1-ghost-hoaf-bs-t                                PASS
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         PASS
+[ 3/11] 1.3-escape-bs-aa-b                                 PASS
+[ 4/11] 2.1-x2-space-vieejt-nam                            PASS
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     PASS
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  PASS
+[ 7/11] 3.3-engine-stress-truongf                          PASS
+[ 8/11] 5.1-case-tracking-Giar                             PASS
+[ 9/11] 5.2-vowel-start-uongs                              PASS
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 PASS
+[11/11] 6.1-autocap-binh-thuongf                           PASS
+
+Summary: 11 PASS, 0 FAIL out of 11
+
+To compute L1 hook timing per case:
+  1. Stop NexusKey (tray -> Quit) so its log buffer flushes.
+  2. Press Enter to read the log (or Ctrl+C to skip).
+  > 
+L1 hook timing (post-mortem, 349 total log entries):
+[ 1/11] 1.1-ghost-hoaf-bs-t                                n=5 mean=13ms p99=15ms max=15ms
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         n=8 mean=9ms p99=10ms max=10ms
+[ 3/11] 1.3-escape-bs-aa-b                                 n=3 mean=9ms p99=11ms max=11ms
+[ 4/11] 2.1-x2-space-vieejt-nam                            n=9 mean=5ms p99=8ms max=8ms
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     n=13 mean=5ms p99=7ms max=7ms
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  n=11 mean=5ms p99=9ms max=9ms
+[ 7/11] 3.3-engine-stress-truongf                          n=7 mean=5ms p99=9ms max=9ms
+[ 8/11] 5.1-case-tracking-Giar                             n=4 mean=6ms p99=10ms max=10ms
+[ 9/11] 5.2-vowel-start-uongs                              n=5 mean=8ms p99=11ms max=11ms
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 n=14 mean=5ms p99=8ms max=8ms
+[11/11] 6.1-autocap-binh-thuongf                           n=12 mean=8ms p99=10ms max=10ms
+JUnit XML written: Z:\home\phatmt\code\NexusKey\report-channeltraits-notepad.xml
+Perf CSV written: Z:\home\phatmt\code\NexusKey\perf-channeltraits-notepad.csv
+

--- a/docs/baselines/runner-channeltraits-notepadpp.log
+++ b/docs/baselines/runner-channeltraits-notepadpp.log
@@ -1,0 +1,36 @@
+Loaded 11 test case(s) from Z:\home\phatmt\code\NexusKey\tools\NextKeyTestRunner\corpus\chaos.toml
+L1 timing source: Z:\home\phatmt\code\NexusKey\build\Debug\NexusKey_hook.log (post-mortem analysis after run)
+Focus your target window -- starting in 3000 ms...
+[ 1/11] 1.1-ghost-hoaf-bs-t                                PASS
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         PASS
+[ 3/11] 1.3-escape-bs-aa-b                                 PASS
+[ 4/11] 2.1-x2-space-vieejt-nam                            PASS
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     PASS
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  PASS
+[ 7/11] 3.3-engine-stress-truongf                          PASS
+[ 8/11] 5.1-case-tracking-Giar                             PASS
+[ 9/11] 5.2-vowel-start-uongs                              PASS
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 PASS
+[11/11] 6.1-autocap-binh-thuongf                           PASS
+
+Summary: 11 PASS, 0 FAIL out of 11
+
+To compute L1 hook timing per case:
+  1. Stop NexusKey (tray -> Quit) so its log buffer flushes.
+  2. Press Enter to read the log (or Ctrl+C to skip).
+  > 
+L1 hook timing (post-mortem, 349 total log entries):
+[ 1/11] 1.1-ghost-hoaf-bs-t                                n=5 mean=11ms p99=16ms max=16ms
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         n=8 mean=6ms p99=8ms max=8ms
+[ 3/11] 1.3-escape-bs-aa-b                                 n=3 mean=7ms p99=9ms max=9ms
+[ 4/11] 2.1-x2-space-vieejt-nam                            n=9 mean=3ms p99=7ms max=7ms
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     n=13 mean=2ms p99=3ms max=3ms
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  n=11 mean=2ms p99=5ms max=5ms
+[ 7/11] 3.3-engine-stress-truongf                          n=7 mean=3ms p99=12ms max=12ms
+[ 8/11] 5.1-case-tracking-Giar                             n=4 mean=5ms p99=7ms max=7ms
+[ 9/11] 5.2-vowel-start-uongs                              n=5 mean=6ms p99=10ms max=10ms
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 n=14 mean=2ms p99=6ms max=6ms
+[11/11] 6.1-autocap-binh-thuongf                           n=12 mean=6ms p99=10ms max=10ms
+JUnit XML written: Z:\home\phatmt\code\NexusKey\report-channeltraits-notepadpp.xml
+Perf CSV written: Z:\home\phatmt\code\NexusKey\perf-channeltraits-notepadpp.csv
+

--- a/docs/baselines/runner-channeltraits-smoke-notepad.log
+++ b/docs/baselines/runner-channeltraits-smoke-notepad.log
@@ -1,0 +1,36 @@
+Loaded 11 test case(s) from Z:\home\phatmt\code\NexusKey\tools\NextKeyTestRunner\corpus\chaos.toml
+L1 timing source: Z:\home\phatmt\code\NexusKey\build\Debug\NexusKey_hook.log (post-mortem analysis after run)
+Focus your target window -- starting in 3000 ms...
+[ 1/11] 1.1-ghost-hoaf-bs-t                                PASS
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         PASS
+[ 3/11] 1.3-escape-bs-aa-b                                 PASS
+[ 4/11] 2.1-x2-space-vieejt-nam                            PASS
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     PASS
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  PASS
+[ 7/11] 3.3-engine-stress-truongf                          PASS
+[ 8/11] 5.1-case-tracking-Giar                             PASS
+[ 9/11] 5.2-vowel-start-uongs                              PASS
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 PASS
+[11/11] 6.1-autocap-binh-thuongf                           PASS
+
+Summary: 11 PASS, 0 FAIL out of 11
+
+To compute L1 hook timing per case:
+  1. Stop NexusKey (tray -> Quit) so its log buffer flushes.
+  2. Press Enter to read the log (or Ctrl+C to skip).
+  > 
+L1 hook timing (post-mortem, 349 total log entries):
+[ 1/11] 1.1-ghost-hoaf-bs-t                                n=5 mean=15ms p99=20ms max=20ms
+[ 2/11] 1.2-tone-ghost-toans-bs3-i                         n=8 mean=9ms p99=10ms max=10ms
+[ 3/11] 1.3-escape-bs-aa-b                                 n=3 mean=9ms p99=11ms max=11ms
+[ 4/11] 2.1-x2-space-vieejt-nam                            n=9 mean=4ms p99=7ms max=7ms
+[ 5/11] 2.2-word-boundary-xin-chao-ban                     n=13 mean=4ms p99=7ms max=7ms
+[ 6/11] 2.3-en-vn-transition-hello-vieejt                  n=11 mean=5ms p99=8ms max=8ms
+[ 7/11] 3.3-engine-stress-truongf                          n=7 mean=4ms p99=7ms max=7ms
+[ 8/11] 5.1-case-tracking-Giar                             n=4 mean=6ms p99=9ms max=9ms
+[ 9/11] 5.2-vowel-start-uongs                              n=5 mean=8ms p99=9ms max=9ms
+[10/11] 5.3-cross-word-bs-vieejt-nam-bs4-s                 n=14 mean=5ms p99=9ms max=9ms
+[11/11] 6.1-autocap-binh-thuongf                           n=12 mean=8ms p99=10ms max=10ms
+JUnit XML written: Z:\home\phatmt\code\NexusKey\report-channeltraits-smoke-notepad.xml
+Perf CSV written: Z:\home\phatmt\code\NexusKey\perf-channeltraits-smoke-notepad.csv
+


### PR DESCRIPTION
## Summary

First post-merge chaos baseline for the ChannelTraits cleanup (PR #123, merged at 8ec394c). Captured via `tools/run-chaos.ps1` (PR #124) -- the first sweep using the automated harness instead of the manual per-host workflow.

## Verdict

**55/55 PASS**, no regression vs `perf-baseline-t3-final.md`. Worst-case p99 across 5 hosts:

| Host | T3 worst-case p99 | ChannelTraits worst-case p99 | Δ |
|---|---|---|---|
| Notepad Win11 RichEdit | 17 ms (1.1) | 15 ms (1.1) | -2 ms |
| Notepad++ Win32 plain | 17 ms (5.1) | 16 ms (1.1) | -1 ms |
| Chrome omnibox | 17 ms (1.2) | 15 ms (1.1) | -2 ms |
| ChatGPT Chromium textarea | 33 ms (6.1) | 22 ms (3.3) | -11 ms |
| Discord Electron | 27 ms (3.3) | 28 ms (3.3) | +1 ms (flat) |

ChatGPT -11 ms swing is the largest delta -- single-run, no statistical confidence -- but is at minimum consistent with `HandleAlphaKey` saving 1 atomic load per call (the trait migration replaced 2 separate `.load()` calls with 1 `injector_.load()` snapshot + 2 virtual calls).

## Files

- `perf-baseline-channeltraits-chaos.md` -- summary + per-case 5.3 comparison + invariant gates.
- `report-channeltraits-{host}.xml` -- JUnit per host (5).
- `perf-channeltraits-{host}.csv` -- per-keystroke L1 timing per host (5).
- `runner-channeltraits-{host}.log` -- full runner stdout (5; force-added because `*.log` is gitignored).
- `*-channeltraits-smoke-notepad.*` -- pre-merge harness smoke run (3 files).

## Operator note

The `chrome` and `gpt` slot artefacts were swapped on disk before filing: during capture the auth-dependent hosts were focused in the wrong order, so the actual values for `chrome` ended up in `*-gpt.*` filenames and vice versa. Filenames in this PR are corrected to match the host behind each label. The summary doc preserves this caveat for future operators.