### PR TITLE
Path G G-3.6: inline Process* impls into Handle* wrappers (closes G-3)

### DIFF
--- a/src/core/engine/TypingEngine.cpp
+++ b/src/core/engine/TypingEngine.cpp
@@ -548,18 +548,6 @@ bool TypingEngine::ProcessModifier(TypingAction action, wchar_t c) {
 // that are 1:1 with their action; HandleVniCircumflex/Breve forward to
 // the Modifier-parameterised VNI vowel modifier helper.
 
-bool TypingEngine::HandleHornW(TypingAction /*action*/, wchar_t c) {
-    return ProcessWModifier(c);
-}
-
-bool TypingEngine::HandleStrokeD(TypingAction /*action*/, wchar_t c) {
-    return ProcessDModifier(c);
-}
-
-bool TypingEngine::HandleVniHorn(TypingAction /*action*/, wchar_t c) {
-    return ProcessVniHornModifier(c);
-}
-
 bool TypingEngine::HandleVniCircumflex(TypingAction /*action*/, wchar_t c) {
     return ProcessVniVowelModifier(Modifier::Circumflex, c);
 }
@@ -734,10 +722,10 @@ bool TypingEngine::HandleAdjacentCircumflex(TypingAction /*action*/, wchar_t c) 
 }
 
 //-----------------------------------------------------------------------------
-// W-Modifier Processing - EXPLICIT PRIORITY ORDER
+// HandleHornW — Telex `w` modifier (EXPLICIT PRIORITY ORDER P1-P8)
 //-----------------------------------------------------------------------------
 
