### PR TITLE
Path G G-3.4 polish + G-3.5: unified modifier dispatch

### DIFF
--- a/src/core/engine/TypingEngine.cpp
+++ b/src/core/engine/TypingEngine.cpp
@@ -383,13 +383,13 @@ void TypingEngine::PushChar(wchar_t c) {
             if (!canEscape) {
                 canEscape = WouldModifierKeyMatchExclusion(lower);
             }
-            if (canEscape && ProcessTelexModifier(action, c, lower)) {
+            if (canEscape && ProcessModifier(action, c)) {
                 engProt_.bias = LanguageBias::Vietnamese;
                 ApplyAutoUO();
                 UpdateSpellState();
                 return;
             }
-        } else if (ProcessTelexModifier(action, c, lower)) {
+        } else if (ProcessModifier(action, c)) {
             engProt_.bias = LanguageBias::Vietnamese;
             ApplyAutoUO();
             UpdateSpellState();
@@ -427,13 +427,13 @@ void TypingEngine::PushChar(wchar_t c) {
             if (!canEscape) {
                 canEscape = WouldModifierKeyMatchExclusion(lower);
             }
-            if (canEscape && ProcessVniModifier(action, c)) {
+            if (canEscape && ProcessModifier(action, c)) {
                 engProt_.bias = LanguageBias::Vietnamese;
                 ApplyAutoUO();
                 UpdateSpellState();
                 return;
             }
-        } else if (ProcessVniModifier(action, c)) {
+        } else if (ProcessModifier(action, c)) {
             engProt_.bias = LanguageBias::Vietnamese;
             ApplyAutoUO();
             UpdateSpellState();
@@ -517,21 +517,55 @@ bool TypingEngine::ProcessClearTone() {
 }
 
 //-----------------------------------------------------------------------------
-// Telex modifier dispatcher — switch(TypingAction) fans out to per-action
-// handlers below plus the unchanged ProcessWModifier / ProcessDModifier.
+// Unified modifier dispatcher — single switch(TypingAction) covering both
+// Telex and VNI modifier actions. PushChar gates per-mode pre-checks (English
+// protection, escape, spell-check disabled) and then routes the approved
+// action here. Handler signature is uniform `(TypingAction, wchar_t)` so this
+// stays a flat fan-out — foundation for G-4 customKeyMap.
 //-----------------------------------------------------------------------------
 
-bool TypingEngine::ProcessTelexModifier(TypingAction action, wchar_t c, wchar_t lower) {
+bool TypingEngine::ProcessModifier(TypingAction action, wchar_t c) {
     switch (action) {
         case TypingAction::HornInsertO:
         case TypingAction::HornInsertU: return HandleHornInsert(action, c);
-        case TypingAction::HornW:       return ProcessWModifier(c);
+        case TypingAction::HornW:       return HandleHornW(action, c);
         case TypingAction::CircumflexA:
         case TypingAction::CircumflexE:
-        case TypingAction::CircumflexO: return HandleAdjacentCircumflex(c, lower);
-        case TypingAction::StrokeD:     return ProcessDModifier(c);
-        default:                         return false;
+        case TypingAction::CircumflexO: return HandleAdjacentCircumflex(action, c);
+        case TypingAction::StrokeD:     return HandleStrokeD(action, c);
+        case TypingAction::VniCircumflex: return HandleVniCircumflex(action, c);
+        case TypingAction::VniHorn:       return HandleVniHorn(action, c);
+        case TypingAction::VniBreve:      return HandleVniBreve(action, c);
+        case TypingAction::VniStroke:     return HandleStrokeD(action, c);
+        default:                          return false;
     }
+}
+
+// Thin wrappers giving the Process* implementation methods a uniform
+// `(TypingAction, wchar_t)` shape so ProcessModifier can dispatch them
+// alongside the natively-uniform handlers (HandleHornInsert,
+// HandleAdjacentCircumflex). The `action` arg is unused for handlers
+// that are 1:1 with their action; HandleVniCircumflex/Breve forward to
+// the Modifier-parameterised VNI vowel modifier helper.
+
+bool TypingEngine::HandleHornW(TypingAction /*action*/, wchar_t c) {
+    return ProcessWModifier(c);
+}
+
+bool TypingEngine::HandleStrokeD(TypingAction /*action*/, wchar_t c) {
+    return ProcessDModifier(c);
+}
+
+bool TypingEngine::HandleVniHorn(TypingAction /*action*/, wchar_t c) {
+    return ProcessVniHornModifier(c);
+}
+
+bool TypingEngine::HandleVniCircumflex(TypingAction /*action*/, wchar_t c) {
+    return ProcessVniVowelModifier(Modifier::Circumflex, c);
+}
+
+bool TypingEngine::HandleVniBreve(TypingAction /*action*/, wchar_t c) {
+    return ProcessVniVowelModifier(Modifier::Breve, c);
 }
 
 bool TypingEngine::HandleHornInsert(TypingAction action, wchar_t c) {
@@ -564,10 +598,11 @@ bool TypingEngine::HandleHornInsert(TypingAction action, wchar_t c) {
     return true;
 }
 
-bool TypingEngine::HandleAdjacentCircumflex(wchar_t c, wchar_t lower) {
+bool TypingEngine::HandleAdjacentCircumflex(TypingAction /*action*/, wchar_t c) {
     // Dispatcher only routes a/e/o here; defensively bail when there's no
     // prior state to apply circumflex against.
     if (states_.empty()) return false;
+    const wchar_t lower = towlower(c);
 
     CharState& last = states_.back();
 
@@ -1438,17 +1473,9 @@ bool TypingEngine::WouldModifierKeyMatchExclusion(wchar_t lower) const {
 
 //-----------------------------------------------------------------------------
 // VNI Modifier Processing (keys 6, 7, 8, 9)
+// G-3.5: dispatch lives in ProcessModifier; the helpers below are called
+// via the HandleVni{Horn,Circumflex,Breve} wrappers.
 //-----------------------------------------------------------------------------
-
-bool TypingEngine::ProcessVniModifier(TypingAction action, wchar_t c) {
-    switch (action) {
-        case TypingAction::VniStroke:     return ProcessDModifier(c);
-        case TypingAction::VniHorn:       return ProcessVniHornModifier(c);
-        case TypingAction::VniCircumflex: return ProcessVniVowelModifier(Modifier::Circumflex, c);
-        case TypingAction::VniBreve:      return ProcessVniVowelModifier(Modifier::Breve, c);
-        default:                           return false;
-    }
-}
 
 bool TypingEngine::ProcessVniHornModifier(wchar_t c) {
     if (states_.empty()) return false;

--- a/src/core/engine/TypingEngine.cpp
+++ b/src/core/engine/TypingEngine.cpp
@@ -63,6 +63,16 @@ constexpr bool IsVniModifierAction(TypingAction a) noexcept {
            a == TypingAction::VniStroke;
 }
 
+constexpr Modifier ActionToVniModifier(TypingAction a) noexcept {
+    switch (a) {
+        case TypingAction::VniCircumflex: return Modifier::Circumflex;
+        case TypingAction::VniHorn:       return Modifier::Horn;
+        case TypingAction::VniBreve:      return Modifier::Breve;
+        case TypingAction::VniStroke:     return Modifier::Stroke;
+        default:                           return Modifier::None;
+    }
+}
+
 constexpr int ModifierIndex(Modifier mod) noexcept {
     switch (mod) {
         case Modifier::Circumflex: return 0;
@@ -408,11 +418,7 @@ void TypingEngine::PushChar(wchar_t c) {
         } else if (config_.spellCheckEnabled && spellCheckDisabled_) {
             // Allow VNI modifier escape or spell exclusion match
             bool canEscape = false;
-            Modifier escMod = Modifier::None;
-            if (c == L'6') escMod = Modifier::Circumflex;
-            else if (c == L'7') escMod = Modifier::Horn;
-            else if (c == L'8') escMod = Modifier::Breve;
-            else if (c == L'9') escMod = Modifier::Stroke;
+            Modifier escMod = ActionToVniModifier(action);
             if (escMod == Modifier::Stroke) {
                 canEscape = HasEscapableModifier(states_.data(), states_.size(), escMod, true);
             } else if (escMod != Modifier::None) {
@@ -511,13 +517,14 @@ bool TypingEngine::ProcessClearTone() {
 }
 
 //-----------------------------------------------------------------------------
-// Modifier Processing (W, [], AA, EE, OO, DD) - TABLE-DRIVEN
+// Telex modifier dispatcher — switch(TypingAction) fans out to per-action
+// handlers below plus the unchanged ProcessWModifier / ProcessDModifier.
 //-----------------------------------------------------------------------------
 
 bool TypingEngine::ProcessTelexModifier(TypingAction action, wchar_t c, wchar_t lower) {
     switch (action) {
-        case TypingAction::HornInsertO: return HandleHornInsertO(c);
-        case TypingAction::HornInsertU: return HandleHornInsertU(c);
+        case TypingAction::HornInsertO:
+        case TypingAction::HornInsertU: return HandleHornInsert(action, c);
         case TypingAction::HornW:       return ProcessWModifier(c);
         case TypingAction::CircumflexA:
         case TypingAction::CircumflexE:
@@ -527,15 +534,19 @@ bool TypingEngine::ProcessTelexModifier(TypingAction action, wchar_t c, wchar_t 
     }
 }
 
-bool TypingEngine::HandleHornInsertO(wchar_t c) {
-    // SimpleTelex omits bracket keys — let `[` fall through to literal.
+bool TypingEngine::HandleHornInsert(TypingAction action, wchar_t c) {
+    // SimpleTelex omits bracket keys — let `[`/`]` fall through to literal.
     if (config_.inputMethod == InputMethod::SimpleTelex) return false;
 
-    // Escape: [[ → undo inserted ơ, produce literal '['
+    const wchar_t bracketChar = (action == TypingAction::HornInsertO) ? L'[' : L']';
+    const wchar_t baseVowel   = (action == TypingAction::HornInsertO) ? L'o' : L'u';
+
+    // Escape: doubled bracket (`[[` or `]]`) undoes the just-inserted ơ/ư
+    // and produces the bracket literal.
     if (!states_.empty() && rawInput_.size() >= 2 &&
-        rawInput_[rawInput_.size() - 2] == L'[') {
+        rawInput_[rawInput_.size() - 2] == bracketChar) {
         CharState& last = states_.back();
-        if (last.base == L'o' && last.mod == Modifier::Horn) {
+        if (last.base == baseVowel && last.mod == Modifier::Horn) {
             size_t consumedIdx = last.rawIdx;
             states_.pop_back();
             EraseConsumedRaw(consumedIdx);
@@ -544,34 +555,9 @@ bool TypingEngine::HandleHornInsertO(wchar_t c) {
             return true;
         }
     }
-    // [ → insert 'ơ' (o with horn)
-    CharState s;
-    s.base = L'o';
-    s.mod = Modifier::Horn;
-    s.rawIdx = rawInput_.empty() ? 0 : rawInput_.size() - 1;
-    states_.push_back(s);
-    return true;
-}
 
-bool TypingEngine::HandleHornInsertU(wchar_t c) {
-    if (config_.inputMethod == InputMethod::SimpleTelex) return false;
-
-    // Escape: ]] → undo inserted ư, produce literal ']'
-    if (!states_.empty() && rawInput_.size() >= 2 &&
-        rawInput_[rawInput_.size() - 2] == L']') {
-        CharState& last = states_.back();
-        if (last.base == L'u' && last.mod == Modifier::Horn) {
-            size_t consumedIdx = last.rawIdx;
-            states_.pop_back();
-            EraseConsumedRaw(consumedIdx);
-            ProcessChar(c);
-            escape_.escape(EscapeKind::Horn);
-            return true;
-        }
-    }
-    // ] → insert 'ư' (u with horn)
     CharState s;
-    s.base = L'u';
+    s.base = baseVowel;
     s.mod = Modifier::Horn;
     s.rawIdx = rawInput_.empty() ? 0 : rawInput_.size() - 1;
     states_.push_back(s);

--- a/src/core/engine/TypingEngine.h
+++ b/src/core/engine/TypingEngine.h
@@ -131,8 +131,8 @@ private:
 
     // Per-action Telex modifier handlers (G-3.3 extraction). Each returns
     // true on consumption, false to fall through to ProcessChar (literal).
-    bool HandleHornInsertO(wchar_t c);   // Telex `[` — inserts ơ, escapes `[[`
-    bool HandleHornInsertU(wchar_t c);   // Telex `]` — inserts ư, escapes `]]`
+    // `action` (HornInsertO|HornInsertU) selects the bracket char + base vowel.
+    bool HandleHornInsert(TypingAction action, wchar_t c);
     bool HandleAdjacentCircumflex(wchar_t c, wchar_t lower);  // aa/ee/oo + cross-vowel free-marking
 
     void ProcessChar(wchar_t c) { ProcessChar(c, towlower(c), iswupper(c)); }

--- a/src/core/engine/TypingEngine.h
+++ b/src/core/engine/TypingEngine.h
@@ -120,28 +120,38 @@ private:
                config_.inputMethod == InputMethod::Combined;
     }
 
-    // Input processing — Telex
+    // Tone keys (Telex z/s/f/r/x/j, VNI 0/1/2/3/4/5) — handled inline in PushChar.
     bool ProcessTone(Tone tone, wchar_t keyChar, size_t cachedTarget = SIZE_MAX);
-    bool ProcessClearTone();          // z/0 — remove existing tone
+    bool ProcessClearTone();
 
-    // Telex modifier dispatcher — fans out to per-action handlers below.
-    // `action` is the TypingAction classified by PushChar (HornInsertO,
-    // HornInsertU, HornW, CircumflexA/E/O, StrokeD); other actions yield false.
-    bool ProcessTelexModifier(TypingAction action, wchar_t c, wchar_t lower);
-
-    // Per-action Telex modifier handlers (G-3.3 extraction). Each returns
-    // true on consumption, false to fall through to ProcessChar (literal).
-    // `action` (HornInsertO|HornInsertU) selects the bracket char + base vowel.
-    bool HandleHornInsert(TypingAction action, wchar_t c);
-    bool HandleAdjacentCircumflex(wchar_t c, wchar_t lower);  // aa/ee/oo + cross-vowel free-marking
+    // Unified modifier dispatch (G-3.5). Single entry point for every
+    // user-mappable modifier action — both Telex and VNI. Switches on
+    // TypingAction and forwards to the per-action handlers below. The
+    // Telex/VNI split lives in PushChar's gating (English protection,
+    // escape, spell-check disabled paths) — once the action is approved,
+    // it's the same dispatch. Foundation for G-4 customKeyMap.
+    bool ProcessModifier(TypingAction action, wchar_t c);
 
     void ProcessChar(wchar_t c) { ProcessChar(c, towlower(c), iswupper(c)); }
     void ProcessChar(wchar_t c, wchar_t lower, bool isUpper);
 
-    // VNI modifier dispatcher — fans out to per-action handlers below.
-    // `action` is the TypingAction classified by PushChar (VniCircumflex,
-    // VniHorn, VniBreve, VniStroke); other actions yield false.
-    bool ProcessVniModifier(TypingAction action, wchar_t c);
+    // Per-action modifier handlers. Uniform `(TypingAction, wchar_t)`
+    // signature so ProcessModifier can dispatch them by action without
+    // per-handler thunks. Each returns true on consumption, false to
+    // fall through to ProcessChar (literal). `action` selects sub-
+    // behaviour where one handler covers multiple actions (HornInsert,
+    // AdjacentCircumflex); ignored where it's 1:1.
+    bool HandleHornInsert(TypingAction action, wchar_t c);          // Telex `[`/`]`
+    bool HandleAdjacentCircumflex(TypingAction action, wchar_t c);  // Telex aa/ee/oo + cross-vowel
+    bool HandleHornW(TypingAction action, wchar_t c);               // Telex w (P1-P8)
+    bool HandleStrokeD(TypingAction action, wchar_t c);             // Telex dd / VNI 9
+    bool HandleVniHorn(TypingAction action, wchar_t c);             // VNI 7
+    bool HandleVniCircumflex(TypingAction action, wchar_t c);       // VNI 6
+    bool HandleVniBreve(TypingAction action, wchar_t c);             // VNI 8
+
+    // Internal helpers used by Handle* wrappers above. The Modifier-
+    // parameterised VNI helper stays here (rather than splitting per-
+    // modifier) so the cross-vowel scan logic isn't duplicated.
     bool ProcessVniHornModifier(wchar_t c);
     bool ProcessVniVowelModifier(Modifier targetMod, wchar_t key);
 


### PR DESCRIPTION
## Summary

Two-commit cluster following the parallel-agent code review of PR #135 (G-3.3 + G-3.4). Cleanup applied first, then the dispatch shape collapsed to a single entry point. Foundation for G-4 customKeyMap.

- **`6e20cf7` G-3.4 polish** — three high-confidence review fixes:
  1. Unify `HandleHornInsertO` + `HandleHornInsertU` into `HandleHornInsert(TypingAction, wchar_t)` — they were 95%-identical mirrors differing only in bracket char + base vowel. Saves ~28 LOC of verbatim duplication.
  2. Replace the if-chain on `c` in PushChar's VNI escape branch with a new `ActionToVniModifier(TypingAction)` helper. The chain re-classified the key right after `ClassifyKey` already did so.
  3. Drop the stale `Modifier Processing ... TABLE-DRIVEN` comment that survived from a prior iteration; the function it heads is a dispatcher, not a table.

  Deferred (tracked for follow-up): `c/k/m/n/p/t` valid-coda predicate lift to a shared helper (touches `EnglishProtection.h`, beyond PR scope), `HandleAdjacentCircumflex` rename, nested-conditional flatten in the cross-vowel scan.

- **`488fc85` G-3.5** — collapse `ProcessTelexModifier` + `ProcessVniModifier` into a single `ProcessModifier(TypingAction, wchar_t)`. PushChar's per-mode gating (English protection, escape, spell-check disabled) stays in 2a / 2b; once the action is approved, both routes call the same dispatch. All handlers now share the uniform `(TypingAction action, wchar_t c)` signature so the dispatcher fans out without per-handler thunks. Five thin wrappers adapt the 1:1 impl methods (`ProcessWModifier`, `ProcessDModifier`, `ProcessVniHornModifier`, plus `HandleVniCircumflex` / `HandleVniBreve` for the Modifier-parameterised `ProcessVniVowelModifier`). `HandleAdjacentCircumflex` drops `(c, lower)` for `(action, c)` and derives lower internally.

## Verification

- Linux GTest: **1450/1450 PASS** (no new tests; behavior preservation only)
- Windows MSVC: **pending @phatMT97 local verify**

## Test Plan

- [ ] Anh build Windows MSVC (/W4 /WX)
- [ ] CI green
- [ ] Manual smoke: Telex `[`/`]` (insert ơ/ư + `[[`/`]]` escape), Telex aa/ee/oo + cross-vowel free-marking, Telex w (P1-P8), Telex dd, VNI 6/7/8/9, Combined mode
- [ ] SimpleTelex still ignores brackets

## Why this shape

Foundation for **G-4 customKeyMap**: `key → TypingAction → ProcessModifier(action, c)`. Rebinding a key in user config just changes the `TypingAction` lookup; the engine code path stays identical. Today the lookup is `ClassifyKey` (key+mode → action); tomorrow it'll be `customKeyMap[key]` falling through to `ClassifyKey`.

## Out of scope (Path G follow-up)

- **G-3.6** (cleanup): measure final TypingEngine.cpp LOC vs ~1300 brainstorm target; decide if `ProcessWModifier`/`ProcessDModifier`/`ProcessVniHornModifier` should be inlined into their `Handle*` wrappers (rename) or kept separate (current state).
- **G-4**: `customKeyMap: array<TypingAction, 256>` field in `TypingConfig` + override layer in PushChar.
- **G-5..G-6**: Sciter UI, Unikey/EVKey import/export.