### PR TITLE
feat(classic): import / export spell-check exception list

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Cảm ơn các thành viên cộng đồng đã test và góp ý:
 - [huntersun](https://github.com/huntersun)
 - [haihv8x](https://github.com/haihv8x)
 - [os-hoanghv](https://github.com/os-hoanghv)
+- [Shzr0](https://github.com/Shzr0)
 
 ## License
 

--- a/src/app/classic/ClassicSpellExclusionsDialog.cpp
+++ b/src/app/classic/ClassicSpellExclusionsDialog.cpp
@@ -18,6 +18,8 @@ enum {
     IDC_SPELL_EDIT,
     IDC_SPELL_BTN_ADD,
     IDC_SPELL_BTN_DELETE,
+    IDC_SPELL_BTN_IMPORT,
+    IDC_SPELL_BTN_EXPORT,
 };
 
 // ════════════════════════════════════════════════════════════
@@ -139,6 +141,17 @@ void ClassicSpellExclusionsDialog::CreateControls() {
         WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON,
         x, y, Dpi(80), btnH,
         hwnd_, reinterpret_cast<HMENU>(IDC_SPELL_BTN_DELETE), hInstance_, nullptr);
+
+    int btnW2 = Dpi(75);
+    btnImport_ = CreateWindowExW(0, L"BUTTON", L"Nhập",
+        WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON,
+        x + cw - btnW2 * 2 - gap, y, btnW2, btnH,
+        hwnd_, reinterpret_cast<HMENU>(IDC_SPELL_BTN_IMPORT), hInstance_, nullptr);
+
+    btnExport_ = CreateWindowExW(0, L"BUTTON", L"Xuất",
+        WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON,
+        x + cw - btnW2, y, btnW2, btnH,
+        hwnd_, reinterpret_cast<HMENU>(IDC_SPELL_BTN_EXPORT), hInstance_, nullptr);
 }
 
 void ClassicSpellExclusionsDialog::PopulateList() {
@@ -188,6 +201,102 @@ void ClassicSpellExclusionsDialog::DeleteSelected() {
     entries_.erase(entries_.begin() + sel);
     PopulateList();
     SaveData();
+}
+
+void ClassicSpellExclusionsDialog::ImportFromFile() {
+    std::wstring path = OpenFileDialog(hwnd_, L"Text Files (*.txt)\0*.txt\0All Files\0*.*\0", L"Nhập danh sách loại trừ");
+    if (path.empty()) return;
+
+    // Ask replace or append
+    int choice = MessageBoxW(hwnd_,
+        L"Thay thế danh sách hiện tại hay thêm vào?",
+        L"Nhập file",
+        MB_YESNOCANCEL | MB_ICONQUESTION);
+    if (choice == IDCANCEL) return;
+
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        MessageBoxW(hwnd_, L"Không thể mở file.", L"Lỗi", MB_ICONERROR);
+        return;
+    }
+
+    if (choice == IDYES) entries_.clear();  // Replace
+
+    std::string line;
+    bool firstLine = true;
+    int added = 0;
+    while (std::getline(file, line)) {
+        // Strip CR if present
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+
+        // Strip UTF-8 BOM on first line
+        if (firstLine) {
+            firstLine = false;
+            if (line.size() >= 3 &&
+                static_cast<unsigned char>(line[0]) == 0xEF &&
+                static_cast<unsigned char>(line[1]) == 0xBB &&
+                static_cast<unsigned char>(line[2]) == 0xBF) {
+                line.erase(0, 3);
+            }
+        }
+
+        if (line.empty()) continue;
+
+        std::wstring wline = Utf8ToWide(line);
+
+        // Trim + validate
+        size_t s = 0, e = wline.size();
+        while (s < e && wline[s] == L' ') ++s;
+        while (e > s && wline[e - 1] == L' ') --e;
+        if (e - s < 2) continue;
+
+        std::wstring entry = wline.substr(s, e - s);
+        for (auto& ch : entry) ch = towlower(ch);
+
+        bool exists = false;
+        for (const auto& existing : entries_) {
+            if (existing == entry) { exists = true; break; }
+        }
+        if (!exists) {
+            entries_.push_back(entry);
+            added++;
+        }
+    }
+
+    std::sort(entries_.begin(), entries_.end());
+    PopulateList();
+    if (added > 0 || choice == IDYES) SaveData();
+
+    MessageBoxW(hwnd_,
+        (L"Đã nhập " + std::to_wstring(added) + L" từ mới.").c_str(),
+        L"Kết quả", MB_OK);
+}
+
+void ClassicSpellExclusionsDialog::ExportToFile() {
+    if (entries_.empty()) {
+        MessageBoxW(hwnd_, L"Danh sách trống.", L"Thông báo", MB_ICONINFORMATION);
+        return;
+    }
+
+    std::wstring path = SaveFileDialog(hwnd_, L"Text Files (*.txt)\0*.txt\0", L"Xuất danh sách loại trừ", L"txt");
+    if (path.empty()) return;
+
+    std::ofstream file(path, std::ios::binary);
+    if (!file.is_open()) {
+        MessageBoxW(hwnd_, L"Không thể tạo file.", L"Lỗi", MB_ICONERROR);
+        return;
+    }
+
+    // Write UTF-8 BOM
+    file.write("\xEF\xBB\xBF", 3);
+
+    for (const auto& entry : entries_) {
+        std::string utf8 = WideToUtf8(entry);
+        file.write(utf8.c_str(), utf8.size());
+        file.write("\r\n", 2);
+    }
+
+    MessageBoxW(hwnd_, L"Đã xuất danh sách thành công.", L"Thành công", MB_OK);
 }
 
 // ════════════════════════════════════════════════════════════
@@ -252,6 +361,12 @@ LRESULT CALLBACK ClassicSpellExclusionsDialog::WndProc(HWND hwnd, UINT msg, WPAR
                 }
                 case IDC_SPELL_BTN_DELETE:
                     self->DeleteSelected();
+                    return 0;
+                case IDC_SPELL_BTN_IMPORT:
+                    self->ImportFromFile();
+                    return 0;
+                case IDC_SPELL_BTN_EXPORT:
+                    self->ExportToFile();
                     return 0;
             }
             break;

--- a/src/app/classic/ClassicSpellExclusionsDialog.h
+++ b/src/app/classic/ClassicSpellExclusionsDialog.h
@@ -28,6 +28,8 @@ private:
     void PopulateList();
     void AddEntry(const std::wstring& text);
     void DeleteSelected();
+    void ImportFromFile();
+    void ExportToFile();
 
     void LoadData();
     void SaveData();
@@ -53,6 +55,8 @@ private:
     HWND editEntry_ = nullptr;
     HWND btnAdd_ = nullptr;
     HWND btnDelete_ = nullptr;
+    HWND btnImport_ = nullptr;
+    HWND btnExport_ = nullptr;
 
     // State
     std::vector<std::wstring> entries_;


### PR DESCRIPTION
## Summary

Adds **Nhập** / **Xuất** buttons to the Classic spell-check exception list dialog. Users can migrate exception lists across NexusKey installs, share team-wide lists via \`.txt\`, or back up before bulk edits.

## Changes

\`ClassicSpellExclusionsDialog\`:
- 2 new buttons in the bottom-right of the editor row
- \`ImportFromFile()\` — opens file picker (\`*.txt\` filter), reads UTF-8 (BOM-stripped, CR-trimmed), confirms replace-vs-append via MessageBoxW, deduplicates against current entries, sorts, persists, reports added count.
- \`ExportToFile()\` — save-as picker, writes one entry per line UTF-8.

Plus README contributor add (Shzr0).

## Scope

UI dialog only — no engine, hook, TSF code touched. Independent feature, no Sprint 3 dependency.

## Test plan

- [ ] Build NexusKey Debug
- [ ] Open Settings → Spell-check exclusion dialog → click "Nhập"
- [ ] Pick a UTF-8 \`.txt\` with 1 entry per line
- [ ] Confirm "Yes" (replace) → list replaced
- [ ] Click "Nhập" again → confirm "No" (append) → entries merged + dedup
- [ ] Click "Xuất" → save to \`.txt\` → re-open file in Notepad → entries 1 per line UTF-8
- [ ] Edge cases: empty file → 0 added; file with BOM → first entry not corrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)