-bool TypingEngine::ProcessWModifier(wchar_t c) {
+bool TypingEngine::HandleHornW(TypingAction /*action*/, wchar_t c) {
     // Simple Telex: 'w' only acts as modifier when preceded by a/o/u vowel
     if (config_.inputMethod == InputMethod::SimpleTelex) {
         bool hasVowelContext = false;
@@ -990,11 +978,11 @@ bool TypingEngine::ProcessWModifier(wchar_t c) {
 }
 
 //-----------------------------------------------------------------------------
-// D-Modifier Processing (dd → đ)
+// HandleStrokeD — Telex `dd` / VNI `9` (dd → đ)
 // Scan logic via FindStrokeDTarget (EngineHelpers.h)
 //-----------------------------------------------------------------------------
 
-bool TypingEngine::ProcessDModifier(wchar_t c) {
+bool TypingEngine::HandleStrokeD(TypingAction /*action*/, wchar_t c) {
     if (escape_.isEscaped(EscapeKind::Stroke)) return false;
     size_t dIdx = FindStrokeDTarget(states_.data(), states_.size());
     if (dIdx == SIZE_MAX) return false;
@@ -1472,15 +1460,15 @@ bool TypingEngine::WouldModifierKeyMatchExclusion(wchar_t lower) const {
 }
 
 //-----------------------------------------------------------------------------
-// VNI Modifier Processing (keys 6, 7, 8, 9)
-// G-3.5: dispatch lives in ProcessModifier; the helpers below are called
-// via the HandleVni{Horn,Circumflex,Breve} wrappers.
+// HandleVniHorn — VNI `7` (uo pair cycle + standalone u/o horn)
+// HandleVniCircumflex / HandleVniBreve are thin wrappers over
+// ProcessVniVowelModifier below; HandleStrokeD covers VNI `9`.
 //-----------------------------------------------------------------------------
 
-bool TypingEngine::ProcessVniHornModifier(wchar_t c) {
+bool TypingEngine::HandleVniHorn(TypingAction /*action*/, wchar_t c) {
     if (states_.empty()) return false;
 
-    // --- uo pair cycle (same logic as Telex ProcessWModifier P2) ---
+    // --- uo pair cycle (same logic as Telex HandleHornW P2) ---
     size_t uIdx = SIZE_MAX, oIdx = SIZE_MAX;
     for (size_t i = 0; i < states_.size(); ++i) {
         if (!states_[i].IsVowel()) continue;

--- a/src/core/engine/TypingEngine.h
+++ b/src/core/engine/TypingEngine.h
@@ -149,10 +149,10 @@ private:
     bool HandleVniCircumflex(TypingAction action, wchar_t c);       // VNI 6
     bool HandleVniBreve(TypingAction action, wchar_t c);             // VNI 8
 
-    // Internal helpers used by Handle* wrappers above. The Modifier-
-    // parameterised VNI helper stays here (rather than splitting per-
-    // modifier) so the cross-vowel scan logic isn't duplicated.
-    bool ProcessVniHornModifier(wchar_t c);
+    // ProcessVniVowelModifier is the shared backing impl for VniCircumflex
+    // and VniBreve — kept Modifier-parameterised so the cross-vowel scan
+    // isn't duplicated. HandleVniCircumflex / HandleVniBreve are the
+    // dispatch entry points that supply the right Modifier.
     bool ProcessVniVowelModifier(Modifier targetMod, wchar_t key);
 
     // Find target for tone/modifier application — delegates to phonotactics_.
@@ -168,12 +168,6 @@ private:
     // Move tone to correct target after modifier changes priority
     // Example: "chuanr" + a → tone moves from u to â (circumflex has higher priority)
     void RelocateToneToTarget();
-
-    // W-Modifier processing (explicit priority order)
-    bool ProcessWModifier(wchar_t c);
-
-    // D-Modifier processing (dd/d9 → đ)
-    bool ProcessDModifier(wchar_t c);
 
     // QU Cluster detection (qu is consonant cluster, u is not vowel)
     bool IsInQUCluster() const;

--- a/tests/SpellCheckerTest.cpp
+++ b/tests/SpellCheckerTest.cpp
@@ -363,7 +363,7 @@ TEST_F(TelexSpellCheckTest, ValidWord_Duoc) {
     // d → state [d]
     // u → state [d, u]
     // o → state [d, u, o]
-    // w → ProcessWModifier: u+o pattern → horn on o → [d, u, ơ] → AutoUO → [d, ư, ơ]
+    // w → HandleHornW: u+o pattern → horn on o → [d, u, ơ] → AutoUO → [d, ư, ơ]
     // c → ProcessChar [d, ư, ơ, c]
     // s → ProcessTone: acute on ơ → [d, ư, ớ, c] → "dước"
     // Actually 'd' at start has no modifier, so it's just 'd' not 'đ'


### PR DESCRIPTION
## Summary

Closes Sprint 3 Path G G-3. Removes the three thin wrappers introduced in G-3.5 by renaming the underlying `Process*` implementations to their `Handle*` counterparts. Each dispatch entry point is now also the implementation — no indirection on the keystroke hot path.

- `ProcessWModifier` (250 LOC P1-P8 cascade) → `HandleHornW`
- `ProcessDModifier` (22 LOC) → `HandleStrokeD`
- `ProcessVniHornModifier` (83 LOC) → `HandleVniHorn`

`ProcessVniVowelModifier` stays — it's the shared backing impl for `HandleVniCircumflex` + `HandleVniBreve`, which still wrap with the `Modifier::Circumflex` / `Modifier::Breve` discriminator (per-modifier split would duplicate the cross-vowel scan).

Section banners updated to the new names. One stale `ProcessWModifier` reference in `HandleVniHorn`'s uo-pair comment (cpp:1471) and the `SpellCheckerTest.cpp` docstring follow.

## Verification

- Linux GTest: **1450/1450 PASS**
- Windows MSVC: **pending @phatMT97 local verify**

## Test Plan

- [ ] Anh build Windows MSVC (/W4 /WX)
- [ ] CI green
- [ ] Manual smoke: Telex w (P1-P8), dd, VNI 6/7/8/9, Combined

## Final Path G state on Main after this merges

Modifier dispatch is now: PushChar → ClassifyKey → ProcessModifier(action, c) → switch → Handle*(action, c). Six Handle* implementations cover the 11 modifier actions (HornInsert{O,U} share, Circumflex{A,E,O} share, StrokeD shared by Telex dd + VNI 9). Wrapper count: zero on the dispatch path; two for the VniVowel split that backs onto a shared scan. Foundation ready for G-4 customKeyMap.

LOC trajectory across G-3:
- Pre-G-3 base (Main 54e379b): ~1645 LOC TypingEngine.cpp
- Post-G-3.6 (this PR): 1657 LOC TypingEngine.cpp + 221 LOC TypingEngine.h

The brainstorm "~1300 LOC" target is unmet — the dispatch refactor reorganises rather than reduces. Net +12 LOC reflects the added unified `ProcessModifier`, six Handle\* signatures with comments, and `TypingAction.h` include — paid for by clearer dispatch shape and customKeyMap-readiness.

## Out of scope

- **G-4**: `customKeyMap: array<TypingAction, 256>` field in `TypingConfig` + override layer in PushChar before `ClassifyKey`. The dispatch shape on Main is now ready to plug into.
- **G-5..G-6**: Sciter UI + per-user keymap files + Unikey/EVKey import/export.