### PR TITLE
Sprint 3 Path G G-4: customKeyMap engine hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,6 +428,7 @@ set(NEXTKEY_TEST_SOURCES
     tests/SpellCheckerTest.cpp
     tests/PhonotacticsTest.cpp
     tests/TypingActionTest.cpp
+    tests/CustomKeyMapTest.cpp
     tests/CodeTableConverterTest.cpp
     tests/UpdateSecurityTest.cpp
     tests/EngineBenchmarkTest.cpp

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,5 +1,40 @@
 # NexusKey Refactor — Sprint 1 Handoff (Notepad 11/11, Chrome 10/11, D13 next)
 
+## 2026-05-07 — Sprint 3 Path G G-4 COMPLETE (CURRENT PICKUP NOTE)
+
+**Branch:** `sprint-3/path-g-customkeymap`. **Goal:** engine-side per-key user override layer.
+
+**Commits:**
+1. G-4.1 — `customKeyMap` field on TypingConfig (default-init all `None`).
+2. G-4.2 — G1 regression tests (default-empty parity, 3 cases).
+3. G-4.3 — Dispatch hook at `TypingEngine.cpp:235` + G2 user-wins tests (2 cases).
+4. G-4.4 — G3-G7 tests (22 cases): gap-fill, ASCII boundary, digit-sequence interaction, sentinel, all-actions parametric.
+
+**Final dispatch shape (G-4):**
+
+```
+PushChar(c)
+  └─ lower = towlower(c)
+  └─ if (lower < 128 && customKeyMap[lower] != None)
+        action = customKeyMap[lower]            ← user override wins
+     else
+        action = ClassifyKey(lower, isTelex, isVni)
+  └─ if (isVniDigitSequence) action = None       ← literal-digit guard post-applies
+  └─ ProcessModifier(action, c) → 6 Handle*
+```
+
+**Test counts:** 1450 (post-G-3) + 27 (G-4 new) = **1477 cases on Linux**.
+
+**Files touched:** `src/core/config/TypingConfig.h` (+1 field, +2 includes), `src/core/engine/TypingEngine.cpp` (+4 LOC at line 235), `tests/CustomKeyMapTest.cpp` (NEW, ~250 LOC), `CMakeLists.txt` (+1 test source).
+
+**Out of scope (deferred to G-5):** TOML schema, Sciter dialog, per-user `keymap_<name>.toml` files, active-method selector. ConfigManager untouched in G-4.
+
+### NEXT — G-5 keymap files + UI
+
+Wire ConfigManager to load per-user `keymap_<name>.toml` files into `TypingConfig.customKeyMap`. Add Sciter dialog for editing. Add `[input].active_user_method` field to select which keymap is loaded. Reuse the existing 7-file split pattern (see `ConfigManager.cpp`).
+
+---
+
 ## 2026-05-07 — Sprint 3 Path G G-3 COMPLETE (CURRENT PICKUP NOTE)
 
 **Main HEAD:** `56f48ed` (PR #137 merged). All Path G G-1..G-3.6 shipped via 4 PRs:

--- a/docs/superpowers/plans/2026-05-07-path-g-g4-customkeymap.md
+++ b/docs/superpowers/plans/2026-05-07-path-g-g4-customkeymap.md
@@ -1,0 +1,723 @@
+# Path G — G-4 customKeyMap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-key user override layer to the TypingEngine dispatch pipeline so users can remap any ASCII key to any `TypingAction` via `TypingConfig::customKeyMap`. Default-empty preserves all 1450 existing GTests byte-identically.
+
+**Architecture:** A `std::array<TypingAction, 128>` field on `TypingConfig` holds the remap. Default-init to all `TypingAction::None`. In `TypingEngine::PushChar`, before calling `ClassifyKey`, look up `customKeyMap[lower]`; if non-`None`, use it; otherwise fall through to `ClassifyKey`. The existing `isVniDigitSequence` literal-digit guard post-applies. `ClassifyKey` itself is unchanged — pure rule layer stays pure.
+
+**Tech Stack:** C++20, GoogleTest (Linux build target `NextKeyTests`), CMake. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-path-g-g4-customkeymap-design.md` (commit `cb181ff`).
+
+**Branch:** `sprint-3/path-g-customkeymap` off `Main` at `cb181ff`.
+
+**Out of scope (deferred to G-5):** ConfigManager TOML wiring, Sciter UI dialog, per-user `keymap_<name>.toml` files, active-method selector, conflict warnings.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/core/config/TypingConfig.h` | Modify | Add `customKeyMap` field + 2 includes |
+| `src/core/engine/TypingEngine.cpp` | Modify | Replace dispatch at line 235 with override-then-fallback |
+| `tests/CustomKeyMapTest.cpp` | Create | All 7 test groups (G1–G7) for the override layer |
+| `CMakeLists.txt` | Modify | Append new test source to `NEXTKEY_TEST_SOURCES` |
+| `HANDOFF.md` | Modify | Mark G-4 complete; flag G-5 as next pickup |
+
+Untouched (deliberately): `src/core/engine/TypingAction.h`, `src/core/config/ConfigManager.{h,cpp}`, all engine handlers, all dialogs.
+
+---
+
+## Task 1 — Branch off Main
+
+**Files:** N/A (workspace setup).
+
+- [ ] **Step 1: Confirm clean working tree on Main at `cb181ff`**
+
+```bash
+git status
+git log --oneline -1
+```
+
+Expected: `working tree clean`, HEAD shows `cb181ff docs(spec): G-4 customKeyMap engine hook design`.
+
+- [ ] **Step 2: Branch off Main**
+
+```bash
+git checkout -b sprint-3/path-g-customkeymap Main
+```
+
+Expected: `Switched to a new branch 'sprint-3/path-g-customkeymap'`.
+
+---
+
+## Task 2 — Add `customKeyMap` field to `TypingConfig`
+
+**Files:**
+- Modify: `src/core/config/TypingConfig.h`
+
+This task is the prerequisite for tests to compile. No behavior change — default-init array of `TypingAction::None` makes the dispatch hook (added later) a no-op.
+
+- [ ] **Step 1: Add includes near the top of `TypingConfig.h`**
+
+In `src/core/config/TypingConfig.h`, **replace** the existing include block:
+
+```cpp
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+```
+
+with:
+
+```cpp
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "core/engine/TypingAction.h"
+```
+
+- [ ] **Step 2: Add the field at the end of `struct TypingConfig`**
+
+In `src/core/config/TypingConfig.h`, **find** the existing line:
+
+```cpp
+    std::vector<std::wstring> spellExclusions;  // Spell check exclusion prefixes (e.g. "hđ", "đp")
+```
+
+and **insert immediately after it** (before the `// Default constructor` comment):
+
+```cpp
+
+    /// Per-key user override (G-4). Index by ASCII code (`towlower(c)` of
+    /// the keystroke). Default-init = all `TypingAction::None`, which the
+    /// dispatcher treats as "no override → fall through to `ClassifyKey`".
+    /// G-5 will populate this from per-user keymap files; G-4 ships the
+    /// engine hook only.
+    std::array<TypingAction, 128> customKeyMap{};
+```
+
+- [ ] **Step 3: Build engine target on Linux to confirm no compile errors**
+
+```bash
+cmake -B build-linux -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug
+cmake --build build-linux --target NextKeyTests
+```
+
+Expected: build completes with no errors. (CMake re-configure not strictly required since we only added a header field, but the test target rebuilds anyway.)
+
+- [ ] **Step 4: Run all existing tests to confirm zero regressions**
+
+```bash
+./build-linux/tests/NextKeyTests
+```
+
+Expected: `[  PASSED  ] 1450 tests.` (the count from HANDOFF.md). Field exists but is read by no one yet, so behavior is identical.
+
+- [ ] **Step 5: Commit field-only change**
+
+```bash
+git add src/core/config/TypingConfig.h
+git commit -m "Sprint 3 Path G G-4.1: add customKeyMap field to TypingConfig
+
+Introduces std::array<TypingAction, 128> customKeyMap field, default-init
+to all TypingAction::None. No engine code reads it yet — dispatch hook
+lands in G-4.2. All 1450 existing GTests pass unchanged.
+
+Per spec docs/superpowers/specs/2026-05-07-path-g-g4-customkeymap-design.md
+section 3.1."
+```
+
+---
+
+## Task 3 — Create `CustomKeyMapTest.cpp` skeleton + G1 regression group
+
+**Files:**
+- Create: `tests/CustomKeyMapTest.cpp`
+- Modify: `CMakeLists.txt`
+
+G1 asserts that with `customKeyMap` default-empty, dispatch produces identical output to baseline. These tests pass before the dispatch hook exists (no read site means no change). They become the regression net.
+
+- [ ] **Step 1: Create the test file with G1 group**
+
+Create `tests/CustomKeyMapTest.cpp` with:
+
+```cpp
+// NexusKey - customKeyMap (G-4) Tests
+// Copyright (c) 2024-2026 PhatMT. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-NexusKey-Commercial
+//
+// Tests for the per-key user override layer added in Path G G-4.
+// Spec: docs/superpowers/specs/2026-05-07-path-g-g4-customkeymap-design.md
+
+#include <gtest/gtest.h>
+
+#include "core/config/TypingConfig.h"
+#include "core/engine/TypingAction.h"
+#include "core/engine/TypingEngine.h"
+#include "TestHelper.h"
+
+namespace NextKey {
+namespace {
+
+using Testing::TypeString;
+
+class CustomKeyMapTest : public ::testing::Test {
+protected:
+    TypingConfig MakeTelexConfig() {
+        TypingConfig cfg;
+        cfg.inputMethod = InputMethod::Telex;
+        cfg.spellCheckEnabled = false;
+        cfg.optimizeLevel = 0;
+        return cfg;
+    }
+
+    TypingConfig MakeVniConfig() {
+        TypingConfig cfg;
+        cfg.inputMethod = InputMethod::VNI;
+        cfg.spellCheckEnabled = false;
+        cfg.optimizeLevel = 0;
+        return cfg;
+    }
+
+    TypingConfig MakeCombinedConfig() {
+        TypingConfig cfg;
+        cfg.inputMethod = InputMethod::Combined;
+        cfg.spellCheckEnabled = false;
+        cfg.optimizeLevel = 0;
+        return cfg;
+    }
+};
+
+// =====================================================================
+// G1 — Default-empty parity: customKeyMap{} → behavior unchanged
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, DefaultEmptyMatchesTelex) {
+    TypingConfig cfg = MakeTelexConfig();
+    TypingEngine engine(cfg);
+    TypeString(engine, L"asfx");  // 'a' + dấu sắc on 'a' = 'á' then literal 's'? Actually a+s = á, then f → grave override → à, then x → tilde → ã
+    // The exact composed result mirrors current G-3.6 behavior. We assert
+    // it matches the value produced by an engine constructed with the same
+    // baseline TypingConfig (no override field touched).
+    const std::wstring withDefault = engine.Peek();
+
+    TypingConfig baseline = MakeTelexConfig();
+    TypingEngine baselineEngine(baseline);
+    TypeString(baselineEngine, L"asfx");
+    EXPECT_EQ(withDefault, baselineEngine.Peek());
+}
+
+TEST_F(CustomKeyMapTest, DefaultEmptyMatchesVni) {
+    TypingConfig cfg = MakeVniConfig();
+    TypingEngine engine(cfg);
+    TypeString(engine, L"a1e2o3");
+    const std::wstring withDefault = engine.Peek();
+
+    TypingConfig baseline = MakeVniConfig();
+    TypingEngine baselineEngine(baseline);
+    TypeString(baselineEngine, L"a1e2o3");
+    EXPECT_EQ(withDefault, baselineEngine.Peek());
+}
+
+TEST_F(CustomKeyMapTest, DefaultEmptyMatchesCombined) {
+    TypingConfig cfg = MakeCombinedConfig();
+    TypingEngine engine(cfg);
+    TypeString(engine, L"as6w7");
+    const std::wstring withDefault = engine.Peek();
+
+    TypingConfig baseline = MakeCombinedConfig();
+    TypingEngine baselineEngine(baseline);
+    TypeString(baselineEngine, L"as6w7");
+    EXPECT_EQ(withDefault, baselineEngine.Peek());
+}
+
+}  // namespace
+}  // namespace NextKey
+```
+
+- [ ] **Step 2: Append the test source to `CMakeLists.txt`**
+
+In `CMakeLists.txt`, **find** the line:
+
+```cmake
+    tests/TypingActionTest.cpp
+```
+
+and **insert immediately after it**:
+
+```cmake
+    tests/CustomKeyMapTest.cpp
+```
+
+(Result: alphabetical order is broken vs `TypingConfigRCUTests.cpp` below, but matches the natural placement next to the related `TypingActionTest.cpp`. The existing list is grouped by topic, not alphabetic.)
+
+- [ ] **Step 3: Re-configure CMake and rebuild test target**
+
+```bash
+cmake -B build-linux -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug
+cmake --build build-linux --target NextKeyTests
+```
+
+Expected: build succeeds. The new test source is compiled into `NextKeyTests`.
+
+- [ ] **Step 4: Run G1 group**
+
+```bash
+./build-linux/tests/NextKeyTests --gtest_filter="CustomKeyMapTest.DefaultEmpty*"
+```
+
+Expected: `[  PASSED  ] 3 tests.` (the three G1 cases). They pass because the `withDefault` and `baseline` engines run identical code paths — no override is consulted yet.
+
+- [ ] **Step 5: Run full test suite to confirm count grew correctly**
+
+```bash
+./build-linux/tests/NextKeyTests
+```
+
+Expected: `[  PASSED  ] 1453 tests.` (1450 + 3 G1 cases). No failures.
+
+- [ ] **Step 6: Commit G1 regression net**
+
+```bash
+git add tests/CustomKeyMapTest.cpp CMakeLists.txt
+git commit -m "Sprint 3 Path G G-4.2: G1 regression tests (default-empty parity)
+
+Adds CustomKeyMapTest fixture + 3 G1 cases that pin current dispatch
+behavior. With customKeyMap{} (default-init), composed output must match
+a parallel engine built with the same baseline config. These tests
+become the structural guarantee that adding the dispatch hook in G-4.3
+preserves all 1450 prior cases.
+
+Linux GTest 1453/1453 PASS."
+```
+
+---
+
+## Task 4 — Add G2 test (failing) → implement dispatch hook → G2 passes
+
+**Files:**
+- Modify: `tests/CustomKeyMapTest.cpp` (append G2 group)
+- Modify: `src/core/engine/TypingEngine.cpp` (replace dispatch at line 235)
+
+This is the TDD RED→GREEN core: the G2 test fails until the dispatch hook is wired.
+
+- [ ] **Step 1: Append G2 group to `tests/CustomKeyMapTest.cpp`**
+
+In `tests/CustomKeyMapTest.cpp`, **find** the closing `}  // namespace` + `}  // namespace NextKey` at the end of the file. **Insert before** the closing `}  // namespace`:
+
+```cpp
+
+// =====================================================================
+// G2 — Replace built-in: user override always wins (precedence)
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, RemapTelexSToToneHook) {
+    TypingConfig cfg = MakeTelexConfig();
+    cfg.customKeyMap[static_cast<size_t>(L's')] = TypingAction::ToneHook;
+    TypingEngine engine(cfg);
+    TypeString(engine, L"as");
+    // Default Telex: 'a' + 's' → 'á' (sắc). With remap 's'→ToneHook: 'a' + 's' → 'ả' (hỏi).
+    EXPECT_EQ(engine.Peek(), L"ả");
+}
+
+TEST_F(CustomKeyMapTest, RemapVniDigit1ToClearTone) {
+    TypingConfig cfg = MakeVniConfig();
+    // Default VNI: '1' → ToneAcute. Remap '1' → ClearTone.
+    cfg.customKeyMap[static_cast<size_t>(L'1')] = TypingAction::ClearTone;
+    TypingEngine engine(cfg);
+    TypeString(engine, L"a2");  // 'a' + grave → 'à'
+    EXPECT_EQ(engine.Peek(), L"à");
+    TypeString(engine, L"1");   // remapped: clear tone
+    EXPECT_EQ(engine.Peek(), L"a");
+}
+```
+
+- [ ] **Step 2: Build and run G2 — expect FAIL**
+
+```bash
+cmake --build build-linux --target NextKeyTests
+./build-linux/tests/NextKeyTests --gtest_filter="CustomKeyMapTest.Remap*"
+```
+
+Expected: **FAIL**. Both G2 cases produce the default behavior (`'á'` for the first test, `'á'` for the second after the `'1'` keystroke) because no code reads `cfg.customKeyMap` yet.
+
+This is the desired RED state.
+
+- [ ] **Step 3: Implement the dispatch hook in `TypingEngine.cpp`**
+
+In `src/core/engine/TypingEngine.cpp`, **find** the block at line 235 (currently):
+
+```cpp
+    // 1. Classify keystroke once (G-3.2 dispatch foundation). VNI digit
+    // sequences override to None so subsequent action checks treat the
+    // digit as literal — matches the pre-G-3 `!isVniDigitSequence` guards
+    // that gated VNI tone, VNI modifier, and clear-tone branches.
+    TypingAction action = ClassifyKey(lower, IsTelexMode(), IsVniMode());
+    if (isVniDigitSequence) action = TypingAction::None;
+```
+
+and **replace** it with:
+
+```cpp
+    // 1. Classify keystroke once (G-3.2 dispatch foundation). G-4 layers
+    // an optional per-key user override above the static rules: when
+    // `customKeyMap[lower]` is non-`None`, it wins. ASCII-only (`lower <
+    // 128`) — non-ASCII keys fall straight to `ClassifyKey`. VNI digit
+    // sequences still override to None so subsequent action checks treat
+    // the digit as literal — matches the pre-G-3 `!isVniDigitSequence`
+    // guards that gated VNI tone, VNI modifier, and clear-tone branches.
+    TypingAction action;
+    if (lower < 128 &&
+        config_.customKeyMap[static_cast<uint8_t>(lower)] != TypingAction::None) {
+        action = config_.customKeyMap[static_cast<uint8_t>(lower)];
+    } else {
+        action = ClassifyKey(lower, IsTelexMode(), IsVniMode());
+    }
+    if (isVniDigitSequence) action = TypingAction::None;
+```
+
+- [ ] **Step 4: Build and run G2 — expect PASS**
+
+```bash
+cmake --build build-linux --target NextKeyTests
+./build-linux/tests/NextKeyTests --gtest_filter="CustomKeyMapTest.Remap*"
+```
+
+Expected: `[  PASSED  ] 2 tests.`
+
+- [ ] **Step 5: Run full suite to confirm zero regressions**
+
+```bash
+./build-linux/tests/NextKeyTests
+```
+
+Expected: `[  PASSED  ] 1455 tests.` (1450 baseline + 3 G1 + 2 G2). No failures — the dispatch hook is byte-equivalent for the 1450 baseline cases (their configs use default-empty `customKeyMap`, so the new branch is never taken).
+
+- [ ] **Step 6: Commit dispatch hook + G2 tests**
+
+```bash
+git add src/core/engine/TypingEngine.cpp tests/CustomKeyMapTest.cpp
+git commit -m "Sprint 3 Path G G-4.3: dispatch hook + G2 user-wins tests
+
+Adds the override layer at TypingEngine.cpp:235. When customKeyMap[lower]
+is non-None, dispatch uses it; otherwise falls back to ClassifyKey.
+isVniDigitSequence guard post-applies (literal-digit escape preserved).
+
+G2 tests verify user override wins over built-in Telex and VNI rules.
+1455/1455 GTest PASS on Linux."
+```
+
+---
+
+## Task 5 — Add remaining test groups G3–G7
+
+**Files:**
+- Modify: `tests/CustomKeyMapTest.cpp` (append G3, G4, G5, G6, G7 groups)
+
+All these tests should PASS immediately because the dispatch hook is in place from Task 4. They lock in the remaining design properties.
+
+- [ ] **Step 1: Append G3 (gap-fill new key)**
+
+In `tests/CustomKeyMapTest.cpp`, append before the closing `}  // namespace`:
+
+```cpp
+
+// =====================================================================
+// G3 — Gap-fill: map a key that ClassifyKey returns None for
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, MapQToClearTone_TelexMode) {
+    TypingConfig cfg = MakeTelexConfig();
+    // 'q' is not a Telex action key — ClassifyKey returns None.
+    cfg.customKeyMap[static_cast<size_t>(L'q')] = TypingAction::ClearTone;
+    TypingEngine engine(cfg);
+    TypeString(engine, L"asq");  // 'a' + sắc → 'á', then 'q' clears tone → 'a'
+    EXPECT_EQ(engine.Peek(), L"a");
+}
+
+TEST_F(CustomKeyMapTest, MapQToToneAcute_VniMode) {
+    TypingConfig cfg = MakeVniConfig();
+    // 'q' is not a VNI action key — ClassifyKey returns None.
+    cfg.customKeyMap[static_cast<size_t>(L'q')] = TypingAction::ToneAcute;
+    TypingEngine engine(cfg);
+    TypeString(engine, L"aq");  // 'a' + remapped 'q' → ToneAcute → 'á'
+    EXPECT_EQ(engine.Peek(), L"á");
+}
+```
+
+- [ ] **Step 2: Append G4 (ASCII boundary)**
+
+In `tests/CustomKeyMapTest.cpp`, append:
+
+```cpp
+
+// =====================================================================
+// G4 — ASCII boundary: non-ASCII keys bypass the override branch
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, NonAsciiKeyFallsBackToClassifyKey) {
+    TypingConfig cfg = MakeTelexConfig();
+    // The override array has only 128 slots; non-ASCII keys must skip
+    // the override check entirely (defensive: `lower < 128` guard).
+    // We verify by typing a Vietnamese char directly — the engine treats
+    // it as a literal char (ClassifyKey returns None for it), and no
+    // override applies because `lower >= 128`.
+    TypingEngine engine(cfg);
+    TypeString(engine, L"á");  // U+00E1, definitely >= 128
+    EXPECT_EQ(engine.Peek(), L"á");  // unchanged literal pass-through
+}
+```
+
+- [ ] **Step 3: Append G5 (`isVniDigitSequence` interaction)**
+
+In `tests/CustomKeyMapTest.cpp`, append:
+
+```cpp
+
+// =====================================================================
+// G5 — isVniDigitSequence post-applies even when override fired
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, OverrideOnDigitYieldsLiteralInDigitSequence) {
+    TypingConfig cfg = MakeVniConfig();
+    // Remap '7' → ToneHook (instead of default VniHorn).
+    cfg.customKeyMap[static_cast<size_t>(L'7')] = TypingAction::ToneHook;
+    TypingEngine engine(cfg);
+    // Type a literal digit first to enter "VNI digit sequence" mode.
+    TypeString(engine, L"4");
+    // Now '7' should be treated as literal (digit-sequence guard wins
+    // over both the override and the default VniHorn) → composed "47".
+    TypeString(engine, L"7");
+    EXPECT_EQ(engine.Peek(), L"47");
+}
+```
+
+- [ ] **Step 4: Append G6 (sentinel semantics)**
+
+In `tests/CustomKeyMapTest.cpp`, append:
+
+```cpp
+
+// =====================================================================
+// G6 — Sentinel: explicit None == not set
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, CustomMapNoneFallsThroughToClassifyKey) {
+    TypingConfig cfg = MakeTelexConfig();
+    // Explicitly set 's' to None — must be indistinguishable from default.
+    cfg.customKeyMap[static_cast<size_t>(L's')] = TypingAction::None;
+    TypingEngine engine(cfg);
+    TypeString(engine, L"as");
+    // Default Telex: 'a' + 's' → 'á' (sắc).
+    EXPECT_EQ(engine.Peek(), L"á");
+}
+```
+
+- [ ] **Step 5: Append G7 (parametric all-actions roundtrip)**
+
+In `tests/CustomKeyMapTest.cpp`, append:
+
+```cpp
+
+// =====================================================================
+// G7 — Parametric smoke: every non-None TypingAction reachable via remap
+// =====================================================================
+
+class CustomKeyMapAllActions
+    : public CustomKeyMapTest,
+      public ::testing::WithParamInterface<TypingAction> {};
+
+TEST_P(CustomKeyMapAllActions, EveryTypingActionRoundtrips) {
+    const TypingAction action = GetParam();
+    ASSERT_NE(action, TypingAction::None) << "G7 only iterates non-None actions";
+
+    // Configure: 'q' (which ClassifyKey returns None for in pure Telex mode)
+    // remapped to the parameter action. Compare composed output of typing
+    // "q" against an engine driven through the natural key for the same
+    // action. We do not assert specific Vietnamese strings here — only
+    // that dispatch reaches the correct action handler (no crash, action
+    // resolves). Engine state observation is via Peek().
+    TypingConfig cfg = MakeCombinedConfig();
+    cfg.customKeyMap[static_cast<size_t>(L'q')] = action;
+    TypingEngine engine(cfg);
+    // Seed a vowel so modifier/tone actions have something to operate on.
+    TypeString(engine, L"a");
+    EXPECT_NO_THROW(TypeString(engine, L"q"));
+    // Final Peek should be a non-empty wstring (engine must not be in a
+    // broken state after dispatch).
+    EXPECT_FALSE(engine.Peek().empty());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllActions,
+    CustomKeyMapAllActions,
+    ::testing::Values(
+        TypingAction::ClearTone,
+        TypingAction::ToneAcute,
+        TypingAction::ToneGrave,
+        TypingAction::ToneHook,
+        TypingAction::ToneTilde,
+        TypingAction::ToneDot,
+        TypingAction::CircumflexA,
+        TypingAction::CircumflexE,
+        TypingAction::CircumflexO,
+        TypingAction::HornW,
+        TypingAction::HornInsertO,
+        TypingAction::HornInsertU,
+        TypingAction::StrokeD,
+        TypingAction::VniCircumflex,
+        TypingAction::VniHorn,
+        TypingAction::VniBreve,
+        TypingAction::VniStroke
+    )
+);
+```
+
+- [ ] **Step 6: Build and run all CustomKeyMapTest cases**
+
+```bash
+cmake --build build-linux --target NextKeyTests
+./build-linux/tests/NextKeyTests --gtest_filter="CustomKeyMap*"
+```
+
+Expected: `[  PASSED  ] N tests.` where N = 3 (G1) + 2 (G2) + 2 (G3) + 1 (G4) + 1 (G5) + 1 (G6) + 17 (G7 parametric) = **27 cases**.
+
+- [ ] **Step 7: Run full suite — confirm total count**
+
+```bash
+./build-linux/tests/NextKeyTests
+```
+
+Expected: `[  PASSED  ] 1477 tests.` (1450 baseline + 27 new). No failures.
+
+- [ ] **Step 8: Commit G3–G7**
+
+```bash
+git add tests/CustomKeyMapTest.cpp
+git commit -m "Sprint 3 Path G G-4.4: G3-G7 test groups
+
+Locks in remaining design properties:
+- G3: gap-fill (map keys ClassifyKey returns None for)
+- G4: ASCII boundary (non-ASCII keys bypass override)
+- G5: isVniDigitSequence post-applies even when override fired
+- G6: sentinel None == not set
+- G7: every non-None TypingAction reachable via remap (17 parametric)
+
+Linux GTest 1477/1477 PASS."
+```
+
+---
+
+## Task 6 — Update HANDOFF.md and final verification
+
+**Files:**
+- Modify: `HANDOFF.md`
+
+- [ ] **Step 1: Update HANDOFF.md top section**
+
+In `HANDOFF.md`, **find** the existing top heading:
+
+```markdown
+## 2026-05-07 — Sprint 3 Path G G-3 COMPLETE (CURRENT PICKUP NOTE)
+```
+
+and **insert before it** a new top section:
+
+```markdown
+## 2026-05-07 — Sprint 3 Path G G-4 COMPLETE (CURRENT PICKUP NOTE)
+
+**Branch:** `sprint-3/path-g-customkeymap`. **Goal:** engine-side per-key user override layer.
+
+**Commits:**
+1. G-4.1 — `customKeyMap` field on TypingConfig (default-init all `None`).
+2. G-4.2 — G1 regression tests (default-empty parity, 3 cases).
+3. G-4.3 — Dispatch hook at `TypingEngine.cpp:235` + G2 user-wins tests (2 cases).
+4. G-4.4 — G3-G7 tests (22 cases): gap-fill, ASCII boundary, digit-sequence interaction, sentinel, all-actions parametric.
+
+**Final dispatch shape (G-4):**
+
+```
+PushChar(c)
+  └─ lower = towlower(c)
+  └─ if (lower < 128 && customKeyMap[lower] != None)
+        action = customKeyMap[lower]            ← user override wins
+     else
+        action = ClassifyKey(lower, isTelex, isVni)
+  └─ if (isVniDigitSequence) action = None       ← literal-digit guard post-applies
+  └─ ProcessModifier(action, c) → 6 Handle*
+```
+
+**Test counts:** 1450 (post-G-3) + 27 (G-4 new) = **1477 cases on Linux**.
+
+**Files touched:** `src/core/config/TypingConfig.h` (+1 field, +2 includes), `src/core/engine/TypingEngine.cpp` (+4 LOC at line 235), `tests/CustomKeyMapTest.cpp` (NEW, ~250 LOC), `CMakeLists.txt` (+1 test source).
+
+**Out of scope (deferred to G-5):** TOML schema, Sciter dialog, per-user `keymap_<name>.toml` files, active-method selector. ConfigManager untouched in G-4.
+
+### NEXT — G-5 keymap files + UI
+
+Wire ConfigManager to load per-user `keymap_<name>.toml` files into `TypingConfig.customKeyMap`. Add Sciter dialog for editing. Add `[input].active_user_method` field to select which keymap is loaded. Reuse the existing 7-file split pattern (see `ConfigManager.cpp`).
+
+---
+
+```
+
+(The trailing horizontal rule separates the new section from the old G-3 pickup note that follows.)
+
+- [ ] **Step 2: Run full test suite one final time**
+
+```bash
+./build-linux/tests/NextKeyTests
+```
+
+Expected: `[  PASSED  ] 1477 tests.`
+
+- [ ] **Step 3: Confirm Linux build is clean**
+
+```bash
+cmake --build build-linux --target NextKeyTests 2>&1 | tail -20
+```
+
+Expected: `[100%] Built target NextKeyTests`. No warnings or errors.
+
+- [ ] **Step 4: Commit HANDOFF update**
+
+```bash
+git add HANDOFF.md
+git commit -m "docs(handoff): Path G G-4 COMPLETE — G-5 keymap files next"
+```
+
+- [ ] **Step 5: Push branch**
+
+```bash
+git push -u origin sprint-3/path-g-customkeymap
+```
+
+Expected: branch published; output ends with `Branch 'sprint-3/path-g-customkeymap' set up to track 'origin/sprint-3/path-g-customkeymap'`.
+
+- [ ] **Step 6: Open PR (manual; not part of automation)**
+
+The user (`@phatMT97`) should:
+1. Run Windows MSVC build locally to confirm cross-platform clean.
+2. Open PR `sprint-3/path-g-customkeymap` → `Main` titled "Sprint 3 Path G G-4: customKeyMap engine hook".
+3. PR body should reference the design spec at `docs/superpowers/specs/2026-05-07-path-g-g4-customkeymap-design.md`.
+
+---
+
+## Acceptance Criteria (from spec §8)
+
+- [ ] `TypingConfig` has `customKeyMap` field of type `std::array<TypingAction, 128>` with default-init to all `None`. (Task 2)
+- [ ] `TypingEngine::PushChar` consults `customKeyMap` before `ClassifyKey` per spec §3.3. (Task 4)
+- [ ] All 1450 pre-G-4 GTests pass on Linux unchanged. (Task 4 Step 5)
+- [ ] New `CustomKeyMapTest.cpp` adds ≥ 12 cases covering G1–G7, all passing. (Tasks 3+4+5; total = 27)
+- [ ] Total Linux GTest count ≥ 1463 PASS. (Task 6 Step 2; actual = 1477)
+- [ ] No source change in `ConfigManager.{h,cpp}`, `TypingAction.h`, or any engine handler. (verified by `git diff Main..HEAD --stat` showing only the 4 files listed in §File Structure plus HANDOFF.md)
+- [ ] Windows MSVC build clean (verified locally by user — manual step).

--- a/docs/superpowers/specs/2026-05-07-path-g-g4-customkeymap-design.md
+++ b/docs/superpowers/specs/2026-05-07-path-g-g4-customkeymap-design.md
@@ -1,0 +1,222 @@
+# Path G — G-4 customKeyMap Engine Hook
+
+**Status:** Design approved 2026-05-07. Awaiting implementation plan.
+**Sprint:** 3 / Path G (refactor + Phonotactics + custom keymap layer)
+**Predecessors:** G-1 (Phonotactics), G-2 (DI + namespace), G-3 (TypingAction enum + dispatch).
+**Successors:** G-5 (Sciter UI + per-user `keymap_<name>.toml` files), G-6 (Unikey/EVKey import-export).
+**Brainstorm:** `_bmad-output/brainstorming/brainstorming-session-2026-05-07-0250.md` (Idea #11).
+
+---
+
+## 1. Goal
+
+Add a per-key user override layer to the input dispatch pipeline. After G-4, the engine accepts a remap from `TypingConfig` and applies it before the static Telex/VNI rules in `ClassifyKey`. With an empty remap, behavior is byte-identical to G-3.6 (current Main).
+
+**Non-goals (explicitly deferred):**
+- Sciter UI for editing keymaps → G-5.
+- TOML schema and per-user `keymap_<name>.toml` files → G-5.
+- ConfigManager loading the field from disk → G-5.
+- Unikey / EVKey format import-export → G-6.
+
+G-4 is a pure engine-side hook. ConfigManager remains untouched. The new field defaults to all-`None` so all 1450 existing GTests pass unchanged.
+
+---
+
+## 2. Requirements
+
+### 2.1 Functional
+
+- F1: `TypingConfig` exposes a `customKeyMap` field of type `std::array<TypingAction, 128>` (ASCII-indexed).
+- F2: When `customKeyMap[key] != TypingAction::None`, the engine dispatches that action regardless of mode and regardless of what `ClassifyKey(key, mode)` would return ("user override always wins").
+- F3: When `customKeyMap[key] == TypingAction::None`, the engine falls through to `ClassifyKey(key, IsTelexMode(), IsVniMode())` (current behavior).
+- F4: Override is mode-agnostic — the same `customKeyMap` applies in Telex, VNI, SimpleTelex, and Combined modes. (Per Idea #11, the active keymap inherently belongs to one parent input method; mode arbitration happens at keymap-selection time, not dispatch time.)
+- F5: The existing `isVniDigitSequence` literal-digit guard (line 236 of `TypingEngine.cpp`) still applies after override resolution. Number sequences like `E747` remain literal even if `'7'` is remapped.
+- F6: Non-ASCII keys (`lower >= 128`) bypass the override branch entirely and go straight to `ClassifyKey`.
+- F7: Override lookup is case-insensitive — the existing `towlower(c) → lower` upstream of dispatch already canonicalizes case.
+
+### 2.2 Non-functional
+
+- NF1: Zero behavior change when `customKeyMap` is default-initialized (all `None`).
+- NF2: Hot-path cost of override check: bounds compare + indexed load + sentinel compare ≤ 3 instructions before fallback. No allocation, no hash, no branch on mode.
+- NF3: Memory: +128 bytes per `TypingConfig` instance. Live count is 1–2 → ≤ 256 B total. Within Path G's "tiny lookup tables" budget.
+- NF4: `TypingConfig` remains trivially copyable (POD-style). The `std::array<TypingAction, 128>` member preserves this.
+- NF5: `TypingAction.h` stays dependency-free (existing comment at `TypingAction.h:8-9`). No new includes.
+- NF6: All 30+ existing call sites that construct or copy `TypingConfig` (engine ctor, `EngineFactory`, dialogs, tests) compile unchanged because the new field is default-initialized.
+
+---
+
+## 3. Design
+
+### 3.1 Data structure
+
+`TypingConfig.h` gains one field and one include:
+
+```cpp
+#include "core/engine/TypingAction.h"   // already dependency-free
+#include <array>
+
+struct TypingConfig {
+    // ... 25 existing fields unchanged ...
+    std::vector<std::wstring> spellExclusions;
+
+    /// Per-key user override. Index by ASCII code (`towlower(c)` of the
+    /// keystroke). Default-initialized to all `TypingAction::None`, which
+    /// the dispatcher treats as "no override → fall through to
+    /// `ClassifyKey`". G-4 introduces the field and dispatch hook only;
+    /// G-5 will populate it from per-user keymap files.
+    std::array<TypingAction, 128> customKeyMap{};
+
+    TypingConfig() = default;
+};
+```
+
+**Why `std::array<TypingAction, 128>`** (settled during brainstorming):
+
+| Constraint | Array satisfies |
+|---|---|
+| YAGNI: Telex/VNI bind ASCII only | ✅ No futureproofing cost for non-ASCII |
+| Hot-path performance | ✅ O(1) indexed load, no hash |
+| Trivially copyable / POD | ✅ Array of `uint8_t` enum |
+| Default = "no override" | ✅ Zero-init = all `None` |
+| Backward compat (additive-only) | ✅ Default ctor unchanged |
+
+Rejected: `std::unordered_map<wchar_t, TypingAction>` (heap, hash, non-trivial copy), `std::vector<TypingAction>` (size-invariant maintenance, empty-check guard).
+
+### 3.2 Sentinel semantics
+
+`TypingAction::None` (G-3.1) already means "literal char, no IME action." The override layer reuses this:
+
+- `customKeyMap[key] == None` ⟺ "no override at this key" — fall through to `ClassifyKey`.
+- `customKeyMap[key] == ToneAcute` ⟺ "user remapped key to dấu sắc" — use directly.
+
+This unifies presence detection with action vocabulary; no parallel `bool hasOverride[128]` is needed.
+
+### 3.3 Dispatch hook
+
+The single insertion point is in `TypingEngine.cpp::PushChar`, replacing the current G-3.2 classification at `TypingEngine.cpp:235`:
+
+```cpp
+// G-3.2 (current):
+TypingAction action = ClassifyKey(lower, IsTelexMode(), IsVniMode());
+if (isVniDigitSequence) action = TypingAction::None;
+```
+
+becomes:
+
+```cpp
+// G-4: User override layer above static rules.
+TypingAction action;
+if (lower < 128 &&
+    config_.customKeyMap[static_cast<uint8_t>(lower)] != TypingAction::None) {
+    action = config_.customKeyMap[static_cast<uint8_t>(lower)];
+} else {
+    action = ClassifyKey(lower, IsTelexMode(), IsVniMode());
+}
+if (isVniDigitSequence) action = TypingAction::None;
+```
+
+**Properties:**
+
+- **Layered, not folded:** `ClassifyKey` stays pure (`TypingAction.h:54` comment "Pure function — no state lookup, no side effects" remains true). Override is a separate concern resolved at the call site.
+- **Pure when empty:** Default-init `customKeyMap` → first branch always false → byte-identical fallback path.
+- **`isVniDigitSequence` post-applies:** Line 236 keeps its semantics. Disambiguation safety preserved.
+- **No mode coupling:** Override does not consult `IsTelexMode()`/`IsVniMode()` — keymap belongs to one parent method (set elsewhere when keymap is selected, G-5).
+
+### 3.4 What does NOT change
+
+- `ClassifyKey` signature in `TypingAction.h` — zero churn on the 10 G-3.1 ClassifyKey GTests.
+- All 6 `Handle*` modifier handlers (`HandleHornInsert`, `HandleAdjacentCircumflex`, `HandleHornW`, `HandleStrokeD`, `HandleVniHorn`, `HandleVniCircumflex`, `HandleVniBreve`) — they receive `action` opaquely.
+- `Tone requestedTone = ActionToTone(action)` (`TypingEngine.cpp:254`) — works with override-derived `action` seamlessly.
+- `ConfigManager.{h,cpp}` — no schema change in G-4.
+- All existing 1450 GTest cases — no behavior change when `customKeyMap` is default-empty.
+
+### 3.5 Files touched
+
+| File | Change | Net LOC |
+|---|---|---|
+| `src/core/config/TypingConfig.h` | +`std::array<TypingAction, 128> customKeyMap{}` field, +2 includes | +5 |
+| `src/core/engine/TypingEngine.cpp` | Replace 2-line dispatch at line 235 with 6-line if/else | +4 |
+| `tests/CustomKeyMapTest.cpp` | NEW — engine-level GTests | +≈200 |
+| `CMakeLists.txt` | Add new test source to `NEXTKEY_TEST_SOURCES` | +1 |
+
+Total production code change: **+9 LOC** across two files. `TypingAction.h`, `ConfigManager.{h,cpp}`, all engine handlers, all dialogs untouched.
+
+---
+
+## 4. Test Plan
+
+New file: `tests/CustomKeyMapTest.cpp`. All tests run via `TypingEngine` directly (Linux-buildable, no Windows/TSF dependency).
+
+**Run:** `./build-linux/tests/NextKeyTests --gtest_filter="CustomKeyMapTest.*"`
+
+### Test groups
+
+| ID | Group | Cases | Verifies |
+|---|---|---|---|
+| G1 | Default-empty preserves existing behavior | `DefaultEmptyMatchesTelex`, `DefaultEmptyMatchesVni`, `DefaultEmptyMatchesCombined` | `customKeyMap{}` → composed output identical to G-3.6 baseline for representative input strings |
+| G2 | Replace built-in (user-wins precedence) | `RemapTelexSToToneHook`, `RemapVniDigit1ToClearTone` | `cfg.customKeyMap['s'] = ToneHook` in Telex → "as" composes to "ả" not "á" |
+| G3 | Add new key (gap-fill) | `MapQToClearTone_TelexMode`, `MapQToToneAcute_VniMode` | Keys that `ClassifyKey` returns `None` for now dispatch real actions |
+| G4 | ASCII boundary | `NonAsciiKeyFallsBackToClassifyKey` | `lower >= 128` defensively skips override branch |
+| G5 | `isVniDigitSequence` interaction | `OverrideOnDigitYieldsLiteralInDigitSequence` | `'7' → ToneHook` in VNI: "E747" still produces literal digits (post-apply guard wins) |
+| G6 | Sentinel semantics | `CustomMapNoneFallsThroughToClassifyKey` | Explicitly setting a key to `None` is identical to leaving it default |
+| G7 | All-actions smoke | `EveryTypingActionRoundtrips` (parametric) | For each of the 17 non-`None` `TypingAction` values, `'q' → action` produces output equivalent to the action firing through the regular dispatch. (`None` is the sentinel; G6 covers that case.) |
+
+### Test count target
+
+≈12–15 GTest cases. Total after G-4: **1450 + ≈13 ≈ 1463 cases**.
+
+### Regression guarantee
+
+Test group G1 is the structural guarantee that all 1450 prior cases keep passing — they run with `TypingConfig{}` (default ctor), which initializes `customKeyMap` to all `None`, which makes the new branch a never-taken no-op.
+
+---
+
+## 5. Backward Compatibility
+
+- **TypingConfig serialization:** No TOML changes in G-4. Existing config files load identically.
+- **TypingConfig consumers:** All current call sites construct/copy `TypingConfig` by value. Default-init of the new array field is automatic — no source change required at any of the 30+ call sites.
+- **EngineFactory & TypingEngine ctors:** Unchanged. Engine receives `TypingConfig` by const-ref or value as today.
+- **Existing GTests:** All 1450 pass with `customKeyMap` default-empty. G1 test group asserts this structurally.
+
+---
+
+## 6. Out of Scope (Path G milestones G-5+)
+
+- **G-5 — Sciter UI + keymap files:** Dialog for editing per-key bindings; per-user `keymap_<name>.toml` files following the existing 7-file split pattern; active-method selector that chooses which keymap loads into `TypingConfig.customKeyMap`; conflict warnings when two keys map to the same action.
+- **G-6 — Import/export:** Unikey config (`S=DAU_SAC F=DAU_HUYEN ...`) and EVKey format compatibility, mapping their key codes into `TypingAction` values.
+
+---
+
+## 7. Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Test G1 group fails due to a subtle dispatch difference | Low | Default-empty array → first branch is unreachable; bytewise-equivalent code path |
+| `TypingConfig` size growth breaks ABI in some niche caller | Very low | All callers are intra-project; no DLL exports `TypingConfig` by ABI |
+| Future G-5 wants per-mode maps | Medium | Brainstorm Idea #11 already settled "1 keymap = 1 parent method" — selection happens at the keymap layer, not the dispatch layer; current array<128> remains correct |
+| Hot-path bounds check costs measurable time | Very low | `lower < 128` is a single compare; whole branch is well-predicted (default-empty users hit always-false) |
+
+---
+
+## 8. Acceptance Criteria
+
+G-4 is complete when **all** of the following hold:
+
+1. `TypingConfig` has the `customKeyMap` field of type `std::array<TypingAction, 128>` with default-init to all `None`.
+2. `TypingEngine::PushChar` consults `customKeyMap` before `ClassifyKey` per the dispatch hook in §3.3.
+3. All 1450 pre-G-4 GTests pass on Linux unchanged.
+4. New `CustomKeyMapTest.cpp` adds ≥ 12 cases covering groups G1–G7, all passing.
+5. Total Linux GTest count ≥ 1463 PASS.
+6. No source change in `ConfigManager.{h,cpp}`, `TypingAction.h`, or any engine handler.
+7. Windows MSVC build clean (verified locally by user).
+
+---
+
+## 9. References
+
+- Brainstorm session: `_bmad-output/brainstorming/brainstorming-session-2026-05-07-0250.md`
+- Path G handoff: `HANDOFF.md` (top section, "2026-05-07 — Sprint 3 Path G G-3 COMPLETE")
+- Predecessor PRs: #134 (G-1..G-3.2), #135 (G-3.3..G-3.4), #136 (G-3.5), #137 (G-3.6)
+- TypingAction enum: `src/core/engine/TypingAction.h`
+- Current dispatch site: `src/core/engine/TypingEngine.cpp:235`
+- Coding rules: `docs/CODING_RULES/`

--- a/src/core/config/TypingConfig.h
+++ b/src/core/config/TypingConfig.h
@@ -3,9 +3,12 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
+
+#include "core/engine/TypingAction.h"
 
 namespace NextKey {
 
@@ -73,6 +76,13 @@ struct TypingConfig {
     bool macroTriggerTab = true;       // Kích hoạt bằng phím Tab
     bool macroTriggerDir = true;       // Kích hoạt bằng phím Mũi tên (Arrows)
     std::vector<std::wstring> spellExclusions;  // Spell check exclusion prefixes (e.g. "hđ", "đp")
+
+    /// Per-key user override (G-4). Index by ASCII code (`towlower(c)` of
+    /// the keystroke). Default-init = all `TypingAction::None`, which the
+    /// dispatcher treats as "no override → fall through to `ClassifyKey`".
+    /// G-5 will populate this from per-user keymap files; G-4 ships the
+    /// engine hook only.
+    std::array<TypingAction, 128> customKeyMap{};
 
     // Default constructor for compiled defaults (FR8 - engine autonomy)
     TypingConfig() = default;

--- a/src/core/config/TypingConfig.h
+++ b/src/core/config/TypingConfig.h
@@ -77,11 +77,9 @@ struct TypingConfig {
     bool macroTriggerDir = true;       // Kích hoạt bằng phím Mũi tên (Arrows)
     std::vector<std::wstring> spellExclusions;  // Spell check exclusion prefixes (e.g. "hđ", "đp")
 
-    /// Per-key user override (G-4). Index by ASCII code; callers MUST
-    /// guard with `lower < 128` before indexing. Default-init = all
-    /// `TypingAction::None`, which the dispatcher treats as "no override
-    /// → fall through to `ClassifyKey`". G-5 will populate this from
-    /// per-user keymap files; G-4 ships the engine hook only.
+    /// Per-key user override. Index by ASCII code; callers MUST guard
+    /// with `lower < 128` before indexing. `TypingAction::None` (the
+    /// default) means "no override — fall through to ClassifyKey".
     std::array<TypingAction, 128> customKeyMap{};
 
     // Default constructor for compiled defaults (FR8 - engine autonomy)

--- a/src/core/config/TypingConfig.h
+++ b/src/core/config/TypingConfig.h
@@ -77,11 +77,11 @@ struct TypingConfig {
     bool macroTriggerDir = true;       // Kích hoạt bằng phím Mũi tên (Arrows)
     std::vector<std::wstring> spellExclusions;  // Spell check exclusion prefixes (e.g. "hđ", "đp")
 
-    /// Per-key user override (G-4). Index by ASCII code (`towlower(c)` of
-    /// the keystroke). Default-init = all `TypingAction::None`, which the
-    /// dispatcher treats as "no override → fall through to `ClassifyKey`".
-    /// G-5 will populate this from per-user keymap files; G-4 ships the
-    /// engine hook only.
+    /// Per-key user override (G-4). Index by ASCII code; callers MUST
+    /// guard with `lower < 128` before indexing. Default-init = all
+    /// `TypingAction::None`, which the dispatcher treats as "no override
+    /// → fall through to `ClassifyKey`". G-5 will populate this from
+    /// per-user keymap files; G-4 ships the engine hook only.
     std::array<TypingAction, 128> customKeyMap{};
 
     // Default constructor for compiled defaults (FR8 - engine autonomy)

--- a/src/core/engine/TypingAction.h
+++ b/src/core/engine/TypingAction.h
@@ -18,10 +18,6 @@ namespace NextKey {
 /// `ClassifyKey` returns one of these based on (key, mode) only —
 /// runtime applicability (state shape, escape flags, English protection,
 /// spell-check gating) stays in the per-action handlers in TypingEngine.
-///
-/// G-3 introduces this enum to centralize the dispatch shape. G-4 will
-/// expose it via `TypingConfig::customKeyMap` so users can rebind keys
-/// without modifying engine code.
 enum class TypingAction : uint8_t {
     None = 0,        // Not an IME-bound key — handled as literal char
 

--- a/src/core/engine/TypingAction.h
+++ b/src/core/engine/TypingAction.h
@@ -6,7 +6,7 @@
 //
 // Action vocabulary for TypingEngine dispatch and (future) per-user keymap.
 // Header is intentionally dependency-free so TypingConfig can hold a
-// `customKeyMap: array<TypingAction, 256>` without circular includes.
+// `customKeyMap: array<TypingAction, 128>` without circular includes.
 
 #pragma once
 

--- a/src/core/engine/TypingEngine.cpp
+++ b/src/core/engine/TypingEngine.cpp
@@ -228,11 +228,20 @@ void TypingEngine::PushChar(wchar_t c) {
         }
     }
 
-    // 1. Classify keystroke once (G-3.2 dispatch foundation). VNI digit
-    // sequences override to None so subsequent action checks treat the
-    // digit as literal — matches the pre-G-3 `!isVniDigitSequence` guards
-    // that gated VNI tone, VNI modifier, and clear-tone branches.
-    TypingAction action = ClassifyKey(lower, IsTelexMode(), IsVniMode());
+    // 1. Classify keystroke once (G-3.2 dispatch foundation). G-4 layers
+    // an optional per-key user override above the static rules: when
+    // `customKeyMap[lower]` is non-`None`, it wins. ASCII-only (`lower <
+    // 128`) — non-ASCII keys fall straight to `ClassifyKey`. VNI digit
+    // sequences still override to None so subsequent action checks treat
+    // the digit as literal — matches the pre-G-3 `!isVniDigitSequence`
+    // guards that gated VNI tone, VNI modifier, and clear-tone branches.
+    TypingAction action;
+    if (lower < 128 &&
+        config_.customKeyMap[static_cast<uint8_t>(lower)] != TypingAction::None) {
+        action = config_.customKeyMap[static_cast<uint8_t>(lower)];
+    } else {
+        action = ClassifyKey(lower, IsTelexMode(), IsVniMode());
+    }
     if (isVniDigitSequence) action = TypingAction::None;
 
     // 1a. Clear tone: Telex 'z' / VNI '0'

--- a/src/core/engine/TypingEngine.cpp
+++ b/src/core/engine/TypingEngine.cpp
@@ -216,7 +216,7 @@ void TypingEngine::PushChar(wchar_t c) {
         }
     }
 
-    // 1. Literal digit sequence protection (VNI mode)
+    // Literal digit sequence protection (VNI mode)
     // If the user types a digit immediately following a literal digit,
     // it's highly likely they are typing a number sequence (e.g., E747).
     // Bypass VNI tone/modifier processing to insert the digit literally.
@@ -228,7 +228,7 @@ void TypingEngine::PushChar(wchar_t c) {
         }
     }
 
-    // 2. Classify keystroke. G-4 layers an optional per-key user override
+    // 1. Classify keystroke. G-4 layers an optional per-key user override
     // above the static rules: when customKeyMap[lower] is non-None (ASCII
     // keys only), it wins; otherwise ClassifyKey provides the built-in
     // Telex/VNI mapping.

--- a/src/core/engine/TypingEngine.cpp
+++ b/src/core/engine/TypingEngine.cpp
@@ -228,20 +228,16 @@ void TypingEngine::PushChar(wchar_t c) {
         }
     }
 
-    // 1. Classify keystroke once (G-3.2 dispatch foundation). G-4 layers
-    // an optional per-key user override above the static rules: when
-    // `customKeyMap[lower]` is non-`None`, it wins. ASCII-only (`lower <
-    // 128`) — non-ASCII keys fall straight to `ClassifyKey`. VNI digit
-    // sequences still override to None so subsequent action checks treat
-    // the digit as literal — matches the pre-G-3 `!isVniDigitSequence`
-    // guards that gated VNI tone, VNI modifier, and clear-tone branches.
-    TypingAction action;
-    if (lower < 128 &&
-        config_.customKeyMap[static_cast<uint8_t>(lower)] != TypingAction::None) {
-        action = config_.customKeyMap[static_cast<uint8_t>(lower)];
-    } else {
-        action = ClassifyKey(lower, IsTelexMode(), IsVniMode());
-    }
+    // 2. Classify keystroke. G-4 layers an optional per-key user override
+    // above the static rules: when customKeyMap[lower] is non-None (ASCII
+    // keys only), it wins; otherwise ClassifyKey provides the built-in
+    // Telex/VNI mapping.
+    const TypingAction overrideAction = (lower < 128)
+        ? config_.customKeyMap[static_cast<uint8_t>(lower)]
+        : TypingAction::None;
+    TypingAction action = (overrideAction != TypingAction::None)
+        ? overrideAction
+        : ClassifyKey(lower, IsTelexMode(), IsVniMode());
     if (isVniDigitSequence) action = TypingAction::None;
 
     // 1a. Clear tone: Telex 'z' / VNI '0'

--- a/tests/CustomKeyMapTest.cpp
+++ b/tests/CustomKeyMapTest.cpp
@@ -52,36 +52,27 @@ TEST_F(CustomKeyMapTest, DefaultEmptyMatchesTelex) {
     TypingConfig cfg = MakeTelexConfig();
     TypingEngine engine(cfg);
     TypeString(engine, L"asfx");
-    const std::wstring withDefault = engine.Peek();
-
-    TypingConfig baseline = MakeTelexConfig();
-    TypingEngine baselineEngine(baseline);
-    TypeString(baselineEngine, L"asfx");
-    EXPECT_EQ(withDefault, baselineEngine.Peek());
+    // G-3.6 baseline: telex 'a'+s+f+x — s=â modifier, f=tone huyền, x=tone ngã
+    // → ã (U+00E3). Captured 2026-05-07.
+    EXPECT_EQ(engine.Peek(), L"ã");
 }
 
 TEST_F(CustomKeyMapTest, DefaultEmptyMatchesVni) {
     TypingConfig cfg = MakeVniConfig();
     TypingEngine engine(cfg);
     TypeString(engine, L"a1e2o3");
-    const std::wstring withDefault = engine.Peek();
-
-    TypingConfig baseline = MakeVniConfig();
-    TypingEngine baselineEngine(baseline);
-    TypeString(baselineEngine, L"a1e2o3");
-    EXPECT_EQ(withDefault, baselineEngine.Peek());
+    // G-3.6 baseline: 'a'+1 → á, then 'e'+2 starts new syllable → é, then
+    // 'o'+3 would continue — actual engine output captured 2026-05-07: aé2o3.
+    EXPECT_EQ(engine.Peek(), L"aé2o3");
 }
 
 TEST_F(CustomKeyMapTest, DefaultEmptyMatchesCombined) {
     TypingConfig cfg = MakeCombinedConfig();
     TypingEngine engine(cfg);
     TypeString(engine, L"as6w7");
-    const std::wstring withDefault = engine.Peek();
-
-    TypingConfig baseline = MakeCombinedConfig();
-    TypingEngine baselineEngine(baseline);
-    TypeString(baselineEngine, L"as6w7");
-    EXPECT_EQ(withDefault, baselineEngine.Peek());
+    // G-3.6 baseline: 'a'+s → â (telex vowel modifier), '6' → tone huyền → ầ,
+    // 'w' → modifier, '7' appended — actual engine output captured 2026-05-07: ắ7.
+    EXPECT_EQ(engine.Peek(), L"ắ7");
 }
 
 }  // namespace

--- a/tests/CustomKeyMapTest.cpp
+++ b/tests/CustomKeyMapTest.cpp
@@ -1,0 +1,88 @@
+// NexusKey - customKeyMap (G-4) Tests
+// Copyright (c) 2024-2026 PhatMT. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-NexusKey-Commercial
+//
+// Tests for the per-key user override layer added in Path G G-4.
+// Spec: docs/superpowers/specs/2026-05-07-path-g-g4-customkeymap-design.md
+
+#include <gtest/gtest.h>
+
+#include "core/config/TypingConfig.h"
+#include "core/engine/TypingAction.h"
+#include "core/engine/TypingEngine.h"
+#include "TestHelper.h"
+
+namespace NextKey {
+namespace {
+
+using Testing::TypeString;
+
+class CustomKeyMapTest : public ::testing::Test {
+protected:
+    TypingConfig MakeTelexConfig() {
+        TypingConfig cfg;
+        cfg.inputMethod = InputMethod::Telex;
+        cfg.spellCheckEnabled = false;
+        cfg.optimizeLevel = 0;
+        return cfg;
+    }
+
+    TypingConfig MakeVniConfig() {
+        TypingConfig cfg;
+        cfg.inputMethod = InputMethod::VNI;
+        cfg.spellCheckEnabled = false;
+        cfg.optimizeLevel = 0;
+        return cfg;
+    }
+
+    TypingConfig MakeCombinedConfig() {
+        TypingConfig cfg;
+        cfg.inputMethod = InputMethod::Combined;
+        cfg.spellCheckEnabled = false;
+        cfg.optimizeLevel = 0;
+        return cfg;
+    }
+};
+
+// =====================================================================
+// G1 — Default-empty parity: customKeyMap{} → behavior unchanged
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, DefaultEmptyMatchesTelex) {
+    TypingConfig cfg = MakeTelexConfig();
+    TypingEngine engine(cfg);
+    TypeString(engine, L"asfx");
+    const std::wstring withDefault = engine.Peek();
+
+    TypingConfig baseline = MakeTelexConfig();
+    TypingEngine baselineEngine(baseline);
+    TypeString(baselineEngine, L"asfx");
+    EXPECT_EQ(withDefault, baselineEngine.Peek());
+}
+
+TEST_F(CustomKeyMapTest, DefaultEmptyMatchesVni) {
+    TypingConfig cfg = MakeVniConfig();
+    TypingEngine engine(cfg);
+    TypeString(engine, L"a1e2o3");
+    const std::wstring withDefault = engine.Peek();
+
+    TypingConfig baseline = MakeVniConfig();
+    TypingEngine baselineEngine(baseline);
+    TypeString(baselineEngine, L"a1e2o3");
+    EXPECT_EQ(withDefault, baselineEngine.Peek());
+}
+
+TEST_F(CustomKeyMapTest, DefaultEmptyMatchesCombined) {
+    TypingConfig cfg = MakeCombinedConfig();
+    TypingEngine engine(cfg);
+    TypeString(engine, L"as6w7");
+    const std::wstring withDefault = engine.Peek();
+
+    TypingConfig baseline = MakeCombinedConfig();
+    TypingEngine baselineEngine(baseline);
+    TypeString(baselineEngine, L"as6w7");
+    EXPECT_EQ(withDefault, baselineEngine.Peek());
+}
+
+}  // namespace
+}  // namespace NextKey

--- a/tests/CustomKeyMapTest.cpp
+++ b/tests/CustomKeyMapTest.cpp
@@ -178,7 +178,7 @@ class CustomKeyMapAllActions
     : public CustomKeyMapTest,
       public ::testing::WithParamInterface<TypingAction> {};
 
-TEST_P(CustomKeyMapAllActions, EveryTypingActionRoundtrips) {
+TEST_P(CustomKeyMapAllActions, EveryTypingActionNoThrow) {
     const TypingAction action = GetParam();
     ASSERT_NE(action, TypingAction::None) << "G7 only iterates non-None actions";
 

--- a/tests/CustomKeyMapTest.cpp
+++ b/tests/CustomKeyMapTest.cpp
@@ -100,5 +100,128 @@ TEST_F(CustomKeyMapTest, RemapVniDigit1ToClearTone) {
     EXPECT_EQ(engine.Peek(), L"a");
 }
 
+
+// =====================================================================
+// G3 — Gap-fill: map a key that ClassifyKey returns None for
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, MapQToClearTone_TelexMode) {
+    TypingConfig cfg = MakeTelexConfig();
+    // 'q' is not a Telex action key — ClassifyKey returns None.
+    cfg.customKeyMap[static_cast<size_t>(L'q')] = TypingAction::ClearTone;
+    TypingEngine engine(cfg);
+    TypeString(engine, L"asq");  // 'a' + sắc → 'á', then 'q' clears tone → 'a'
+    EXPECT_EQ(engine.Peek(), L"a");
+}
+
+TEST_F(CustomKeyMapTest, MapQToToneAcute_VniMode) {
+    TypingConfig cfg = MakeVniConfig();
+    // 'q' is not a VNI action key — ClassifyKey returns None.
+    cfg.customKeyMap[static_cast<size_t>(L'q')] = TypingAction::ToneAcute;
+    TypingEngine engine(cfg);
+    TypeString(engine, L"aq");  // 'a' + remapped 'q' → ToneAcute → 'á'
+    EXPECT_EQ(engine.Peek(), L"á");
+}
+
+// =====================================================================
+// G4 — ASCII boundary: non-ASCII keys bypass the override branch
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, NonAsciiKeyFallsBackToClassifyKey) {
+    TypingConfig cfg = MakeTelexConfig();
+    // The override array has only 128 slots; non-ASCII keys must skip
+    // the override check entirely (defensive: `lower < 128` guard).
+    // We verify by typing a Vietnamese char directly — the engine treats
+    // it as a literal char (ClassifyKey returns None for it), and no
+    // override applies because `lower >= 128`.
+    TypingEngine engine(cfg);
+    TypeString(engine, L"á");  // U+00E1, definitely >= 128
+    EXPECT_EQ(engine.Peek(), L"á");  // unchanged literal pass-through
+}
+
+// =====================================================================
+// G5 — isVniDigitSequence post-applies even when override fired
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, OverrideOnDigitYieldsLiteralInDigitSequence) {
+    TypingConfig cfg = MakeVniConfig();
+    // Remap '7' → ToneHook (instead of default VniHorn).
+    cfg.customKeyMap[static_cast<size_t>(L'7')] = TypingAction::ToneHook;
+    TypingEngine engine(cfg);
+    // Type a literal digit first to enter "VNI digit sequence" mode.
+    TypeString(engine, L"4");
+    // Now '7' should be treated as literal (digit-sequence guard wins
+    // over both the override and the default VniHorn) → composed "47".
+    TypeString(engine, L"7");
+    EXPECT_EQ(engine.Peek(), L"47");
+}
+
+// =====================================================================
+// G6 — Sentinel: explicit None == not set
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, CustomMapNoneFallsThroughToClassifyKey) {
+    TypingConfig cfg = MakeTelexConfig();
+    // Explicitly set 's' to None — must be indistinguishable from default.
+    cfg.customKeyMap[static_cast<size_t>(L's')] = TypingAction::None;
+    TypingEngine engine(cfg);
+    TypeString(engine, L"as");
+    // Default Telex: 'a' + 's' → 'á' (sắc).
+    EXPECT_EQ(engine.Peek(), L"á");
+}
+
+// =====================================================================
+// G7 — Parametric smoke: every non-None TypingAction reachable via remap
+// =====================================================================
+
+class CustomKeyMapAllActions
+    : public CustomKeyMapTest,
+      public ::testing::WithParamInterface<TypingAction> {};
+
+TEST_P(CustomKeyMapAllActions, EveryTypingActionRoundtrips) {
+    const TypingAction action = GetParam();
+    ASSERT_NE(action, TypingAction::None) << "G7 only iterates non-None actions";
+
+    // Configure: 'q' (which ClassifyKey returns None for in pure Telex mode)
+    // remapped to the parameter action. Compare composed output of typing
+    // "q" against an engine driven through the natural key for the same
+    // action. We do not assert specific Vietnamese strings here — only
+    // that dispatch reaches the correct action handler (no crash, action
+    // resolves). Engine state observation is via Peek().
+    TypingConfig cfg = MakeCombinedConfig();
+    cfg.customKeyMap[static_cast<size_t>(L'q')] = action;
+    TypingEngine engine(cfg);
+    // Seed a vowel so modifier/tone actions have something to operate on.
+    TypeString(engine, L"a");
+    EXPECT_NO_THROW(TypeString(engine, L"q"));
+    // Final Peek should be a non-empty wstring (engine must not be in a
+    // broken state after dispatch).
+    EXPECT_FALSE(engine.Peek().empty());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllActions,
+    CustomKeyMapAllActions,
+    ::testing::Values(
+        TypingAction::ClearTone,
+        TypingAction::ToneAcute,
+        TypingAction::ToneGrave,
+        TypingAction::ToneHook,
+        TypingAction::ToneTilde,
+        TypingAction::ToneDot,
+        TypingAction::CircumflexA,
+        TypingAction::CircumflexE,
+        TypingAction::CircumflexO,
+        TypingAction::HornW,
+        TypingAction::HornInsertO,
+        TypingAction::HornInsertU,
+        TypingAction::StrokeD,
+        TypingAction::VniCircumflex,
+        TypingAction::VniHorn,
+        TypingAction::VniBreve,
+        TypingAction::VniStroke
+    )
+);
+
 }  // namespace
 }  // namespace NextKey

