### PR TITLE
design: FSM engine refactor (Sprint 3) + implementation plan

### DIFF
--- a/docs/plans/2026-05-05-fsm-engine-refactor-design.md
+++ b/docs/plans/2026-05-05-fsm-engine-refactor-design.md
@@ -1,0 +1,642 @@
+# FSM Engine Core Refactor — Design
+
+> **Branch:** `design/fsm-engine-refactor` (this branch — design doc only)
+> **Implementation branch:** `sprint-3/fsm-engine` (to be created at D0)
+> **Foundation:** [`docs/PHILOSOPHY.md`](../PHILOSOPHY.md) · [`docs/CODE_GOVERNANCE.md`](../CODE_GOVERNANCE.md) §1 (FSM core) + §4 (plugin layer) · [`docs/CODING_RULES/11-hook-system-rules.md`](../CODING_RULES/11-hook-system-rules.md) · [`docs/RuleTiengViet_Summary.md`](../RuleTiengViet_Summary.md)
+> **Predecessor:** Sprint 1 (single-owner hook) + Sprint 2 T3 (IOutputInjector) — both shipped on Main.
+> **Baseline before FSM-1:** chaos 55/55 PASS on Main, GTest 1409/1409 PASS Linux. FSM-1 must preserve.
+> **Status:** Design (brainstormed 2026-05-05). Ready for plan-doc → implementation.
+
+---
+
+## 0. CODE_GOVERNANCE — 5-Question Pre-Code Gate
+
+### Q1 — Layer Check
+
+FSM lives in `src/core/engine/` (replaces `TypingEngine.cpp` + `SpellChecker.cpp`). Three sub-layers:
+
+```
+[Hook callback] → [Input Mapping]    → [FSM Core]      → [Plugin Bus] → [IOutputInjector]
+                       ↑                    ↑                ↑
+                  src/core/engine/     src/core/engine/  src/core/engine/
+                  InputMapping.{h,cpp} FsmDispatcher    FsmPluginBus
+                                       FsmTable (data)   IFsmPlugin
+```
+
+Hook callback layer (`src/app/system/HookEngine.cpp`) is unchanged in topology — it now calls `FsmDispatcher::Process(rawKey)` instead of `TypingEngine::ProcessChar`. Output dispatch via `IOutputInjector` (Sprint 2 T3) preserved.
+
+CODE_GOVERNANCE §1 (FSM core) + §4 (plugin extension) realized; §2 (output) already shipped Sprint 2; §3 (SPSC) remains roadmap (Sprint 4).
+
+### Q2 — Performance Impact
+
+Hot-path cost per keystroke after FSM-1:
+
+| Step | Cost |
+|---|---|
+| `std::atomic_load(&activeKeymap_)` (RCU shared_ptr) | ~10 ns |
+| `keymap[rawKey]` → abstract input | ~1 ns (array lookup) |
+| `std::atomic_load(&fsmTable_)` | ~10 ns |
+| `table[state][input]` → (nextState, action) | ~5 ns (table cell, cache-line) |
+| Plugin chain (1 plugin: SyllableValidator strict mode) | ~50 ns (1 hash lookup) |
+| Action emit via `injector_->Replace(...)` | ~11 ns (Sprint 2 baseline) |
+| **Total per key** | **≈ 87 ns** |
+
+Current `TypingEngine::ProcessChar` measured ~36-106 µs (per `docs/plans/hot-path-optimization-plan.md`). FSM expected **~3 orders of magnitude faster**. Real benefit: deterministic O(1) lookup vs scan-back loop variability.
+
+Hook 1 ms budget (Rule #11.1) preserved with vast headroom.
+
+### Q3 — Native Alternative
+
+| Alternative considered | Rejected because |
+|---|---|
+| Keep `TypingEngine.cpp` if/else; minor cleanups | 1,603 LOC with 9 spell-check branches; bug `cafcs → các` traceable to scan-back complexity. Future extensions (VNI, Telex+VNI combined, user-custom keymap from issue #111) compound complexity super-linearly. |
+| Hand-write FSM 2D table | Vietnamese phonotactics (20,504 valid syllables per `RuleTiengViet_Summary.md`) too large to hand-encode without errors. Maintenance impossible — 1 rule edit = re-trace many cells. |
+| FSM hybrid (table for simple cases + scan-back for modifier rules) | Splits source-of-truth across two implementations; same maintainability problem in smaller form. |
+| **FSM with codegen tool (CHOSEN)** | Single source-of-truth = rule files; tool generates table; exhaustive verify proves coverage. Codegen tool itself reusable for future languages (Lao/Khmer extension D). |
+
+### Q4 — No-Lock / No-Exception Rule
+
+FSM hot path:
+- **Lock-free**: 2 atomic_load (RCU activeKeymap_, fsmTable_, injector_), 1 array lookup, optional plugin chain. No mutex.
+- **No exception**: all paths `noexcept`. Action emit may fail (injector returns false) → handled via Verdict::ROLLBACK in plugin chain.
+- **Bounded work**: O(1) per key (table cell + bounded plugin chain).
+
+Cold path (focus change, config change, plugin register/unregister): can lock; runs on `MainThreadWorker` from Sprint 1 D8-D10.
+
+### Q5 — Trade-Off Disclosure
+
+| Trade-off | Cost | Benefit |
+|---|---|---|
+| Codegen tool engineering (~1 week dev) | New tool, Python dependency at build time. Generated `.h` committed so headless build works. | Single source-of-truth, exhaustive verification, future-proofing for new languages/methods. |
+| 50-80 KB resident memory for FSM tables | +0.05% NexusKey RSS. | O(1) lookup vs scan-back loop. |
+| Plugin event bus indirection | 1 vtable jump per registered plugin per event. | Clean extension; macro/auto-cap/CJK/spell-check all unify under one contract. |
+| Migration via parallel-run diff harness | Test corpus must contain reference outputs (provided by `vietnamese_telex_pairs.txt` from gonhanh.org, BSD-3, 30,337 pairs). | High-confidence cut-over without user-visible regression. |
+
+---
+
+## 1. Locked Decisions (Brainstorm 2026-05-05)
+
+This section records 8 decisions locked in conversation with anh. Each affects scope; revisit only if new evidence contradicts.
+
+| # | Decision | Rationale |
+|---|---|---|
+| **1** | **Migration style: incremental D-day** (B). One commit per D, chaos PASS gate per commit. Bisect-friendly. | Same pattern Sprint 1 + Sprint 2 used; shipped 55/55 chaos. |
+| **2** | **Sprint scope: FSM core + Telex/VNI/Combined preset built-in + plugin event bus contract.** Macro/auto-cap/CJK plugin migration deferred to FSM-2 sprint. UI custom keymap (issue #111) deferred. | Engine refactor + UI form are different disciplines. Bundling violates Q5. |
+| **3** | **Spell-check is a plugin** (`SyllableValidatorPlugin`). Toggle "Gõ tự do" = plugin off. | Aligns with anh's mental model: "core minimal, everything else plugin". Macro/auto-cap/CJK same pattern (sprint sau). |
+| **4** | **Shorthand `cc→ch` is a plugin**, not FSM core. | Shorthand is optional gõ-tắt feature, not part of orthographic transition. Plug via `OnPattern` event. |
+| **5** | **Spell-check has 2 modes**: strict (dictionary lookup ~6711 từ) vs free (orthography only, FSM by construction). Plugin enabled/disabled toggles. | User clarified: strict = check dictionary, free = no check beyond orthography. |
+| **6** | **FSM 2D table via codegen tool** (option A from brainstorm). NFA → DFA → minimize → emit constexpr. | Pure FSM realizes governance §1 fully. Codegen tool reusable for new languages. |
+| **7** | **Dictionary source: `vi.dic` from gonhanh.org** (BSD-3, 6711 từ). | License-compatible with NexusKey GPL-3. Skip PHTV (AGPL conflict) and xkey (Swift parse). |
+| **8** | **Diff verification corpus: `vietnamese_telex_pairs.txt` from gonhanh.org** (BSD-3, 30,337 pairs). | 20× current `TelexEngineTest.cpp` (1409 cases). Production-grade Telex test corpus. |
+
+### What's NOT in scope this sprint
+
+- Macro plugin migration (lives in HookEngine cũ, plug bus chừa hook point)
+- Auto-cap plugin migration (same)
+- CJK detection plugin migration (same)
+- Issue #111 UI custom keymap form
+- Pass-through plugin (§4 governance fallback)
+- New language tables (Lao/Khmer)
+- Bug `cafcs → các` separate fix (will resolve naturally via codegen rule + diff harness)
+
+---
+
+## 2. Architecture
+
+### 2.1 Layer diagram (full data flow)
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ HOOK CALLBACK (LowLevelKeyboardProc) — 1 ms budget, lock-free         │
+│                                                                        │
+│  rawKey ─► InputMapping ─► FsmDispatcher ─► PluginBus ─► Injector     │
+│              │                  │              │            │          │
+│              ▼                  ▼              ▼            ▼          │
+│          activeKeymap_      activeFsmTable_  registered   activeInj_   │
+│         (atomic_load)      (atomic_load)    plugins[]   (atomic_load) │
+│                                                                        │
+│          + HistoryRingBuffer<Record, 256>  ◄─ write per transition     │
+│          + CommitUndoSM                    ◄─ tracks Idle/Primed/Ready │
+└──────────────────────────────────────────────────────────────────────┘
+                                     │
+                                     ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ COLD PATH (MainThreadWorker, WinEventProc) — can lock                 │
+│                                                                        │
+│  - InputMethodRegistry: publish activeKeymap_ on config change        │
+│  - FsmTableRegistry: publish activeFsmTable_ on language change       │
+│  - FocusTracker: publish activeInjector_ on EVENT_OBJECT_FOCUS         │
+│  - PluginRegistry: register/unregister IFsmPlugin instances           │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Components on hook (must, lock-free)
+
+| Component | Responsibility | Memory |
+|---|---|---|
+| `InputMapping` | rawKey → AbstractInput. RCU `shared_ptr<KeymapTable>`. | ~250-400 byte per keymap; 4 keymaps total |
+| `FsmDispatcher` | `(state, abstractInput) → (nextState, Action)`. RCU `shared_ptr<FsmTable>`. | 50-80 KB per table |
+| `HistoryRingBuffer<Record, 256>` | Last 256 transitions for BS rewind. SPSC same-thread, no lock. | 256 × ~16 byte = 4 KB |
+| `CommitUndoSM` | Idle/Primed/Ready state machine for "BS revoke commit" semantics. | Trivial, ~16 byte |
+| `FsmPluginBus::Dispatch` | Iterate registered plugins, call event method, collect Verdict. | Trivial |
+
+### 2.3 Components off hook (cold path, can lock)
+
+| Component | Trigger | Where |
+|---|---|---|
+| `InputMethodRegistry::Publish` | User changes "Kiểu gõ" in Settings | UI → `MainThreadWorker.Signal()` → atomic_store |
+| `FsmTableRegistry::Publish` | Language change (future) | Same path |
+| `FocusTracker` | `SetWinEventHook` → EVENT_OBJECT_FOCUS | Already exists Sprint 1 D9; reuse |
+| `IFsmPlugin::Register/Unregister` | App startup, config toggle | `MainThreadWorker.Post` with copy-publish-swap |
+
+---
+
+## 3. FSM Core Specification
+
+### 3.1 State
+
+State is an opaque `uint16_t` ID assigned by codegen tool after DFA minimization.
+
+Conceptually each state encodes a partial-syllable pattern:
+- consonant initial position state
+- vowel sequence state (1/2/3 vowels seen, which ones)
+- final consonant state (none / C1 / C2 / C3)
+- tone applied state (none / sắc / huyền / hỏi / ngã / nặng)
+- modifier applied state (none / circumflex / breve / horn / d-bar)
+- escape pending flag (after `aaa → aa` literal)
+
+Codegen produces ~500-2000 minimized states.
+
+### 3.2 Abstract input
+
+Finite enum used for FSM table indexing (~32 values):
+
+```cpp
+enum class AbstractInput : uint16_t {
+    // Tone keys (mapped from raw via active keymap)
+    TONE_SAC, TONE_HUYEN, TONE_HOI, TONE_NGA, TONE_NANG,
+
+    // Modifier keys
+    MOD_CIRCUMFLEX,    // Telex: aa/oo/ee, VNI: 6
+    MOD_BREVE,         // Telex: aw, VNI: 8
+    MOD_HORN,          // Telex: w/uw/ow, VNI: 7
+    MOD_D_BAR,         // Telex: dd, VNI: 9
+
+    // Literal vowel/consonant inserts
+    INSERT_LITERAL_a, INSERT_LITERAL_b, ..., INSERT_LITERAL_z,
+
+    // Special
+    SYLLABLE_BOUNDARY, // space, punct, Enter
+    BACKSPACE,
+    PASSTHROUGH        // raw key, FSM emits as-is
+};
+```
+
+### 3.3 Action
+
+Output emitted to `IOutputInjector`:
+
+```cpp
+struct Action {
+    enum Kind : uint8_t { NOOP, INSERT_CHAR, REPLACE_LAST, PASS_THROUGH, RESET };
+    Kind kind;
+    uint8_t bsCount;      // for REPLACE_LAST
+    wchar_t replacement[6]; // small-string-optimized; max Vietnamese syllable ~7
+};
+```
+
+Action dispatch:
+- `NOOP` → no-op (FSM in escape buffer, no output yet)
+- `INSERT_CHAR(c)` → `injector.Replace(0, &c)` (1 char insert)
+- `REPLACE_LAST(N, text)` → `injector.Replace(N, text)`
+- `PASS_THROUGH` → return CallNextHookEx (do not eat key)
+- `RESET` → clear FSM state, history, commit-undo SM
+
+### 3.4 FsmTable layout
+
+```cpp
+struct FsmCell {
+    uint16_t nextState;
+    uint16_t actionId;   // index into ActionTable
+};
+
+struct FsmTable {
+    static constexpr size_t kStateCount  = N;   // codegen output
+    static constexpr size_t kInputCount  = 32;
+    FsmCell cells[kStateCount][kInputCount];
+    Action  actions[kActionCount];
+};
+```
+
+Sparse encoding fallback if dense > 100 KB:
+```cpp
+struct FsmTransition { uint16_t state; uint16_t input; uint16_t nextState; uint16_t actionId; };
+struct FsmTableSparse { FsmTransition transitions[N]; /* sorted, binary search */ };
+```
+
+Codegen picks dense vs sparse based on size threshold.
+
+### 3.5 InputMapping (keymap)
+
+```cpp
+struct Keymap {
+    static constexpr size_t kRawKeyMax = 256;  // ASCII range covers all telex/VNI
+    AbstractInput map[kRawKeyMax];              // PASSTHROUGH default
+};
+```
+
+Compile-time generated from `rules/telex-keymap.toml` etc:
+
+```toml
+# rules/telex-keymap.toml
+[mappings]
+"s" = "TONE_SAC"
+"f" = "TONE_HUYEN"
+"r" = "TONE_HOI"
+"x" = "TONE_NGA"
+"j" = "TONE_NANG"
+"w" = "MOD_HORN"
+
+# 2-char sequences: handled by FSM state, not keymap.
+# (e.g., 'aa' triggers MOD_CIRCUMFLEX via state 'after-a' + input 'INSERT_LITERAL_a')
+```
+
+VNI keymap:
+```toml
+"1" = "TONE_SAC"
+"2" = "TONE_HUYEN"
+"3" = "TONE_HOI"
+"4" = "TONE_NGA"
+"5" = "TONE_NANG"
+"6" = "MOD_CIRCUMFLEX"
+"7" = "MOD_HORN"
+"8" = "MOD_BREVE"
+"9" = "MOD_D_BAR"
+```
+
+Combined keymap = union (Telex letters + VNI digits, disjoint, no conflict).
+
+---
+
+## 4. HistoryRingBuffer + Commit-undo SM + Plugin Event Bus
+
+### 4.1 HistoryRingBuffer<Record, 256>
+
+```cpp
+struct Record {
+    wchar_t       rawKey;          // raw input (e.g., 'f')
+    AbstractInput abstractInput;   // mapped (e.g., TONE_HUYEN)
+    uint16_t      preState;        // FSM state before transition
+    uint16_t      postState;       // FSM state after
+    Action        action;          // Action emitted
+};
+
+class HistoryRingBuffer {
+public:
+    void Push(Record r) noexcept;      // O(1)
+    bool PopLast(Record& out) noexcept; // O(1) — for BS within syllable
+    bool RewindToPrevSyllable(uint16_t& restoredState, std::vector<Record>& popped) noexcept;
+};
+```
+
+**Backspace handling in FsmDispatcher:**
+
+```
+BACKSPACE received:
+   if currentState == EMPTY (no syllable in progress):
+       if history.HasPrevSyllable():
+           // Cross-syllable BS — revive previous syllable
+           history.RewindToPrevSyllable() → restoredState, popped[]
+           setState(restoredState)
+           injector.Replace(popped.totalChars, "")  // erase previous syllable text
+           // Now user can type tone/modifier to fix word
+           return EATEN
+       else:
+           // Nothing to rewind; let BS pass through
+           return PASSTHROUGH
+   else:
+       // BS within current syllable
+       history.PopLast() → record
+       setState(record.preState)
+       injector.Replace(record.action.replacement.size(), "")
+       return EATEN
+```
+
+256 records ≈ 40 từ Việt trung bình. Beyond that, BS passes through (OS handles raw delete).
+
+### 4.2 CommitUndoSM
+
+3 states retained from current HookEngine:
+
+```cpp
+enum class CommitState { Idle, Primed, Ready };
+
+class CommitUndoSM {
+    CommitState state_ = Idle;
+public:
+    void OnSyllableBoundary() noexcept;  // space/punct/Enter → Primed
+    void OnBackspace() noexcept;          // Primed → Ready (revoke commit)
+    void OnNonBsInput() noexcept;         // Primed → Idle (commit sealed)
+};
+```
+
+Lives in core (always-on, not plugin) because it's tied to FSM transitions (every input checks).
+
+### 4.3 Plugin Event Bus
+
+```cpp
+enum class Verdict : uint8_t { PASS, VETO, ROLLBACK, CONSUME };
+
+class IFsmPlugin {
+public:
+    virtual ~IFsmPlugin() = default;
+    virtual const char* Name() const noexcept = 0;
+
+    // Pre-transition hooks
+    virtual Verdict BeforeInput(wchar_t rawKey)                                    { return Verdict::PASS; }
+    virtual Verdict BeforeTransition(uint16_t state, AbstractInput input)          { return Verdict::PASS; }
+
+    // Post-transition observers
+    virtual void    AfterTransition(uint16_t prev, AbstractInput in,
+                                    uint16_t next, const Action& a)                {}
+
+    // Result-validity gate (spell-check uses this)
+    virtual Verdict OnPostAction(const Action& action,
+                                  std::wstring_view resultBuf)                      { return Verdict::PASS; }
+
+    // Word/syllable boundary observers (macro/auto-cap)
+    virtual void    OnWordBoundary(std::wstring_view committedWord)                {}
+    virtual void    OnCommit(std::wstring_view syllable)                           {}
+
+    // Edge cases
+    virtual void    OnInvalidTransition(uint16_t state, AbstractInput input)       {}
+    virtual void    OnFocusChange(HWND hwnd)                                       {}
+
+    // Lifecycle
+    virtual void    OnRegister()                                                    {}
+    virtual void    OnUnregister()                                                  {}
+};
+```
+
+**Verdict semantics:**
+- `PASS`: continue normally
+- `VETO`: transition not applied; FSM emits PASSTHROUGH instead
+- `ROLLBACK`: transition applied then reverted (undo via injector + history.PopLast)
+- `CONSUME`: skip remaining plugins for this event
+
+**Plugin registration order matters** (first-registered runs first). Sprint FSM-1 only registers `SyllableValidatorPlugin`. Future plugins:
+
+| Plugin (sprint sau) | Hook |
+|---|---|
+| `MacroExpansionPlugin` | `OnWordBoundary` |
+| `AutoCapitalizationPlugin` | `OnCommit` + `OnPostAction` |
+| `CjkDetectionPlugin` | `OnFocusChange` |
+| `ShorthandPlugin` (cc→ch) | `BeforeTransition` |
+| `EnglishProtectionPlugin` (#issue protect) | `OnPostAction` |
+| `PassThroughFallbackPlugin` (governance §4) | `OnInvalidTransition` |
+
+### 4.4 SyllableValidatorPlugin (in scope FSM-1)
+
+```cpp
+class SyllableValidatorPlugin final : public IFsmPlugin {
+    bool                    enabled_ = true;       // toggle "Gõ tự do" = false
+    std::unordered_set<std::wstring> dict_;        // ~6711 từ from vi.dic
+    std::unordered_set<std::wstring> userException_; // user whitelist for #111
+
+public:
+    Verdict OnPostAction(const Action& a, std::wstring_view buf) override {
+        if (!enabled_) return Verdict::PASS;                  // free typing
+        if (userException_.count(std::wstring(buf))) return Verdict::PASS;
+        if (dict_.count(std::wstring(buf))) return Verdict::PASS;
+        // Orthography is enforced by FSM by construction; we only veto when
+        // dictionary requires meaningful word.
+        return Verdict::ROLLBACK;
+    }
+};
+```
+
+Free mode = `enabled_ = false`. Strict mode = `enabled_ = true`. UI exposes both as `freeTyping_` config (existing key, semantic preserved).
+
+---
+
+## 5. Codegen Pipeline
+
+### 5.1 Source-of-truth files
+
+```
+rules/
+  vietnamese-phonotactics.toml   ← Vietnamese syllable structure + N1/N2/N3 + exceptions
+                                    Authored by hand from RuleTiengViet_Summary.md
+                                    Versioned; source of all FSM tables
+  telex-keymap.toml              ← raw key → AbstractInput
+  telex-simple-keymap.toml       ← subset (no shorthand)
+  vni-keymap.toml                ← VNI digit → AbstractInput
+                                    Telex+VNI combined = union, generated automatically
+
+  dictionary.toml                ← ~6711 từ (from gonhanh.org/vi.dic, BSD-3)
+                                    + user exception list (separate file, runtime-loaded)
+```
+
+### 5.2 Tool
+
+`tools/fsm-codegen/main.py` (~500 LOC):
+
+```
+Input: rules/*.toml
+Steps:
+  1. Parse phonotactic rules → build NFA
+     - States = partial-syllable patterns
+     - Transitions = consonant/vowel/tone/modifier sequences
+     - Accept states = complete valid syllables (orthographic)
+  2. Subset construction → DFA
+  3. Hopcroft minimization → minimized DFA
+  4. Apply tone/modifier overlay (cross-product with tone state, escape rules)
+  5. Verify exhaustively:
+       enumerate 20,504 valid syllables (per RuleTiengViet)
+       simulate input sequence on DFA
+       assert FINAL state corresponds to syllable's representation
+       any failure → fail codegen
+  6. Emit C++ files:
+       src/core/engine/generated/fsm_table_telex.h
+       src/core/engine/generated/fsm_table_telex_simple.h
+       src/core/engine/generated/fsm_table_vni.h
+       src/core/engine/generated/fsm_table_combined.h
+       src/core/engine/generated/keymap_*.h
+```
+
+### 5.3 Build integration
+
+- CMake: `add_custom_command(... COMMAND python3 tools/fsm-codegen/main.py ...)` runs at configure time.
+- Generated `.h` files **committed to git** so headless build (no Python) works. Common pattern (e.g., bison/flex output).
+- CI gate: re-run codegen on PR, diff committed vs regenerated → must match.
+- Local dev: developers re-run codegen after editing rules; `make codegen` shortcut.
+
+### 5.4 Sparse vs dense encoding
+
+```python
+# In main.py:
+dense_size = len(states) * len(inputs) * sizeof_cell
+if dense_size <= 80 * 1024:  # 80 KB threshold
+    emit_dense()
+else:
+    emit_sparse()  # binary-search transitions
+```
+
+---
+
+## 6. Migration Plan (D-day)
+
+Single PR at end of D6. Each D-day commits chaos PASS or skip with explanation.
+
+| Day | Task | DoD |
+|---|---|---|
+| **D-1** | Codegen tool dev (1 week pre-sprint) | `tools/fsm-codegen/` Python pkg + unit tests + sample rule input. Linux-only, no project dep. |
+| **D0** | Codegen tool emit → `src/core/engine/generated/*.h` committed. `FsmTable` struct + accessors. Linux GTest unchanged. **Not wired to engine yet.** | Generated `.h` PASS exhaustive 20,504-syllable verify. CMake `make codegen` works. |
+| **D1** | `FsmDispatcher` class + `InputMapping` + `HistoryRingBuffer`. **Diff harness** `tests/FsmDispatcherDiffTest.cpp` runs `vietnamese_telex_pairs.txt` (30,337 cases) through both engines. | Diff <5% mismatch initial. Engine cũ untouched. |
+| **D2** | Audit + fix mismatches. Update rule TOML, regen codegen. Until **diff = 0**. | 30,337/30,337 PASS. TelexEngineTest 1409/1409 still PASS via FsmDispatcher. |
+| **D3** | Plugin event bus + `SyllableValidatorPlugin` (extracted from `SpellChecker`). Free typing toggle still works. | Plugin contract test PASS. Diff harness 30,337 PASS. Strict + free toggle test PASS. |
+| **D4** | HookEngine swap: `LowLevelKeyboardProc` routes via `FsmDispatcher`. TypingEngine code dead but compiled. **Chaos 55/55 PASS.** Run `tools/run-chaos.ps1`. | Chaos baseline `perf-baseline-fsm-d4.{md,csv,xml}` committed, 55/55 PASS. |
+| **D5** | Delete `TypingEngine.cpp` + `SpellChecker.cpp`. Delete redundant tests (replaced by codegen verify + diff harness). Update `tools/audit/check_hook_thread_no_mutex.sh` regex. | Linux GTest PASS, build clean, dead code removed. ~1,800 LOC deleted. |
+| **D6** | Final cleanup, baseline doc, PR review. Open `feat: FSM engine refactor (Sprint 3 §1)` PR. | PR open, baseline `perf-baseline-fsm.md` committed, ready merge. |
+
+**Estimated wall-time**: 1.5-2 weeks (D-1 codegen 1 week + D0-D6 6 days).
+
+### 6.1 Rollback strategy
+
+If D4 chaos < 55/55:
+- Atomic revert D4 commit (engine swap). FsmDispatcher remains compiled but unused.
+- Re-audit diff harness — likely a case `vietnamese_telex_pairs.txt` doesn't cover.
+- Add to corpus, fix rule, retry D4 next day.
+
+No feature flag (per `feedback_no_backwards_compat_hacks` memory). Atomic revert is cleaner.
+
+### 6.2 Bug `cafcs → các` resolution
+
+Currently a TODO bug. Expected resolution path:
+1. D2 diff harness includes `cafcs\tcác` test pair (codegen check).
+2. If TypingEngine cũ produces `càcs` → diff != 0 → audit reveals SpellChecker over-rejection.
+3. Codegen rule encoding makes `(VOWEL_a + TONE_huyền) + TONE_sắc → VOWEL_a + TONE_sắc` explicit transition. FSM produces `các` correctly.
+4. D5 deletes SpellChecker; bug gone.
+
+If `cafcs` not in `vietnamese_telex_pairs.txt`, D2 budget includes adding it manually.
+
+---
+
+## 7. Testing Strategy
+
+### Test pyramid
+
+```
+┌─────────────────────────────────────────────┐
+│  Manual E2E (Win, post-merge)               │  Daily-use defense
+│  - anh dùng NexusKey 1-2 tuần               │
+├─────────────────────────────────────────────┤
+│  Integration (CI matrix Linux + Win)        │  D4 + D6 gate
+│  - run-chaos.ps1: 5 host × 11 case = 55/55  │
+│  - sustained.toml: 0% drift                  │
+├─────────────────────────────────────────────┤
+│  Diff harness (CI Linux)                    │  D1-D2 gate
+│  - tests/FsmDispatcherDiffTest.cpp          │
+│  - 30,337 cases gonhanh telex pairs         │
+│  - 1,409 cases TelexEngineTest              │
+│  - 11 cases chaos.toml on Linux             │
+│  - Required: 31,757/31,757 ASSERT_EQ        │
+├─────────────────────────────────────────────┤
+│  Unit (CI Linux)                            │  Always PASS
+│  - FsmDispatcherTest: hot-swap, escape      │
+│  - InputMappingTest: 4 keymap variants       │
+│  - HistoryRingBufferTest: rewind cases      │
+│  - FsmPluginBusTest: VETO/ROLLBACK/CONSUME  │
+│  - SyllableValidatorTest: dict+free+excpt   │
+├─────────────────────────────────────────────┤
+│  Codegen (D0 build-time)                    │  D0 gate
+│  - tools/fsm-codegen/tests: parse/NFA/DFA   │
+│  - exhaustive 20,504 syllable verify        │
+└─────────────────────────────────────────────┘
+```
+
+### Performance gate
+
+- Hot-path microbenchmark in `tests/FsmDispatcherBenchTest.cpp`. Asserts: per-key dispatch ≤ 1 µs (1000× margin vs 1 ms hook budget).
+- Memory: `static_assert(sizeof(FsmTable) <= 100 * 1024)` at compile.
+
+### Chaos preservation
+
+- Sprint 2 baseline `perf-baseline-channeltraits-chaos.md`: 55/55 PASS.
+- FSM-1 baseline must match or improve. Worst-case p99 not regress > 10%.
+
+---
+
+## 8. Open Questions (Resolved)
+
+| # | Question | Resolution |
+|---|---|---|
+| 1 | Codegen tool language? | Python (~500 LOC). |
+| 2 | Spell-check dictionary? | gonhanh.org `vi.dic` 6711 từ (BSD-3). |
+| 3 | Rollback if D4 chaos fail? | Atomic revert D4 commit. No feature flag. |
+| 4 | Backward compat user config? | Preserve `freeTyping`, `vietnameseMode` semantics. |
+| 5 | Naming class chính? | `FsmDispatcher`, `IFsmPlugin`, `FsmTable`. |
+| 6 | Plugin migration order sprint sau? | Defer; not FSM-1 scope. |
+| 7 | Issue #111 UI form? | FSM-2 sprint, post-FSM-1 stable 1-2 weeks. |
+| 8 | CI codegen verify? | Separate gh-actions job, not block local dev. |
+
+## 9. Open Questions (Remaining — answer at plan-doc time)
+
+These need lock-in before D-1 starts coding. Minor enough to defer to plan doc.
+
+- DSL syntax for `vietnamese-phonotactics.toml`: hand-design vs reuse existing format (e.g., gonhanh's `telex_doubles.rs`)?
+- Dense vs sparse threshold: 80 KB? Or measure empirically and pick lower?
+- Plugin priority/order: register-time order, or explicit priority field?
+- Diff harness fail mode: hard fail (CI red) on first mismatch, or collect all mismatches into report?
+- Linux-only vs Windows codegen: tool runs on dev's machine; do we ship Windows builders?
+
+---
+
+## 10. References
+
+### NexusKey docs
+- [`docs/PHILOSOPHY.md`](../PHILOSOPHY.md) — Pillar 1-4 + project_three_questions
+- [`docs/CODE_GOVERNANCE.md`](../CODE_GOVERNANCE.md) §1 (FSM core), §4 (plugin extension)
+- [`docs/CODING_RULES/11-hook-system-rules.md`](../CODING_RULES/11-hook-system-rules.md) — 1 ms hot-path budget
+- [`docs/RuleTiengViet_Summary.md`](../RuleTiengViet_Summary.md) — Vietnamese phonotactics (20,504 syllables)
+- [`docs/plans/sprint-1-single-owner-refactor.md`](sprint-1-single-owner-refactor.md) — Sprint 1 D-day pattern
+- [`docs/plans/sprint-2-output-injector.md`](sprint-2-output-injector.md) — Sprint 2 T3 IOutputInjector
+- [`docs/plans/sprint-2-output-injector-plan.md`](sprint-2-output-injector-plan.md) — Sprint 2 implementation plan reference
+
+### External (license-compatible)
+- [gonhanh.org](https://github.com/khaphanspace/gonhanh.org) — BSD-3-Clause
+  - `core/src/data/dictionaries/vi.dic` (6,711 từ) → `rules/dictionary.toml`
+  - `core/tests/data/vietnamese_telex_pairs.txt` (30,337 cases) → `tests/corpus/gonhanh-telex-pairs.txt`
+  - Attribute in `LICENSE-3RD-PARTY.md` + file header
+- [PHTV](https://github.com/PhamHungTien/PHTV) — AGPL-3.0 — **SKIP** (license conflict with NexusKey GPL-3)
+- [xkey](https://github.com/xmannv/xkey) — MIT — **SKIP** (Swift code, parse cost > benefit)
+
+### Algorithms
+- Hopcroft DFA minimization — Wikipedia + libraries `automata-lib` / `pyfsa`
+- NFA → DFA subset construction — standard textbook (Aho/Sethi/Ullman §3.7)
+
+### Issues
+- [#111](https://github.com/phatMT97/NexusKey/issues/111) — User-defined custom keymap (deferred FSM-2)
+
+---
+
+## 11. Glossary
+
+- **FSM** — Finite State Machine. Here: 2D table indexed by (state, abstract_input) returning (next_state, action).
+- **DFA** — Deterministic FSM. Codegen output after subset construction + minimization.
+- **NFA** — Non-deterministic FSM. Codegen intermediate.
+- **AbstractInput** — Enum of post-keymap abstract symbols (TONE_SAC, MOD_HORN, INSERT_LITERAL_a, etc).
+- **Keymap** — `array[256] of AbstractInput`, raw key → abstract input. Telex/VNI/Combined are different keymaps over same FSM.
+- **Hopcroft minimization** — Algorithm to reduce DFA to minimal equivalent.
+- **RCU** — Read-Copy-Update. Lock-free publish via `std::atomic<std::shared_ptr<T>>`. Used Sprint 1 D6 for `config_`, Sprint 2 D3 for `injector_`, here for `fsmTable_` + `keymap_`.
+- **Verdict** — Plugin return value: PASS / VETO / ROLLBACK / CONSUME.
+- **Diff harness** — Test that runs both old engine + new FSM on same input corpus, asserts identical output.
+- **Parallel-run** — Compiled-in coexistence of old + new engine, output compared. NOT runtime — D1-D2 only.
+
+---
+
+## 12. Sign-off
+
+This design was brainstormed conversationally on 2026-05-05, based on user's philosophy "Nhanh / Nhẹ / Mượt / Mở rộng-không-giảm-perf" and CODE_GOVERNANCE §1+§4 prescriptions. Locked decisions in §1 reflect user's preferences captured during brainstorm.
+
+Next step: `gsd:plan-phase` (or hand-write plan doc) to break D-1 / D0 / D1 / ... into per-task checklists, then start D-1 codegen tool development.

--- a/docs/plans/2026-05-05-fsm-engine-refactor-design.md
+++ b/docs/plans/2026-05-05-fsm-engine-refactor-design.md
@@ -492,8 +492,8 @@ Single PR at end of D6. Each D-day commits chaos PASS or skip with explanation.
 |---|---|---|
 | **D-1** | Codegen tool dev (1 week pre-sprint) | `tools/fsm-codegen/` Python pkg + unit tests + sample rule input. Linux-only, no project dep. |
 | **D0** | Codegen tool emit → `src/core/engine/generated/*.h` committed. `FsmTable` struct + accessors. Linux GTest unchanged. **Not wired to engine yet.** | Generated `.h` PASS exhaustive 20,504-syllable verify. CMake `make codegen` works. |
-| **D1** | `FsmDispatcher` class + `InputMapping` + `HistoryRingBuffer`. **Diff harness** `tests/FsmDispatcherDiffTest.cpp` runs `vietnamese_telex_pairs.txt` (30,337 cases) through both engines. | Diff <5% mismatch initial. Engine cũ untouched. |
-| **D2** | Audit + fix mismatches. Update rule TOML, regen codegen. Until **diff = 0**. | 30,337/30,337 PASS. TelexEngineTest 1409/1409 still PASS via FsmDispatcher. |
+| **D1** | `FsmDispatcher` class + `InputMapping` + `HistoryRingBuffer`. **Diff harness** `tests/FsmDispatcherDiffTest.cpp` runs combined corpus (gonhanh 30,337 + TelexEngineTest 1,409 + chaos.toml 11 = 31,757 cases) through both engines. | Diff <5% mismatch initial. Engine cũ untouched. |
+| **D2** | Audit + fix mismatches. Update rule TOML, regen codegen. Until **diff = 0** on all 3 corpus tiers. ⚠️ chaos corpus (11 cases) catches edge cases gonhanh pairs don't cover (`cafcs`, `uongs`, `truongwf`, `vieejt`). | 31,757/31,757 PASS. |
 | **D3** | Plugin event bus + `SyllableValidatorPlugin` (extracted from `SpellChecker`). Free typing toggle still works. | Plugin contract test PASS. Diff harness 30,337 PASS. Strict + free toggle test PASS. |
 | **D4** | HookEngine swap: `LowLevelKeyboardProc` routes via `FsmDispatcher`. TypingEngine code dead but compiled. **Chaos 55/55 PASS.** Run `tools/run-chaos.ps1`. | Chaos baseline `perf-baseline-fsm-d4.{md,csv,xml}` committed, 55/55 PASS. |
 | **D5** | Delete `TypingEngine.cpp` + `SpellChecker.cpp`. Delete redundant tests (replaced by codegen verify + diff harness). Update `tools/audit/check_hook_thread_no_mutex.sh` regex. | Linux GTest PASS, build clean, dead code removed. ~1,800 LOC deleted. |
@@ -603,13 +603,17 @@ These need lock-in before D-1 starts coding. Minor enough to defer to plan doc.
 - [`docs/plans/sprint-2-output-injector.md`](sprint-2-output-injector.md) — Sprint 2 T3 IOutputInjector
 - [`docs/plans/sprint-2-output-injector-plan.md`](sprint-2-output-injector-plan.md) — Sprint 2 implementation plan reference
 
-### External (license-compatible)
-- [gonhanh.org](https://github.com/khaphanspace/gonhanh.org) — BSD-3-Clause
-  - `core/src/data/dictionaries/vi.dic` (6,711 từ) → `rules/dictionary.toml`
-  - `core/tests/data/vietnamese_telex_pairs.txt` (30,337 cases) → `tests/corpus/gonhanh-telex-pairs.txt`
-  - Attribute in `LICENSE-3RD-PARTY.md` + file header
-- [PHTV](https://github.com/PhamHungTien/PHTV) — AGPL-3.0 — **SKIP** (license conflict with NexusKey GPL-3)
-- [xkey](https://github.com/xmannv/xkey) — MIT — **SKIP** (Swift code, parse cost > benefit)
+### External (license-compatible — verified 2026-05-05)
+
+**[gonhanh.org](https://github.com/khaphanspace/gonhanh.org)** — BSD-3-Clause (Khá Phạm + Gõ Nhanh Contributors, 2025). Attribution: copyright notice in source + binary distribution required.
+- `core/src/data/dictionaries/vi.dic` (UTF-8, header `6711` + 6,711 lines, 1 word/line) → `rules/dictionary.toml`. Verified clean format.
+- `core/tests/data/vietnamese_telex_pairs.txt` (UTF-8, 30,337 lines, `telex<TAB>expected`) → `tests/corpus/gonhanh-telex-pairs.txt`. Verified clean format.
+- ⚠️ **Coverage gap (verified)**: gonhanh pairs cover **forward typing only**. Chaos failure cases `cafcs`, `uongs`, `truongwf`, `vieejt` NOT in pairs file. D1-D2 diff harness MUST also run NexusKey's own `TelexEngineTest.cpp` (~1,409 cases) + `corpus/chaos.toml` (11) for edge-case + chaos coverage. Total D2 gate = **31,757 ASSERT_EQ**.
+- Attribute in: `LICENSE-3RD-PARTY.md` (top-level) + file header of `tests/corpus/gonhanh-telex-pairs.txt` + file header of `rules/dictionary.toml`.
+
+**[PHTV](https://github.com/PhamHungTien/PHTV)** — AGPL-3.0 — **SKIP** (license conflict with NexusKey GPL-3; AGPL would force NexusKey upgrade).
+
+**[xkey](https://github.com/xmannv/xkey)** — MIT — **SKIP** (compatible license, but Swift code in `VNEngine.swift` 183 KB; parse cost > benefit).
 
 ### Algorithms
 - Hopcroft DFA minimization — Wikipedia + libraries `automata-lib` / `pyfsa`

--- a/docs/plans/sprint-3-fsm-engine-plan.md
+++ b/docs/plans/sprint-3-fsm-engine-plan.md
@@ -1,0 +1,687 @@
+# Sprint 3 FSM Engine Refactor — Implementation Plan
+
+> **For agentic workers:** Use checkbox (`- [ ]`) tracking. Tasks group by D-day; each D-day = ONE atomic commit.
+>
+> **Branch policy:** D-1 work on `sprint-3/codegen-tool` (codegen tool only, can land first). D0-D6 work on `sprint-3/fsm-engine` (engine refactor). Codegen tool merged first; engine PR second.
+>
+> **Foundation:** [`2026-05-05-fsm-engine-refactor-design.md`](2026-05-05-fsm-engine-refactor-design.md) — Read §0 (5-question gate), §1 (locked decisions), §6 (D-day plan) before starting.
+>
+> **Baseline:** chaos 55/55 PASS on Main. GTest 1409/1409 PASS Linux. Sprint 2 output injector preserved.
+
+---
+
+## D-1 — Codegen Tool Development (~1 week pre-sprint)
+
+Goal: Python tool that parses phonotactic rules + keymap TOML, builds NFA, converts to DFA, minimizes via Hopcroft, exhaustive-verifies against 20,504 syllables, emits C++ constexpr tables.
+
+Branch: `sprint-3/codegen-tool` from Main. Standalone — no NexusKey runtime dep. Lands as separate PR before D0.
+
+### Task 1: Project skeleton
+
+**Files:**
+- Create: `tools/fsm-codegen/pyproject.toml`
+- Create: `tools/fsm-codegen/main.py`
+- Create: `tools/fsm-codegen/codegen/__init__.py`
+- Create: `tools/fsm-codegen/codegen/nfa.py`
+- Create: `tools/fsm-codegen/codegen/dfa.py`
+- Create: `tools/fsm-codegen/codegen/parser.py`
+- Create: `tools/fsm-codegen/codegen/emitter.py`
+- Create: `tools/fsm-codegen/codegen/verifier.py`
+- Create: `tools/fsm-codegen/tests/__init__.py`
+- Create: `tools/fsm-codegen/tests/test_nfa.py`
+- Create: `tools/fsm-codegen/tests/test_dfa.py`
+- Create: `tools/fsm-codegen/tests/test_parser.py`
+- Create: `tools/fsm-codegen/tests/test_emitter.py`
+- Create: `tools/fsm-codegen/tests/test_verifier.py`
+- Create: `tools/fsm-codegen/README.md`
+
+- [ ] **Step 1:** Init `pyproject.toml` with deps: `tomli` (Python <3.11) or stdlib `tomllib` (>=3.11), `pytest`, `pyfsa` (or `automata-lib` — pick one after spike).
+- [ ] **Step 2:** Skeleton modules with empty class stubs (`Nfa`, `Dfa`, `RuleParser`, `CppEmitter`, `Verifier`).
+- [ ] **Step 3:** `main.py` CLI: `python -m fsm_codegen --rules rules/ --output src/core/engine/generated/`.
+- [ ] **Step 4:** Run pytest stub — all tests pass (no asserts yet). Verify Python pkg structure.
+- [ ] **Step 5:** README explains pipeline + how to run.
+
+### Task 2: Parse phonotactic rules
+
+**Files:**
+- Create: `rules/vietnamese-phonotactics.toml` (hand-authored from `docs/RuleTiengViet_Summary.md`)
+- Create: `rules/telex-keymap.toml`
+- Create: `rules/vni-keymap.toml`
+- Modify: `tools/fsm-codegen/codegen/parser.py`
+
+- [ ] **Step 1:** Author `rules/vietnamese-phonotactics.toml`. Schema:
+
+```toml
+[consonants]
+initial_d1 = ["b", "d", "đ", "g", "l", "m", "n", "p", "r", "s", "t", "v", "ch", "nh", "ph", "tr"]
+initial_d2 = ["c", "h", "th", "kh"]   # c includes k/qu variants by rule
+initial_d3 = ["x", "gi", "ng"]         # ng includes ngh
+initial_special = ["k", "qu", "gh", "ngh"]   # context-dependent
+
+[vowels]
+single  = ["a", "ă", "â", "e", "ê", "i", "o", "ô", "ơ", "u", "ư"]   # 11
+diphthong = ["ai", "ao", "au", "ay", "âu", "ây", "eo", "êu", "ia", "iê",
+             "iu", "oa", "oă", "oe", "oi", "ôi", "ơi", "ua", "uâ", "uê",
+             "ui", "uô", "uơ", "uy", "ưa", "ưi", "ươ", "ưu", "oo", "ôô"]    # 30
+triphthong = ["iêu", "oai", "oay", "uây", "uôi", "uyê", "uyu",
+              "ươi", "ươu", "uya", "oao", "oeo"]                            # 12
+
+[final_consonants]
+c1 = ["ng", "c"]
+c2 = ["nh", "ch"]
+c3 = ["m", "n", "p", "t"]
+
+[vowel_groupings]
+n1 = ["â", "e", "o", "ô", "u", "ư", "ơ", "ă", "oă", "oe", "uâ", "uô", "uơ", "ươ"]   # only c1+c3, no c2
+n2 = ["ê", "i", "uê", "uy", "ua"]                                                     # only c2+c3, no c1
+n3 = ["a", "oa", "iê", "uyê"]                                                         # all c1, c2, c3
+
+closed_vowels = ["ai", "ao", "au", "ay", ...]   # 28 — never have final consonant
+suspended_vowels = ["ă", "â", "iê", "oă", "uâ", "uô", "oo", "ôô", "ươ", "uyê"]      # 10 — must have final
+
+[tone_rules]
+tones = ["sắc", "huyền", "hỏi", "ngã", "nặng"]
+hard_constraint = { codas = ["c", "ch", "p", "t"], allowed_tones = ["sắc", "nặng"] }
+```
+
+- [ ] **Step 2:** Author `rules/telex-keymap.toml`:
+
+```toml
+[mappings]
+# Tone keys (single-press)
+"s" = "TONE_SAC"
+"f" = "TONE_HUYEN"
+"r" = "TONE_HOI"
+"x" = "TONE_NGA"
+"j" = "TONE_NANG"
+
+# Modifier keys (single-press; 2-char sequences handled by FSM state)
+"w" = "MOD_HORN"
+
+# 2-char trigger sequences
+[double_sequences]
+"aa" = "MOD_CIRCUMFLEX_a"   # → â
+"oo" = "MOD_CIRCUMFLEX_o"   # → ô
+"ee" = "MOD_CIRCUMFLEX_e"   # → ê
+"aw" = "MOD_BREVE_a"         # → ă
+"ow" = "MOD_HORN_o"          # → ơ (alt for w-after-o)
+"uw" = "MOD_HORN_u"          # → ư (alt for w-after-u)
+"dd" = "MOD_D_BAR"           # → đ
+```
+
+- [ ] **Step 3:** Author `rules/vni-keymap.toml` (same structure, digit keys).
+
+- [ ] **Step 4:** Implement `RuleParser.load_phonotactics(path)` — parse TOML, validate schema, return structured `PhonotacticsRule` dataclass.
+
+- [ ] **Step 5:** Implement `RuleParser.load_keymap(path)` → `KeymapRule`.
+
+- [ ] **Step 6:** Tests `test_parser.py`: malformed TOML → raise; missing required field → raise; valid TOML → correct dataclass.
+
+- [ ] **Step 7:** Run `pytest tools/fsm-codegen/tests/test_parser.py` — PASS.
+
+### Task 3: Build NFA
+
+**Files:**
+- Modify: `tools/fsm-codegen/codegen/nfa.py`
+
+- [ ] **Step 1:** Define dataclass `NfaState`, `NfaTransition`. State = abstract syllable-position label.
+
+- [ ] **Step 2:** Implement `Nfa.from_phonotactics(rules)` — walk syllable structure:
+   - Start state `S0`.
+   - For each initial consonant: edge `S0 -> S1[cons]` on consonant input.
+   - For each vowel from `S1[cons]`: edge to `S2[cons,vowel]`.
+   - Apply `n1/n2/n3` constraint when adding final consonant edges.
+   - Apply tone overlay: each accept state has 6 variants (1 per tone, including no-tone).
+   - Apply suspended/closed-vowel constraints.
+   - Accept states = complete syllables.
+
+- [ ] **Step 3:** Apply keymap on top: for each Telex/VNI key, add transitions encoding modifier/tone application.
+
+- [ ] **Step 4:** Apply escape rules: state `MOD_APPLIED + same modifier key` → state `ESCAPE_LITERAL` + emit literal pair.
+
+- [ ] **Step 5:** Tests `test_nfa.py`: sample mini-grammar (just `a` + `s` → `á`, `aa` → `â`, `aaa` → `aa`). Walk NFA → expected accept state.
+
+- [ ] **Step 6:** Pytest PASS.
+
+### Task 4: Subset construction (NFA → DFA)
+
+**Files:**
+- Modify: `tools/fsm-codegen/codegen/dfa.py`
+
+- [ ] **Step 1:** Implement `Dfa.from_nfa(nfa)` — subset construction algorithm (Aho/Sethi/Ullman §3.7):
+   - Start state = ε-closure of NFA start.
+   - For each input symbol, compute move + ε-closure → new DFA state.
+   - Continue until fixpoint.
+
+- [ ] **Step 2:** Sanity check: DFA from sample NFA should be deterministic (each state has at most 1 transition per input).
+
+- [ ] **Step 3:** Tests `test_dfa.py`: sample NFA with epsilon transitions → expected DFA.
+
+- [ ] **Step 4:** Pytest PASS.
+
+### Task 5: Hopcroft minimization
+
+**Files:**
+- Modify: `tools/fsm-codegen/codegen/dfa.py`
+
+- [ ] **Step 1:** Implement `Dfa.minimize()` via Hopcroft algorithm:
+   - Initial partition: {accept_states, non_accept_states}.
+   - For each input symbol, refine partition until no further split.
+   - Return Dfa with merged equivalent states.
+
+- [ ] **Decision:** Use library `automata-lib` if available (`pip install automata-lib`), else implement from scratch.
+
+- [ ] **Step 2:** Tests `test_dfa.py::test_minimize`: pre-known case (3-state DFA collapses to 2) → assert result.
+
+- [ ] **Step 3:** Pytest PASS.
+
+### Task 6: Apply tone/modifier overlay + escape semantics
+
+**Files:**
+- Modify: `tools/fsm-codegen/codegen/nfa.py` or new `codegen/overlay.py`
+
+- [ ] **Step 1:** After base DFA built, cross-product with tone state {NoTone, Sắc, Huyền, Hỏi, Ngã, Nặng}.
+- [ ] **Step 2:** For each tone key (TONE_SAC, ...), add transition: `(accept_state, tone_key) → (same_accept_state, tone_set)` + emit `REPLACE_LAST(N, toned_text)`.
+- [ ] **Step 3:** For escape: `(toned_state, same_tone_key) → (literal_escape_state)` + emit `REPLACE_LAST(1, "ay")` (literal pair, e.g., `aff → af`).
+- [ ] **Step 4:** Validate: tone-on-coda hard constraint (c/ch/p/t → only sắc/nặng) — codegen reject invalid combos.
+- [ ] **Step 5:** Tests: escape pattern `lè` + `f` → `lèf` (literal escape). `cafcs` → `các` (tone replacement, not escape because different tones).
+
+### Task 7: Exhaustive verify
+
+**Files:**
+- Modify: `tools/fsm-codegen/codegen/verifier.py`
+
+- [ ] **Step 1:** Enumerate all 20,504 valid Vietnamese syllables programmatically (cross-product per phonotactic rules).
+- [ ] **Step 2:** For each syllable + each keymap (Telex/VNI), generate the input keystroke sequence that should produce it.
+- [ ] **Step 3:** Run sequence through DFA → assert final state corresponds to expected output.
+- [ ] **Step 4:** If any failure → print mismatch, exit codegen with error code.
+- [ ] **Step 5:** Time budget: full verify ≤ 30 seconds (else codegen too slow for build pipeline).
+
+### Task 8: Emit C++ tables
+
+**Files:**
+- Modify: `tools/fsm-codegen/codegen/emitter.py`
+- Output (created at run time): `src/core/engine/generated/fsm_table_telex.h` etc.
+
+- [ ] **Step 1:** Implement `CppEmitter.emit_dense(dfa, path)`:
+
+```cpp
+// AUTO-GENERATED by tools/fsm-codegen/main.py — DO NOT EDIT
+// Source: rules/vietnamese-phonotactics.toml + rules/telex-keymap.toml
+// Generated: 2026-05-XX HH:MM:SS
+// Source-of-truth license: BSD-3-Clause (Gõ Nhanh Contributors, 2025)
+
+#pragma once
+#include <array>
+#include <cstdint>
+
+namespace NextKey::Engine::Generated {
+
+struct FsmCell { uint16_t nextState; uint16_t actionId; };
+
+inline constexpr std::size_t kStateCount  = 1234;   // codegen output
+inline constexpr std::size_t kInputCount  = 32;
+inline constexpr std::size_t kActionCount = 567;
+
+inline constexpr std::array<std::array<FsmCell, kInputCount>, kStateCount> kFsmTableTelex = {{
+    /* state 0 */ {{ {0,0}, {1,5}, {0,0}, ... }},
+    /* state 1 */ {{ ... }},
+    ...
+}};
+
+inline constexpr std::array<Action, kActionCount> kActionTable = { ... };
+
+}  // namespace NextKey::Engine::Generated
+```
+
+- [ ] **Step 2:** Implement `CppEmitter.emit_sparse(dfa, path)` for fallback (sorted transitions for binary search).
+
+- [ ] **Step 3:** Switch dense vs sparse based on size threshold (80 KB).
+
+- [ ] **Step 4:** Emit keymap tables: `keymap_telex.h`, `keymap_vni.h`, `keymap_combined.h`.
+
+- [ ] **Step 5:** Tests `test_emitter.py`: emit small DFA → verify output compiles via `clang -fsyntax-only`.
+
+### Task 9: CMake integration (deferred until D0)
+
+D-1 tool stands alone. CMake hook added in D0 when engine consumes.
+
+### Task 10: D-1 commits
+
+- [ ] **Step 1:** Atomic commits per task (Task 1 commit, Task 2 commit, ..., Task 8 commit).
+- [ ] **Step 2:** Linux pytest CI green.
+- [ ] **Step 3:** Run codegen end-to-end: `python -m fsm_codegen --rules rules/ --output /tmp/test-gen/`. Inspect output `.h` for sanity.
+- [ ] **Step 4:** Open PR `tooling: FSM codegen tool (Sprint 3 D-1)`. Merge to Main before D0.
+
+---
+
+## D0 — Engine scaffolding
+
+Goal: codegen tool consumed by CMake. Generated `.h` committed to repo. `FsmTable` accessor + RCU `shared_ptr` member in HookEngine. NOT wired to hook callback yet. Linux GTest 1409/1409 still passes.
+
+Branch: `sprint-3/fsm-engine` from Main.
+
+### Task 11: CMake codegen integration
+
+**Files:**
+- Modify: `CMakeLists.txt` (root)
+- Modify: `src/CMakeLists.txt`
+
+- [ ] **Step 1:** Add `find_package(Python3 REQUIRED COMPONENTS Interpreter)`.
+- [ ] **Step 2:** Add `add_custom_command` to run codegen at configure time, output to `${CMAKE_BINARY_DIR}/generated/`.
+- [ ] **Step 3:** Add `add_custom_target(codegen DEPENDS generated/fsm_table_telex.h ...)`.
+- [ ] **Step 4:** Header search path includes `${CMAKE_BINARY_DIR}/generated/`.
+- [ ] **Step 5:** Pre-generated output also COMMITTED to `src/core/engine/generated/` (headless build fallback). CMake picks committed if codegen unavailable.
+
+### Task 12: Generated headers committed
+
+**Files:**
+- Create (via tool): `src/core/engine/generated/fsm_table_telex.h`
+- Create: `src/core/engine/generated/fsm_table_telex_simple.h`
+- Create: `src/core/engine/generated/fsm_table_vni.h`
+- Create: `src/core/engine/generated/fsm_table_combined.h`
+- Create: `src/core/engine/generated/keymap_telex.h`
+- Create: `src/core/engine/generated/keymap_vni.h`
+- Create: `src/core/engine/generated/keymap_combined.h`
+- Create: `src/core/engine/generated/abstract_input.h` (enum)
+
+- [ ] **Step 1:** Run `python -m fsm_codegen --rules rules/ --output src/core/engine/generated/`.
+- [ ] **Step 2:** Commit generated `.h`. Sizes: dense ≤ 100 KB total expected.
+- [ ] **Step 3:** CI step: re-run codegen, `git diff` → must be empty (no drift).
+
+### Task 13: FsmDispatcher class skeleton
+
+**Files:**
+- Create: `src/core/engine/FsmDispatcher.h`
+- Create: `src/core/engine/FsmDispatcher.cpp`
+
+- [ ] **Step 1:** Header skeleton:
+
+```cpp
+#pragma once
+#include "generated/abstract_input.h"
+#include <atomic>
+#include <memory>
+
+namespace NextKey::Engine {
+
+struct FsmTable;        // forward
+struct Keymap;          // forward
+class HistoryRingBuffer;
+class CommitUndoSM;
+class FsmPluginBus;
+class IOutputInjector;  // from Sprint 2
+
+class FsmDispatcher {
+public:
+    FsmDispatcher(std::shared_ptr<FsmPluginBus> bus,
+                  std::shared_ptr<IOutputInjector> initialInjector) noexcept;
+
+    enum class HookVerdict { EATEN, PASS_THROUGH };
+    HookVerdict ProcessKey(wchar_t rawKey) noexcept;
+    HookVerdict ProcessBackspace() noexcept;
+
+    void SetActiveKeymap(std::shared_ptr<const Keymap> km) noexcept;
+    void SetActiveFsmTable(std::shared_ptr<const FsmTable> tbl) noexcept;
+    void SetActiveInjector(std::shared_ptr<IOutputInjector> inj) noexcept;
+
+private:
+    std::atomic<std::shared_ptr<const Keymap>>          activeKeymap_;
+    std::atomic<std::shared_ptr<const FsmTable>>        activeFsmTable_;
+    std::atomic<std::shared_ptr<IOutputInjector>>       activeInjector_;
+    std::shared_ptr<FsmPluginBus>                       pluginBus_;
+    HistoryRingBuffer*                                  history_;
+    CommitUndoSM*                                       commitUndo_;
+    uint16_t                                            currentState_;
+};
+
+}  // namespace NextKey::Engine
+```
+
+- [ ] **Step 2:** Source skeleton: ctor stores members, `ProcessKey` returns PASS_THROUGH (stub). All accessors atomic_store.
+
+- [ ] **Step 3:** CMakeLists adds source.
+
+- [ ] **Step 4:** Linux compile clean.
+
+### Task 14: HistoryRingBuffer
+
+**Files:**
+- Create: `src/core/engine/HistoryRingBuffer.h`
+- Create: `src/core/engine/HistoryRingBuffer.cpp`
+- Create: `tests/HistoryRingBufferTest.cpp`
+
+- [ ] **Step 1:** Implement fixed-size ring buffer (`std::array<Record, 256>` + read/write head).
+- [ ] **Step 2:** API: `Push`, `PopLast`, `RewindToPrevSyllable`, `Clear`.
+- [ ] **Step 3:** Tests: 256-record fill + wrap, push-pop matched, rewind to prev syllable correctly identifies boundary.
+- [ ] **Step 4:** Linux GTest PASS.
+
+### Task 15: CommitUndoSM
+
+**Files:**
+- Create: `src/core/engine/CommitUndoSM.h`
+- Create: `src/core/engine/CommitUndoSM.cpp`
+- Create: `tests/CommitUndoSMTest.cpp`
+
+- [ ] **Step 1:** Port commit-undo state machine logic from `HookEngine.cpp` (lines 556-594 per `docs/archive/ghost-chars-chrome-investigation.md`). Same 3-state Idle/Primed/Ready semantics.
+- [ ] **Step 2:** Tests: state transitions on space/punct/Enter + Backspace + non-BS input.
+- [ ] **Step 3:** Linux GTest PASS.
+
+### Task 16: D0 commit
+
+- [ ] **Step 1:** All scaffolding committed: codegen output + FsmDispatcher skeleton + HistoryRingBuffer + CommitUndoSM. Engine wiring NOT touched.
+- [ ] **Step 2:** Linux GTest 1409+ PASS (1409 existing + new HistoryRingBuffer + CommitUndoSM tests).
+- [ ] **Step 3:** Windows MSVC compile clean.
+- [ ] **Step 4:** Commit message: `Sprint 3 D0: FSM scaffolding (codegen output, FsmDispatcher, HistoryRingBuffer, CommitUndoSM)`.
+
+---
+
+## D1 — FsmDispatcher implementation + diff harness
+
+Goal: FsmDispatcher fully implements `ProcessKey` + `ProcessBackspace` using FSM table lookup. Diff harness runs combined corpus (31,757 cases) through both engines, asserts equality. Initial mismatch <5%.
+
+### Task 17: Implement FsmDispatcher::ProcessKey
+
+**Files:**
+- Modify: `src/core/engine/FsmDispatcher.cpp`
+
+- [ ] **Step 1:** Hot path:
+
+```cpp
+HookVerdict FsmDispatcher::ProcessKey(wchar_t rawKey) noexcept {
+    // 1. Plugin BeforeInput
+    auto bus = pluginBus_;
+    if (bus->BeforeInput(rawKey) == Verdict::CONSUME) return HookVerdict::EATEN;
+
+    // 2. Map raw key
+    auto km = std::atomic_load(&activeKeymap_);
+    AbstractInput input = km->map[rawKey];
+
+    // 3. FSM lookup
+    auto tbl = std::atomic_load(&activeFsmTable_);
+    auto cell = tbl->cells[currentState_][static_cast<size_t>(input)];
+    Action action = tbl->actions[cell.actionId];
+
+    // 4. Plugin BeforeTransition (VETO?)
+    if (bus->BeforeTransition(currentState_, input) == Verdict::VETO) {
+        // emit literal raw key
+        return HookVerdict::PASS_THROUGH;
+    }
+
+    // 5. Apply transition
+    uint16_t prevState = currentState_;
+    currentState_ = cell.nextState;
+
+    // 6. Emit action
+    auto inj = std::atomic_load(&activeInjector_);
+    EmitAction(action, *inj);
+
+    // 7. Record history
+    history_->Push({rawKey, input, prevState, currentState_, action});
+
+    // 8. Plugin OnPostAction (ROLLBACK?)
+    auto resultBuf = ComputeResultBuf();
+    if (bus->OnPostAction(action, resultBuf) == Verdict::ROLLBACK) {
+        Rollback();
+        return HookVerdict::PASS_THROUGH;
+    }
+
+    // 9. Plugin AfterTransition (observers)
+    bus->AfterTransition(prevState, input, currentState_, action);
+
+    // 10. CommitUndoSM update
+    commitUndo_->OnNonBsInput();
+
+    return HookVerdict::EATEN;
+}
+```
+
+- [ ] **Step 2:** Implement `EmitAction` (dispatch to `injector_->Replace` etc).
+- [ ] **Step 3:** Implement `Rollback` (pop history, undo emit).
+
+### Task 18: Implement FsmDispatcher::ProcessBackspace
+
+**Files:**
+- Modify: `src/core/engine/FsmDispatcher.cpp`
+
+- [ ] **Step 1:** BS within syllable: `history_->PopLast()` → restore prev state + undo emit.
+- [ ] **Step 2:** BS cross-syllable: `history_->RewindToPrevSyllable()` → revive previous syllable state.
+- [ ] **Step 3:** BS at empty history: PASS_THROUGH.
+
+### Task 19: Diff harness
+
+**Files:**
+- Create: `tests/FsmDispatcherDiffTest.cpp`
+- Create: `tests/corpus/gonhanh-telex-pairs.txt` (downloaded from gonhanh.org/HEAD with attribution header)
+- Create: `LICENSE-3RD-PARTY.md`
+
+- [ ] **Step 1:** Download `vietnamese_telex_pairs.txt` from gonhanh.org HEAD (after merge of upstream this commit), commit with attribution header (BSD-3 notice + copyright).
+- [ ] **Step 2:** Create `LICENSE-3RD-PARTY.md` listing gonhanh.org BSD-3 attribution + upstream commit hash.
+- [ ] **Step 3:** Test fixture loads `gonhanh-telex-pairs.txt` (30,337 lines), parses `telex<TAB>expected`.
+- [ ] **Step 4:** For each pair: feed `telex` chars to BOTH engines (`TypingEngine` cũ + `FsmDispatcher` mới), compare output. ASSERT_EQ.
+- [ ] **Step 5:** Add: feed `chaos.toml` 11 cases (load via existing TomlLoader). ASSERT_EQ.
+- [ ] **Step 6:** Add: feed `TelexEngineTest.cpp` 1409 cases (refactor as parametrized). ASSERT_EQ.
+- [ ] **Step 7:** Total: 31,757 ASSERT_EQ. D1 may have <5% mismatch — D2 task to fix.
+
+### Task 20: D1 commit
+
+- [ ] **Step 1:** Commit `Sprint 3 D1: FsmDispatcher impl + diff harness (31,757 cases, initial mismatch X%)`.
+- [ ] **Step 2:** CI runs diff harness on Linux, reports % mismatch.
+
+---
+
+## D2 — Fix to diff = 0
+
+Goal: 31,757/31,757 PASS. Audit mismatches, update rule TOML, regen codegen.
+
+### Task 21: Audit mismatches
+
+- [ ] **Step 1:** Diff harness emits report file: `tests/diff-report.txt` listing each mismatch as `<input> | <old_output> | <new_output>`.
+- [ ] **Step 2:** Group by category (forward typing / chaos / engine internal). Count per category.
+- [ ] **Step 3:** Investigate top 10 mismatches manually. Identify root cause: rule missing? Codegen bug? FSM transition incorrect?
+
+### Task 22: Iterate rule fixes
+
+- [ ] **Step 1:** For each rule fix: update `rules/*.toml`, regen codegen, re-run diff. Decrement mismatch count.
+- [ ] **Step 2:** Hard cap: 2 days. If mismatch > 0 after 2 days, escalate to anh — review per-case decision (keep cũ vs accept FSM fix).
+- [ ] **Step 3:** **Bug `cafcs → các` resolution**: this case may flip from FAIL to PASS in FSM (because rule encoding makes tone-replacement explicit). Diff harness shows: TypingEngine=`càcs`, FsmDispatcher=`các`. Decision: accept FSM (correct per Vietnamese phonotactics). Document in commit.
+
+### Task 23: D2 commit
+
+- [ ] **Step 1:** All 31,757 cases PASS via FsmDispatcher.
+- [ ] **Step 2:** Commit `Sprint 3 D2: 31,757/31,757 PASS, FsmDispatcher ≡ TypingEngine`.
+
+---
+
+## D3 — Plugin event bus + SyllableValidator
+
+Goal: Plugin bus implementation. SyllableValidator extracted from `SpellChecker.cpp`. Free typing toggle still works.
+
+### Task 24: FsmPluginBus
+
+**Files:**
+- Create: `src/core/engine/FsmPluginBus.h`
+- Create: `src/core/engine/FsmPluginBus.cpp`
+- Create: `src/core/engine/IFsmPlugin.h`
+- Create: `tests/FsmPluginBusTest.cpp`
+
+- [ ] **Step 1:** Implement `IFsmPlugin` interface (per design §4.3).
+- [ ] **Step 2:** Implement `FsmPluginBus` with `Register/Unregister/Dispatch*` methods. Plugin order = registration order.
+- [ ] **Step 3:** Tests:
+   - Register 2 plugins, both get called.
+   - 1st plugin returns CONSUME → 2nd not called.
+   - 1st plugin returns VETO → transition not applied.
+   - 1st plugin returns ROLLBACK → applied then reverted.
+   - Unregister → removed from chain.
+- [ ] **Step 4:** GTest PASS.
+
+### Task 25: SyllableValidatorPlugin
+
+**Files:**
+- Create: `src/core/engine/plugins/SyllableValidatorPlugin.h`
+- Create: `src/core/engine/plugins/SyllableValidatorPlugin.cpp`
+- Create: `rules/dictionary.toml` (auto-converted from gonhanh's `vi.dic`)
+- Create: `tests/SyllableValidatorPluginTest.cpp`
+
+- [ ] **Step 1:** Convert gonhanh's `vi.dic` (6711 từ, plain text) → `rules/dictionary.toml` (TOML wordlist).
+- [ ] **Step 2:** SyllableValidatorPlugin loads dict at startup, builds `std::unordered_set<std::wstring>`.
+- [ ] **Step 3:** Implement `OnPostAction`:
+   - If `!enabled_` → PASS (free mode).
+   - If buf in user exception list → PASS.
+   - If buf in dict → PASS.
+   - Else → ROLLBACK.
+- [ ] **Step 4:** Wire `freeTyping_` config flag (existing, in user.toml) → `validatorPlugin_.SetEnabled(!freeTyping)`.
+- [ ] **Step 5:** Tests: dict word PASS, non-dict word ROLLBACK, user exception PASS, free mode all PASS.
+- [ ] **Step 6:** Diff harness rerun: 31,757 still PASS.
+
+### Task 26: D3 commit
+
+- [ ] **Step 1:** Commit `Sprint 3 D3: plugin event bus + SyllableValidator (free/strict toggle)`.
+
+---
+
+## D4 — HookEngine swap + chaos
+
+Goal: HookEngine routes through FsmDispatcher. TypingEngine code unreachable but compiled. Chaos 55/55 PASS on Win.
+
+### Task 27: HookEngine route swap
+
+**Files:**
+- Modify: `src/app/system/HookEngine.cpp`
+- Modify: `src/app/system/HookEngine.h`
+
+- [ ] **Step 1:** Replace `typingEngine_->ProcessChar` calls with `fsmDispatcher_->ProcessKey`. Bridge return value (HookVerdict::EATEN → eat key, PASS_THROUGH → call next hook).
+- [ ] **Step 2:** Replace `typingEngine_->ProcessBackspace` with `fsmDispatcher_->ProcessBackspace`.
+- [ ] **Step 3:** Wire `fsmDispatcher_` in HookEngine ctor — pass injector pointer (existing) + plugin bus + initial keymap/table.
+- [ ] **Step 4:** Wire focus change: `OnFocusChange` → `fsmDispatcher_->SetActiveInjector(newInjector)`.
+- [ ] **Step 5:** Wire config change (Sprint 1 D9 MainThreadWorker handler): `freeTyping` config change → `validatorPlugin_->SetEnabled(...)`.
+- [ ] **Step 6:** Wire input method change: `inputMethod` config → `fsmDispatcher_->SetActiveKeymap(...)`.
+
+### Task 28: Chaos sweep
+
+- [ ] **Step 1:** Build NexusKey Debug Win.
+- [ ] **Step 2:** Run `tools/run-chaos.ps1 -RunnerExe build\tools\Debug\NextKeyTestRunner.exe` (5 host × 11 case sweep).
+- [ ] **Step 3:** Capture output: `docs/baselines/perf-baseline-fsm-d4-chaos.{md,csv,xml}`.
+- [ ] **Step 4:** Verdict: 55/55 PASS required. p99 not regress > 10% vs Sprint 2 baseline.
+- [ ] **Step 5:** If FAIL: stop, atomic revert, audit. Likely a case 31,757 corpus didn't cover.
+
+### Task 29: D4 commit
+
+- [ ] **Step 1:** Commit `Sprint 3 D4: HookEngine routes via FsmDispatcher (chaos 55/55 PASS)`.
+
+---
+
+## D5 — Delete TypingEngine + SpellChecker
+
+Goal: ~1,800 LOC dead code removed. Audit script update. Ship clean.
+
+### Task 30: Delete code
+
+**Files:**
+- Delete: `src/core/engine/TypingEngine.cpp` (1,603 LOC)
+- Delete: `src/core/engine/TypingEngine.h` (197 LOC)
+- Delete: `src/core/engine/SpellChecker.cpp`
+- Delete: `src/core/engine/SpellChecker.h`
+- Delete: `src/core/engine/EnglishProtection.{h,cpp}` (if logic migrated to plugin or unused)
+- Modify: `src/CMakeLists.txt` — drop sources
+- Modify: `tools/audit/check_hook_thread_no_mutex.sh` — drop checks for old field names
+
+- [ ] **Step 1:** Verify no `#include` references to deleted files (grep).
+- [ ] **Step 2:** Build clean Linux + Windows.
+- [ ] **Step 3:** Linux GTest PASS (TelexEngineTest.cpp consumed via diff harness; can delete or keep as archive — decide with anh).
+- [ ] **Step 4:** Windows compile clean.
+
+### Task 31: D5 commit
+
+- [ ] **Step 1:** Commit `Sprint 3 D5: delete TypingEngine + SpellChecker (~1800 LOC dead code removed)`.
+
+---
+
+## D6 — Final cleanup + PR
+
+### Task 32: Baseline doc
+
+**Files:**
+- Create: `docs/baselines/perf-baseline-fsm-final.md`
+
+- [ ] **Step 1:** Document final chaos 55/55 PASS. Compare p99 vs ChannelTraits (Sprint 2 ending) baseline.
+- [ ] **Step 2:** Document GTest count delta (1409 - existing + new tests).
+- [ ] **Step 3:** Document memory: `sizeof(FsmTable)` + `sizeof(Keymap)` + dictionary heap.
+- [ ] **Step 4:** Reference all 6 D-day commits.
+
+### Task 33: PR open
+
+- [ ] **Step 1:** Push `sprint-3/fsm-engine` branch.
+- [ ] **Step 2:** Open PR `feat: FSM engine refactor (Sprint 3 §1 + §4 plugin layer)`.
+- [ ] **Step 3:** PR body links: design doc, plan doc, baseline, all 6 commits.
+- [ ] **Step 4:** Anh review.
+
+### Task 34: D6 commit
+
+- [ ] **Step 1:** Commit `Sprint 3 D6: baseline + PR prep`.
+
+---
+
+## D7 — Buffer (0-2 days)
+
+If D2 audit > 2 days OR D4 chaos failure required investigation.
+
+---
+
+## Cross-cutting
+
+### Atomic field convention
+
+All RCU pointers (`activeKeymap_`, `activeFsmTable_`, `activeInjector_`) follow Sprint 1 D6 RCU pattern: `std::atomic<std::shared_ptr<const T>>`. Read with `std::atomic_load` (memory_order_acquire), write with `std::atomic_store` (release). Pre-tested in Sprint 1+2; no new concurrency invariant.
+
+### Audit script
+
+`tools/audit/check_hook_thread_no_mutex.sh` (Sprint 1 D7) — D5 task updates regex to drop deleted field names + add Check 6: "no use of `TypingEngine::` in HookEngine.cpp" (regression trap).
+
+### CI matrix
+
+- Linux Debug + GTest (existing).
+- Linux + codegen verify (re-run, diff vs committed).
+- Windows MSVC Debug compile (existing).
+- Windows manual chaos (D4 + D6 only).
+
+### Memory budget assertions
+
+`static_assert(sizeof(FsmTable) <= 100 * 1024)` at compile.
+`static_assert(sizeof(Keymap) <= 1024)` at compile.
+
+### Naming
+
+| Symbol | Source-of-truth |
+|---|---|
+| `NextKey::Engine::FsmDispatcher` | `src/core/engine/FsmDispatcher.h` |
+| `NextKey::Engine::FsmTable` | `generated/fsm_table_*.h` |
+| `NextKey::Engine::Keymap` | `generated/keymap_*.h` |
+| `NextKey::Engine::AbstractInput` | `generated/abstract_input.h` |
+| `NextKey::Engine::IFsmPlugin` | `src/core/engine/IFsmPlugin.h` |
+| `NextKey::Engine::FsmPluginBus` | `src/core/engine/FsmPluginBus.h` |
+| `NextKey::Engine::HistoryRingBuffer` | `src/core/engine/HistoryRingBuffer.h` |
+| `NextKey::Engine::CommitUndoSM` | `src/core/engine/CommitUndoSM.h` |
+| `NextKey::Engine::Plugins::SyllableValidatorPlugin` | `src/core/engine/plugins/SyllableValidatorPlugin.h` |
+
+---
+
+## Risk table
+
+| Risk | Probability | Mitigation |
+|---|---|---|
+| Codegen tool dev > 1 week | Medium | Use `automata-lib` library if Hopcroft impl complex. Time-box D-1 to 1 week, escalate. |
+| D2 mismatch > 2 days | Medium | Per-case review with anh. Some cases may accept FSM-correct (vd `cafcs`) over TypingEngine. |
+| D4 chaos < 55/55 | Low (corpus 31,757 + 11 chaos covers most) | Atomic revert D4. Add failing case to corpus. Retry next day. |
+| User custom keymap (#111) early-need | Low | UI defer to FSM-2. Keymap loading API designed extensible. |
+| Performance regression > 10% p99 | Low (FSM 87ns vs scan-back µs) | Benchmark gate at D6. If regress, investigate cache misses in dense table. |
+| Generated `.h` drift | Low | CI gate re-runs codegen, asserts no diff. |
+| License attribution missed | Low (audited) | `LICENSE-3RD-PARTY.md` + file headers (Task 19). |
+
+---
+
+## Sign-off
+
+Plan derived from [`2026-05-05-fsm-engine-refactor-design.md`](2026-05-05-fsm-engine-refactor-design.md). All 8 brainstorm decisions locked. Ready to start D-1.
+
+**Next concrete step:** create branch `sprint-3/codegen-tool` from Main, begin Task 1.


### PR DESCRIPTION
## Summary

Brainstorm session 2026-05-05 with anh on FSM engine refactor (CODE_GOVERNANCE §1 + §4). Adds 2 design docs:

- \`docs/plans/2026-05-05-fsm-engine-refactor-design.md\` (642 lines) — architecture, locked decisions, codegen pipeline, license audit
- \`docs/plans/sprint-3-fsm-engine-plan.md\` (687 lines) — D-1..D6 task breakdown with checkbox tracking

## 8 locked decisions (recorded in §1)

1. Migration: incremental D-day pattern (Sprint 1/2 proven).
2. Scope FSM-1: core + Telex/VNI/Combined keymap + plugin event bus contract. Macro/auto-cap/CJK plugin migration deferred to FSM-2. Issue #111 UI custom keymap deferred.
3. Spell-check is a plugin (toggle "Gõ tự do" = plugin off).
4. Shorthand \`cc→ch\` is a plugin, not FSM core.
5. Free typing has 2 levels (orthography by FSM construction, dictionary via SyllableValidatorPlugin).
6. FSM via codegen tool (NFA → DFA → Hopcroft → emit C++).
7. Dictionary: gonhanh.org \`vi.dic\` (BSD-3, 6711 từ).
8. Diff corpus: gonhanh.org \`vietnamese_telex_pairs.txt\` (BSD-3, 30,337 cases).

## License audit (§10)

- gonhanh.org BSD-3 ✅ compatible with NexusKey GPL-3
- PHTV AGPL-3 ❌ skip (license conflict)
- xkey MIT ✅ skip (Swift parse cost > benefit)

## Scope

**Doc-only PR** — no code changes. Implementation lands in follow-up PR \`tooling: FSM codegen tool (Sprint 3 D-1)\` on branch \`sprint-3/codegen-tool\`.

## Test plan

- [x] Both docs render correctly on GitHub
- [x] Cross-references between design + plan + governance docs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)