### PR TITLE
chore: tidy repo root chaos artefacts + 2026-05-05 handoff section

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,77 @@
 # NexusKey Refactor — Sprint 1 Handoff (Notepad 11/11, Chrome 10/11, D13 next)
 
+## Post-T3 status (2026-05-05 PM) — current pickup note
+
+Today's session shipped 7 PRs (#122-128) on top of the post-T3 cleanup
+(PR #121, c19239c). Main is now at `32fceb7`. Two production fixes,
+one piece of shared tooling, three small follow-ups, one baseline
+capture.
+
+### Landed today
+
+| PR | Subject | Effect |
+|---|---|---|
+| #122 | Pre-T3 Minor 2: lock-free hot path in `QuickSyncFromSharedState` | Hot path no longer acquires `stateMutex_` on common case. Slow path (configGeneration bumped) still locks but is user-paced. Closes the highest-impact open audit item from the Pre-T3 review. |
+| #123 | ChannelTraits cleanup | `isElectronApp_` + `needBaitChar_` atomic flags moved from HookEngine onto `IOutputInjector` as `HasMultiProcessRenderer()` / `NeedsBaitCharPrefix()` virtual methods. `HandleAlphaKey` now reads via 1 `injector_.load()` snapshot + 2 virtual calls instead of 2 separate atomic loads. `SplitDispatchInjector` gained a 3rd ctor param to distinguish Electron (multi-process renderer) from Console. |
+| #124 | `tools/run-chaos.ps1` harness | Single-command driver replacing the per-host manual workflow. Loops over 5 hosts (notepad / notepadpp / chrome / discord / gpt), launches NexusKey + target, drives the runner, watches stdout for the "stop NexusKey" prompt, kills + Enter, parses each report. Exit 0 iff every host clean. |
+| #125–127 | Three quick follow-ups on the harness | `pwsh` → `powershell` invocation (PS 7+ vs 5.1), strip non-ASCII chars from the script (Win-1252 misdecode of em-dash terminated string literals on PS 5.1), and correct the default `-RunnerExe` path to match CMake's `RUNTIME_OUTPUT_DIRECTORY`. |
+| #128 | `perf-baseline-channeltraits-chaos` | Full chaos verify of #123 via the new harness — 55/55 PASS, no regression vs T3 baseline. ChatGPT improved -11 ms p99 (consistent with the saved atomic load); other hosts flat or slightly improved. |
+
+### Verified gates
+
+- Linux GTest **1409 / 1409 PASS**.
+- Audit `tools/audit/check_hook_thread_no_mutex.sh` **5 / 5 PASS** (Check 5 added in #122 enforces lock-free hot path; Check 3's `ATOMIC_BOOLS` list pruned in #123 to drop the deleted names).
+- Windows chaos sweep **55 / 55 PASS** across all 5 hosts (`docs/baselines/perf-baseline-channeltraits-chaos.md`).
+
+### Worst-case p99 vs T3 baseline
+
+| Host | T3 | ChannelTraits | Δ |
+|---|---|---|---|
+| Notepad Win11 RichEdit | 17 ms | **15 ms** | -2 ms |
+| Notepad++ | 17 ms | **16 ms** | -1 ms |
+| Chrome omnibox | 17 ms | **15 ms** | -2 ms |
+| ChatGPT (Chromium textarea) | 33 ms | **22 ms** | -11 ms |
+| Discord | 27 ms | **28 ms** | +1 ms (flat) |
+
+### Items pending — pickup priority for next session
+
+1. **Pre-T3 Minor 1 — `LowLevelMouseProc` race on `cachedFocusedHwnd_`.** Investigate-first: read the exact write set in the mouse callback, then decide between (a) atomic migration, (b) defer to `MainThreadWorker`, (c) document as benign. Detailed in `docs/TODO.md` "Review (2026-05-05)" section.
+
+2. **M3 — dual-route `TrackedSendInput` unification.** Bundles cleanly with the output area refactored in #123. Route the 4 VB6/clipboard sites + reinjectVk through `Internal::TrackedSendInput`, then delete the `HookEngine::TrackedSendInput` member. ~5 call sites, non-trivial.
+
+3. **Typing bug `cafcs → các`** (spell-check tone-replacement gate). User-facing. Investigation-first via `nexuskey-typing-bugs` skill before reading code. Repro + 3 hypotheses captured in `docs/TODO.md`.
+
+4. **M2 — constants naming convention (`kFoo` vs `UPPER_SNAKE`).** Needs 3-collaborator decision before code: update Rule 9.1 to formalise the k-prefix convention, or rename ~10 codebase constants. Recommendation in TODO is to update the rule.
+
+### Repo cleanup landed in this same PR
+
+- All 30 D1–D5 chaos artefacts (`perf-d{1-5}-*.csv`, `report-d{1-5}-*.xml`) moved from repo root into `docs/baselines/` so `perf-baseline-t3-final.md`'s "Companion files in this directory" note is accurate. `docs/baselines/` is now the canonical location for chaos-capture artefacts (T3, ChannelTraits, and the D-day predecessors).
+- 13 untagged + harness-smoke trial files (`perf-{host}.csv`, `report-{host}.xml`, `*-harness-smoke-notepad.*`) deleted — no doc references them; they were trial captures from prior sessions.
+
+### Key references
+
+| Doc | Use for |
+|---|---|
+| `docs/TODO.md` (top) | Pending items, audit follow-ups, deferred work |
+| `docs/baselines/perf-baseline-channeltraits-chaos.md` | Latest chaos baseline + comparison vs T3 |
+| `docs/CODE_GOVERNANCE.md` Part 1 | 5-question gate before architectural proposals |
+| `docs/CODING_RULES/11-hook-system-rules.md` | Rule #11 (1 ms budget, contention law) |
+| `docs/plans/sprint-1-single-owner-refactor.md` D6 | RCU pattern reference (Pre-T3 Minor 2 used it) |
+| `tools/run-chaos.ps1` + `tools/README.md` | Chaos harness — for verifying every future hook-engine change |
+
+### Memory (auto-loaded each session)
+
+Already-captured rules that future-em should follow without re-deriving:
+- `feedback_no_coauthor` — no `Co-Authored-By` in commits
+- `feedback_review_discipline` — review = report only, never auto-fix
+- `feedback_vietnamese_response` — reason in English, respond in Vietnamese
+- `feedback_role_split` — anh verifies feature/UI/test results; em decides architecture, codes, runs tests
+- `project_test_first` — failing test before implementation; concurrency bugs only caught by tests
+- `project_three_questions` — right place / impact / better way before code
+- `project_core_philosophy` — Nhanh / Nhẹ / Mượt / Mở rộng-không-ảnh-hưởng-perf
+
+---
+
 ## TL;DR
 
 NexusKey's hook engine has long-standing race-condition bugs (x2 space, ghost

--- a/docs/baselines/perf-d1-chrome.csv
+++ b/docs/baselines/perf-d1-chrome.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,594,5,15,16,16,16,16
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,636,8,15,16,17,17,17
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,562,3,15,16,16,16,16
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,531,9,3,3,7,7,7
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,561,13,2,2,3,3,3
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,562,11,2,2,4,4,4
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,530,7,2,1,11,11,11
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,594,4,12,16,17,17,17
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,608,5,15,16,16,16,16
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,560,14,2,2,4,4,4
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,753,13,16,16,32,32,32

--- a/docs/baselines/perf-d1-notepadpp.csv
+++ b/docs/baselines/perf-d1-notepadpp.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,620,5,18,16,30,30,30
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,655,8,15,16,16,16,16
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,591,3,15,15,16,16,16
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,563,9,2,2,9,9,9
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,557,13,2,2,9,9,9
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,545,11,2,2,4,4,4
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,532,7,3,2,13,13,13
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,593,4,11,16,16,16,16
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,620,5,15,16,16,16,16
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,561,14,2,2,5,5,5
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,750,13,16,16,31,31,31

--- a/docs/baselines/perf-d2-chrome.csv
+++ b/docs/baselines/perf-d2-chrome.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,607,5,15,15,16,16,16
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,652,8,15,16,16,16,16
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,548,3,15,16,16,16,16
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,537,9,2,2,3,3,3
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,544,13,2,2,4,4,4
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,545,11,2,2,4,4,4
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,546,7,2,2,6,6,6
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,576,4,11,15,16,16,16
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,620,5,15,16,16,16,16
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,562,14,2,3,4,4,4
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,747,13,15,16,16,16,16

--- a/docs/baselines/perf-d2-notepad-fixed.csv
+++ b/docs/baselines/perf-d2-notepad-fixed.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,566,5,13,14,15,15,15
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,560,8,9,10,11,11,11
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,511,3,10,10,12,12,12
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,528,9,4,4,8,8,8
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,546,13,4,4,7,7,7
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,534,11,4,5,7,7,7
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,514,7,4,4,7,7,7
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,510,4,7,9,11,11,11
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,524,5,8,8,11,11,11
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,573,14,5,5,8,8,8
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,596,13,8,8,10,10,10

--- a/docs/baselines/perf-d2-notepad.csv
+++ b/docs/baselines/perf-d2-notepad.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,549,5,13,13,15,15,15
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,545,8,7,7,13,13,13
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,511,3,8,8,9,9,9
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,522,9,4,4,6,6,6
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,530,13,3,3,9,9,9
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,521,11,3,4,7,7,7
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,525,7,4,3,15,15,15
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,503,4,6,8,9,9,9
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,522,5,7,8,10,10,10
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,537,14,3,4,8,8,8
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,590,13,8,7,16,16,16

--- a/docs/baselines/perf-d2-notepadpp.csv
+++ b/docs/baselines/perf-d2-notepadpp.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,612,5,15,16,16,16,16
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,654,8,15,16,16,16,16
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,573,3,15,16,16,16,16
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,565,9,2,2,7,7,7
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,572,13,2,2,4,4,4
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,562,11,2,2,6,6,6
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,546,7,3,2,10,10,10
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,574,4,12,16,16,16,16
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,607,5,15,16,16,16,16
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,564,14,2,3,7,7,7
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,736,13,15,16,16,16,16

--- a/docs/baselines/perf-d3-discord.csv
+++ b/docs/baselines/perf-d3-discord.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,547,5,13,12,20,20,20
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,547,8,8,7,18,18,18
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,510,3,10,8,15,15,15
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,527,9,5,3,14,14,14
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,557,13,4,3,15,15,15
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,540,11,5,4,14,14,14
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,536,7,6,2,27,27,27
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,524,4,5,7,9,9,9
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,540,5,8,7,17,17,17
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,552,14,4,3,13,13,13
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,613,13,9,7,26,26,26

--- a/docs/baselines/perf-d3-gpt.csv
+++ b/docs/baselines/perf-d3-gpt.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,588,5,15,15,16,16,16
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,654,8,15,16,16,16,16
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,564,3,15,15,16,16,16
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,560,9,3,2,10,10,10
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,576,13,3,3,10,10,10
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,558,11,3,2,7,7,7
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,560,7,3,2,11,11,11
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,575,4,11,16,16,16,16
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,609,5,15,16,17,17,17
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,606,14,3,4,7,7,7
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,775,13,17,16,31,31,31

--- a/docs/baselines/perf-d3-notepad.csv
+++ b/docs/baselines/perf-d3-notepad.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,555,5,14,14,16,16,16
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,559,8,9,10,11,11,11
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,518,3,10,10,12,12,12
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,539,9,5,5,11,11,11
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,542,13,4,4,7,7,7
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,543,11,5,5,8,8,8
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,519,7,5,5,7,7,7
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,514,4,7,10,10,10,10
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,528,5,9,9,12,12,12
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,570,14,5,5,10,10,10
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,599,13,8,9,11,11,11

--- a/docs/baselines/perf-d3-notepadpp.csv
+++ b/docs/baselines/perf-d3-notepadpp.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,640,5,19,16,32,32,32
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,641,8,15,16,16,16,16
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,560,3,15,16,16,16,16
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,545,9,3,2,6,6,6
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,574,13,2,2,7,7,7
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,562,11,2,2,4,4,4
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,574,7,3,2,12,12,12
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,593,4,11,16,16,16,16
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,625,5,15,16,16,16,16
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,566,14,2,3,6,6,6
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,750,13,16,16,32,32,32

--- a/docs/baselines/perf-d4-notepad.csv
+++ b/docs/baselines/perf-d4-notepad.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,560,5,14,14,16,16,16
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,562,8,9,10,11,11,11
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,514,3,9,10,10,10,10
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,531,9,5,6,7,7,7
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,552,13,5,5,8,8,8
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,537,11,5,5,7,7,7
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,526,7,4,5,8,8,8
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,510,4,6,9,9,9,9
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,526,5,8,8,11,11,11
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,574,14,5,6,8,8,8
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,590,13,8,8,11,11,11

--- a/docs/baselines/perf-d4-notepadpp.csv
+++ b/docs/baselines/perf-d4-notepadpp.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,591,5,15,16,16,16,16
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,640,8,15,16,16,16,16
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,576,3,15,15,16,16,16
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,581,9,2,2,5,5,5
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,573,13,2,2,4,4,4
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,545,11,2,2,5,5,5
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,546,7,3,2,11,11,11
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,575,4,11,15,16,16,16
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,610,5,15,16,17,17,17
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,576,14,2,2,6,6,6
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,752,13,15,16,16,16,16

--- a/docs/baselines/perf-d5-chrome.csv
+++ b/docs/baselines/perf-d5-chrome.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,607,5,15,16,16,16,16
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,644,8,15,16,17,17,17
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,560,3,15,16,16,16,16
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,532,9,2,2,4,4,4
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,561,13,2,2,6,6,6
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,547,11,2,2,5,5,5
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,546,7,2,1,8,8,8
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,578,4,11,15,16,16,16
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,608,5,15,16,16,16,16
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,562,14,2,2,6,6,6
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,717,13,15,16,16,16,16

--- a/docs/baselines/perf-d5-discord.csv
+++ b/docs/baselines/perf-d5-discord.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,540,5,13,12,20,20,20
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,548,8,8,7,20,20,20
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,504,3,10,7,16,16,16
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,530,9,5,3,14,14,14
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,551,13,4,4,19,19,19
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,540,11,5,5,13,13,13
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,531,7,6,3,26,26,26
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,507,4,5,6,10,10,10
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,535,5,9,7,18,18,18
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,562,14,5,4,14,14,14
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,614,13,9,8,22,22,22

--- a/docs/baselines/perf-d5-gpt.csv
+++ b/docs/baselines/perf-d5-gpt.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,593,5,15,16,16,16,16
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,639,8,15,16,16,16,16
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,560,3,15,16,16,16,16
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,544,9,3,3,7,7,7
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,577,13,3,3,10,10,10
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,561,11,3,3,8,8,8
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,558,7,3,2,15,15,15
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,574,4,11,15,16,16,16
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,608,5,15,16,16,16,16
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,592,14,4,4,8,8,8
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,749,13,17,16,33,33,33

--- a/docs/baselines/perf-d5-notepad.csv
+++ b/docs/baselines/perf-d5-notepad.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,558,5,14,15,17,17,17
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,561,8,9,10,11,11,11
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,514,3,9,10,11,11,11
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,542,9,5,5,9,9,9
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,558,13,5,5,7,7,7
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,547,11,5,5,9,9,9
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,526,7,4,4,8,8,8
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,513,4,7,9,11,11,11
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,536,5,9,9,11,11,11
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,573,14,6,7,10,10,10
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,603,13,8,9,10,10,10

--- a/docs/baselines/perf-d5-notepadpp.csv
+++ b/docs/baselines/perf-d5-notepadpp.csv
@@ -1,0 +1,12 @@
+case_name,verdict,verdict_mode,error_chars,error_pct,inter_key_us_config,wall_clock_ms,l1_count,l1_mean_ms,l1_p50_ms,l1_p95_ms,l1_p99_ms,l1_max_ms
+1.1-ghost-hoaf-bs-t,PASS,exact,0,0.00,10000,607,5,15,16,17,17,17
+1.2-tone-ghost-toans-bs3-i,PASS,exact,0,0.00,5000,654,8,15,16,16,16,16
+1.3-escape-bs-aa-b,PASS,exact,0,0.00,5000,576,3,15,15,16,16,16
+2.1-x2-space-vieejt-nam,PASS,exact,0,0.00,1000,559,9,3,3,8,8,8
+2.2-word-boundary-xin-chao-ban,PASS,exact,0,0.00,1000,578,13,2,2,4,4,4
+2.3-en-vn-transition-hello-vieejt,PASS,exact,0,0.00,1000,575,11,3,3,8,8,8
+3.3-engine-stress-truongf,PASS,exact,0,0.00,500,576,7,3,2,9,9,9
+5.1-case-tracking-Giar,PASS,exact,0,0.00,5000,592,4,11,15,17,17,17
+5.2-vowel-start-uongs,PASS,exact,0,0.00,5000,605,5,15,16,16,16,16
+5.3-cross-word-bs-vieejt-nam-bs4-s,PASS,exact,0,0.00,1000,559,14,2,3,7,7,7
+6.1-autocap-binh-thuongf,PASS,exact,0,0.00,5000,763,13,16,16,31,31,31

--- a/docs/baselines/report-d1-chrome.xml
+++ b/docs/baselines/report-d1-chrome.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.491">
+  <testsuite name="chaos" tests="11" failures="0" time="6.491">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.594"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.636"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.562"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.531"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.561"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.562"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.530"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.594"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.608"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.560"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.753"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d1-notepadpp.xml
+++ b/docs/baselines/report-d1-notepadpp.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.589">
+  <testsuite name="chaos" tests="11" failures="0" time="6.589">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.620"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.655"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.591"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.563"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.557"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.545"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.532"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.593"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.620"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.561"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.750"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d2-chrome.xml
+++ b/docs/baselines/report-d2-chrome.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.486">
+  <testsuite name="chaos" tests="11" failures="0" time="6.486">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.607"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.652"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.548"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.537"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.544"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.545"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.546"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.576"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.620"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.562"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.747"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d2-notepad-fixed.xml
+++ b/docs/baselines/report-d2-notepad-fixed.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="5.963">
+  <testsuite name="chaos" tests="11" failures="0" time="5.963">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.566"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.560"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.511"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.528"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.546"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.534"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.514"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.510"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.524"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.573"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.596"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d2-notepad.xml
+++ b/docs/baselines/report-d2-notepad.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="5.855">
+  <testsuite name="chaos" tests="11" failures="0" time="5.855">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.549"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.545"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.511"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.522"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.530"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.521"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.525"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.503"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.522"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.537"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.590"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d2-notepadpp.xml
+++ b/docs/baselines/report-d2-notepadpp.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.567">
+  <testsuite name="chaos" tests="11" failures="0" time="6.567">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.612"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.654"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.573"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.565"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.572"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.562"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.546"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.574"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.607"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.564"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.736"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d3-discord.xml
+++ b/docs/baselines/report-d3-discord.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="5.995">
+  <testsuite name="chaos" tests="11" failures="0" time="5.995">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.547"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.547"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.510"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.527"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.557"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.540"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.536"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.524"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.540"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.552"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.613"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d3-gpt.xml
+++ b/docs/baselines/report-d3-gpt.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.628">
+  <testsuite name="chaos" tests="11" failures="0" time="6.628">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.588"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.654"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.564"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.560"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.576"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.558"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.560"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.575"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.609"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.606"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.775"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d3-notepad.xml
+++ b/docs/baselines/report-d3-notepad.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="5.986">
+  <testsuite name="chaos" tests="11" failures="0" time="5.986">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.555"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.559"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.518"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.539"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.542"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.543"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.519"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.514"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.528"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.570"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.599"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d3-notepadpp.xml
+++ b/docs/baselines/report-d3-notepadpp.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.630">
+  <testsuite name="chaos" tests="11" failures="0" time="6.630">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.640"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.641"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.560"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.545"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.574"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.562"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.574"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.593"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.625"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.566"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.750"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d4-notepad.xml
+++ b/docs/baselines/report-d4-notepad.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="5.983">
+  <testsuite name="chaos" tests="11" failures="0" time="5.983">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.560"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.562"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.514"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.531"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.552"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.537"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.526"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.510"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.526"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.574"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.590"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d4-notepadpp.xml
+++ b/docs/baselines/report-d4-notepadpp.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.568">
+  <testsuite name="chaos" tests="11" failures="0" time="6.568">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.591"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.640"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.576"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.581"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.573"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.545"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.546"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.575"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.610"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.576"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.752"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d5-chrome.xml
+++ b/docs/baselines/report-d5-chrome.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.462">
+  <testsuite name="chaos" tests="11" failures="0" time="6.462">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.607"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.644"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.560"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.532"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.561"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.547"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.546"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.578"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.608"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.562"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.717"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d5-discord.xml
+++ b/docs/baselines/report-d5-discord.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="5.962">
+  <testsuite name="chaos" tests="11" failures="0" time="5.962">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.540"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.548"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.504"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.530"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.551"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.540"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.531"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.507"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.535"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.562"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.614"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d5-gpt.xml
+++ b/docs/baselines/report-d5-gpt.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.556">
+  <testsuite name="chaos" tests="11" failures="0" time="6.556">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.593"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.639"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.560"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.544"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.577"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.561"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.558"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.574"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.608"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.592"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.749"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d5-notepad.xml
+++ b/docs/baselines/report-d5-notepad.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.032">
+  <testsuite name="chaos" tests="11" failures="0" time="6.032">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.558"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.561"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.514"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.542"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.558"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.547"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.526"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.513"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.536"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.573"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.603"/>
+  </testsuite>
+</testsuites>

--- a/docs/baselines/report-d5-notepadpp.xml
+++ b/docs/baselines/report-d5-notepadpp.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="NextKeyTestRunner" tests="11" failures="0" time="6.646">
+  <testsuite name="chaos" tests="11" failures="0" time="6.646">
+    <testcase name="1.1-ghost-hoaf-bs-t" classname="chaos" time="0.607"/>
+    <testcase name="1.2-tone-ghost-toans-bs3-i" classname="chaos" time="0.654"/>
+    <testcase name="1.3-escape-bs-aa-b" classname="chaos" time="0.576"/>
+    <testcase name="2.1-x2-space-vieejt-nam" classname="chaos" time="0.559"/>
+    <testcase name="2.2-word-boundary-xin-chao-ban" classname="chaos" time="0.578"/>
+    <testcase name="2.3-en-vn-transition-hello-vieejt" classname="chaos" time="0.575"/>
+    <testcase name="3.3-engine-stress-truongf" classname="chaos" time="0.576"/>
+    <testcase name="5.1-case-tracking-Giar" classname="chaos" time="0.592"/>
+    <testcase name="5.2-vowel-start-uongs" classname="chaos" time="0.605"/>
+    <testcase name="5.3-cross-word-bs-vieejt-nam-bs4-s" classname="chaos" time="0.559"/>
+    <testcase name="6.1-autocap-binh-thuongf" classname="chaos" time="0.763"/>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
## Summary

Two unrelated but session-end-natural changes bundled together:

### 1. Repo root cleanup

After today's 7-PR session (#122-128), 44 stray chaos artefacts had accumulated in repo root over the course of Sprint 2 D1-D5. This PR:

- **Moves 30 D1-D5 sprint-2 artefacts** (\`perf-d{1-5}-*.csv\`, \`report-d{1-5}-*.xml\`) into \`docs/baselines/\`. \`perf-baseline-t3-final.md\` already names them as "Companion files in this directory" -- they belong there. \`docs/baselines/\` is now the canonical location for chaos-capture artefacts across T3, ChannelTraits, and the D-day predecessors.
- **Deletes 13 trial files**: 5 untagged \`perf-{host}.csv\` + 5 untagged \`report-{host}.xml\` (no doc references them, ad-hoc pre-D1 captures) + 3 \`*-harness-smoke-notepad.*\` files (verification already preserved in PR #128's smoke companions inside \`docs/baselines/\`).

### 2. Handoff note

\`HANDOFF.md\` prepended with a \`Post-T3 status (2026-05-05 PM)\` section so next-session pickup is one read away. Covers:

- 7 PRs landed today with one-liner each.
- Verified gates (Linux 1409/1409, audit 5/5, chaos 55/55).
- Worst-case p99 comparison vs T3 baseline.
- Pending items in priority order (Pre-T3 Minor 1 / M3 / cafcs typing bug / M2 naming).
- Cleanup record so the repo-root tidy isn't surprising next session.
- Key references + auto-loaded memory rules.

The original Sprint 1 D12 TL;DR is preserved below the new section -- still relevant historical context, just no longer the most-recent state.

## Test plan

No code changed. Smoke check: \`tools/audit/check_hook_thread_no_mutex.sh\` should still PASS 5/5 (it doesn't touch the moved files).