--- a/tests/CustomKeyMapTest.cpp
+++ b/tests/CustomKeyMapTest.cpp
@@ -75,5 +75,30 @@ TEST_F(CustomKeyMapTest, DefaultEmptyMatchesCombined) {
     EXPECT_EQ(engine.Peek(), L"ắ7");
 }
 
+
+// =====================================================================
+// G2 — Replace built-in: user override always wins (precedence)
+// =====================================================================
+
+TEST_F(CustomKeyMapTest, RemapTelexSToToneHook) {
+    TypingConfig cfg = MakeTelexConfig();
+    cfg.customKeyMap[static_cast<size_t>(L's')] = TypingAction::ToneHook;
+    TypingEngine engine(cfg);
+    TypeString(engine, L"as");
+    // Default Telex: 'a' + 's' → 'á' (sắc). With remap 's'→ToneHook: 'a' + 's' → 'ả' (hỏi).
+    EXPECT_EQ(engine.Peek(), L"ả");
+}
+
+TEST_F(CustomKeyMapTest, RemapVniDigit1ToClearTone) {
+    TypingConfig cfg = MakeVniConfig();
+    // Default VNI: '1' → ToneAcute. Remap '1' → ClearTone.
+    cfg.customKeyMap[static_cast<size_t>(L'1')] = TypingAction::ClearTone;
+    TypingEngine engine(cfg);
+    TypeString(engine, L"a2");  // 'a' + grave → 'à'
+    EXPECT_EQ(engine.Peek(), L"à");
+    TypeString(engine, L"1");   // remapped: clear tone
+    EXPECT_EQ(engine.Peek(), L"a");
+}
+
 }  // namespace
 }  // namespace NextKey


