### PR TITLE
H3 refactor: atomic migration for cachedFocusedHwnd_

### DIFF
--- a/src/app/system/HookEngine.cpp
+++ b/src/app/system/HookEngine.cpp
@@ -784,8 +784,8 @@ LRESULT CALLBACK HookEngine::LowLevelMouseProc(int nCode, WPARAM wParam, LPARAM 
                 // Click may move focus to another control within the same app (no
                 // EVENT_SYSTEM_FOREGROUND fires) — invalidate cache so the next
                 // TryEditMessagePaste re-queries the focused HWND.
-                self->cachedFocusedHwnd_ = nullptr;
-                self->cachedFocusedClass_.clear();
+                self->cachedFocusedHwnd_.store(nullptr, std::memory_order_relaxed);
+                self->cachedFocusedClass_.clear();  // see HWND comment in HookEngine.h: tuple race benign
             }
         }
     } catch (const std::exception& e) {
@@ -2000,10 +2000,10 @@ bool HookEngine::TryEditMessagePaste(const std::wstring& text, size_t backspaceC
 
     // Prefer cached focused HWND (populated in OnFocusChanged / invalidated on mouse click)
     // to avoid AttachThreadInput on every keystroke. Fall back to a fresh query on miss.
-    HWND hwnd = cachedFocusedHwnd_;
+    HWND hwnd = cachedFocusedHwnd_.load(std::memory_order_relaxed);
     if (!hwnd || !IsWindow(hwnd)) {
         RefreshFocusCache(GetForegroundWindow());
-        hwnd = cachedFocusedHwnd_;
+        hwnd = cachedFocusedHwnd_.load(std::memory_order_relaxed);
         if (!hwnd) {
             HOOK_LOG(L"  EditMsgPaste: no focused child hwnd");
             return false;
@@ -2540,10 +2540,11 @@ void HookEngine::OnTickPoll() noexcept {
 }
 
 void HookEngine::RefreshFocusCache(HWND foreground) noexcept {
-    cachedFocusedHwnd_ = ::NextKey::GetFocusedChildHwnd(foreground);
-    if (cachedFocusedHwnd_) {
+    HWND focused = ::NextKey::GetFocusedChildHwnd(foreground);
+    cachedFocusedHwnd_.store(focused, std::memory_order_relaxed);
+    if (focused) {
         wchar_t cls[64] = {};
-        GetClassNameW(cachedFocusedHwnd_, cls, 64);
+        GetClassNameW(focused, cls, 64);
         cachedFocusedClass_.assign(cls);
     } else {
         cachedFocusedClass_.clear();
@@ -2692,7 +2693,7 @@ void HookEngine::OnFocusChanged(HWND triggerHwnd) {
     if (localClipboard || localEditMsg) {
         RefreshFocusCache(activeHwnd);
     } else {
-        cachedFocusedHwnd_ = nullptr;
+        cachedFocusedHwnd_.store(nullptr, std::memory_order_relaxed);
         cachedFocusedClass_.clear();
     }
 

--- a/src/app/system/HookEngine.h
+++ b/src/app/system/HookEngine.h
@@ -435,7 +435,14 @@ private:
     // Focused child HWND + class name, cached to avoid AttachThreadInput per keystroke
     // (used by TryEditMessagePaste for VB6/ANSI apps). Refreshed in OnFocusChanged and
     // invalidated on mouse click (within-app focus change).
-    HWND cachedFocusedHwnd_ = nullptr;
+    //
+    // Cross-thread: written by LowLevelMouseProc (mouse hook thread) AND
+    // WinEventProc (window event thread); read by key thread. HWND is atomic
+    // (compiler-fence + intent doc; x64 hardware already torn-read-safe for
+    // 8B aligned pointers). Class wstring is NOT atomic — the resulting
+    // tuple race is benign: a brief stale-class read causes at worst a
+    // 1-keystroke filter miss, which the next focus change recovers.
+    std::atomic<HWND> cachedFocusedHwnd_{nullptr};
     std::wstring cachedFocusedClass_;
 
     // Direct SharedState reader — pointer to the global SharedStateManager (same process)


### PR DESCRIPTION
## Summary

Closes Pre-T3 Minor 1 (`docs/TODO.md`) per `docs/REFACTOR_STATUS.md` §C H3.

`HookEngine::cachedFocusedHwnd_` is written by **LowLevelMouseProc** (mouse hook thread) and **WinEventProc** (window event thread), and read by the **key thread** during `TryEditMessagePaste`. Migrate the field to `std::atomic<HWND>` with `relaxed` memory order to formalise the cross-thread access pattern.

## What changed

| Site | Before | After |
|---|---|---|
| Decl (HookEngine.h:438) | `HWND cachedFocusedHwnd_ = nullptr` | `std::atomic<HWND> cachedFocusedHwnd_{nullptr}` |
| LowLevelMouseProc (787) | `= nullptr` | `.store(nullptr, relaxed)` |
| TryEditMessagePaste (2003, 2006) | implicit read | `.load(relaxed)` |
| RefreshFocusCache (2543-46) | direct write + double-read | local var + `.store(focused, relaxed)` |
| OnFocusChanged off-path (2696) | `= nullptr` | `.store(nullptr, relaxed)` |

## Why `relaxed`?

HWND value is independent of other state — no happens-before coupling needed. On x64, 8B aligned pointer reads/writes are torn-safe in hardware; `std::atomic<HWND>` adds compiler-fence + intent documentation.

## Tuple race with `cachedFocusedClass_`

Documented as benign in the field comment. The wstring is not cleanly atomic-able; brief stale-class read between mouse-clear and refresh causes at most a 1-keystroke filter miss, recovered on next focus change. **MainThreadWorker defer** (option 2 from docs/TODO.md) was rejected as overkill for benign window.

## Test plan

- [x] Linux GTest 1477/1477 PASS (no regression)
- [ ] Windows MSVC build clean — to be verified by @phatMT97
- [ ] Manual smoke: type → switch focus mid-word via mouse click → verify no stale-cache misroute (TryEditMessagePaste fires correctly after focus shift)

## Refactor inventory delta

After merge: REFACTOR_STATUS.md §C row H3 will be marked DONE in a follow-up doc commit (or anh can do inline).