### PR DESCRIPTION
## Summary

G-4 of Sprint 3 Path G — adds a per-key user override layer to `TypingEngine` so users can remap any ASCII key to any `TypingAction`. Default-empty preserves all 1450 prior GTests byte-identically.

- **+1 field** on `TypingConfig` (`std::array<TypingAction, 128> customKeyMap{}`)
- **+4 effective LOC** at `TypingEngine.cpp:235` (single-load ternary override-then-fallback)
- **+27 GTest cases** in `tests/CustomKeyMapTest.cpp` (10 named + 17 parametric) → total **1477 PASS** on Linux

## Dispatch shape (G-4)

```
PushChar(c)
  └─ lower = towlower(c)
  └─ if (lower < 128 && customKeyMap[lower] != None)
        action = customKeyMap[lower]            ← user override wins
     else
        action = ClassifyKey(lower, isTelex, isVni)
  └─ if (isVniDigitSequence) action = None       ← literal-digit guard post-applies
  └─ ProcessModifier(action, c) → 6 Handle*
```

## Spec §8 acceptance criteria

| AC | Status |
|---|---|
| #1 customKeyMap field type/default | ✅ `array<TypingAction, 128>{}` in TypingConfig.h |
| #2 PushChar consults override per §3.3 | ✅ Single-load ternary at TypingEngine.cpp:235 |
| #3 1450 baseline tests still pass | ✅ Verified |
| #4 ≥12 new tests covering G1-G7 | ✅ 27 (10 named + 17 parametric) |
| #5 Total ≥1463 | ✅ 1477 |
| #6 No source change in ConfigManager / TypingAction.h / handlers | ✅ ConfigManager 0-byte diff. TypingAction.h diff = doc-only (`256→128` stale comment fix + remove "G-4 will" forward-ref). All Handle* untouched |
| #7 Windows MSVC clean | ✅ Verified locally by @phatMT97 |

## Out of scope (deferred to G-5)

ConfigManager TOML wiring, Sciter dialog for editing keymaps, per-user `keymap_<name>.toml` files, active-method selector. G-4 ships engine hook only — `customKeyMap` is initialized empty.

## Review trail

Workflow: brainstorming → spec → plan → execute (subagent-driven). Each task had spec-compliance review + code-quality review with fix loops. Final review pass with `nexuskey-review` checklist + `simplify` (3-agent: reuse/quality/efficiency).

- **Spec:** `docs/superpowers/specs/2026-05-07-path-g-g4-customkeymap-design.md`
- **Plan:** `docs/superpowers/plans/2026-05-07-path-g-g4-customkeymap.md`

## Test plan

- [x] Linux GTest 1477/1477 PASS (\`./build-linux/tests/NextKeyTests\`)
- [x] Windows MSVC build clean (verified locally)
- [ ] Manual smoke: type with default config → no behavior change vs Main
- [ ] Manual smoke: hand-set \`customKeyMap['q'] = ToneAcute\` in a test config → q applies sắc