### PR TITLE
fix(T5): tone replacement + modifier on invalid buffer recover validity

### DIFF
--- a/src/core/engine/TypingEngine.cpp
+++ b/src/core/engine/TypingEngine.cpp
@@ -282,7 +282,25 @@ void TypingEngine::PushChar(wchar_t c) {
                     [](const CharState& s) { return Compose(s); },
                     t, tonedCh);
             }
-            if (!isEscape && !matchesExclusion) { asLiteral(); return; }
+            // T5 (docs/TODO.md): allow tone REPLACEMENT when the current invalid
+            // buffer would become Valid after swapping the existing tone for the
+            // requested one. Covers `cafcs → các`: `càc` is invalid (huyền + stop
+            // coda c) so spellCheckDisabled_=true; without this branch the next
+            // tone key 's' falls through to asLiteral and produces `càcs`. With
+            // this branch we speculatively validate `các` (sắc + stop coda c =
+            // valid), and ProcessTone replaces huyền with sắc as the user intended.
+            // Conservative: requires an EXISTING tone at target (HasTone) — first-
+            // application on invalid buffer still treats key as literal.
+            bool wouldRecover = false;
+            if (!isEscape && !matchesExclusion && t != SIZE_MAX && states_[t].HasTone()) {
+                Tone savedTone = states_[t].tone;
+                states_[t].tone = requestedTone;
+                auto result = Phonology::ValidateSyllableState(
+                    states_.data(), states_.size(), config_.allowZwjf);
+                states_[t].tone = savedTone;
+                wouldRecover = (result == Phonology::SyllableState::Valid);
+            }
+            if (!isEscape && !matchesExclusion && !wouldRecover) { asLiteral(); return; }
         }
         // Tone escape: user pressed same tone twice — blocks Vietnamese.
         if (escape_.isEscaped())                                { asLiteral(); return; }
@@ -388,7 +406,15 @@ void TypingEngine::PushChar(wchar_t c) {
             if (!canEscape) {
                 canEscape = WouldModifierKeyMatchExclusion(lower);
             }
-            if (canEscape && ProcessModifier(action, c)) {
+            // T5 case 2 (anh 2026-05-07): if the buffer is invalid SOLELY because
+            // of tone-stop-coda mismatch (e.g., càc — huyền + stop coda c), allow
+            // the modifier through. The user is mid-correction; subsequent tone
+            // keystroke recovers validity via the T5 case 1 branch in the tone
+            // gate above. Covers `cafcwj → cặc`, `cafcaj → cậc`, etc. Without
+            // this, modifier is treated as literal and the chain never reaches
+            // the recovery tone.
+            bool isToneStopCodaMismatch = IsToneStopCodaMismatch();
+            if ((canEscape || isToneStopCodaMismatch) && ProcessModifier(action, c)) {
                 engProt_.bias = LanguageBias::Vietnamese;
                 ApplyAutoUO();
                 UpdateSpellState();
@@ -432,7 +458,11 @@ void TypingEngine::PushChar(wchar_t c) {
             if (!canEscape) {
                 canEscape = WouldModifierKeyMatchExclusion(lower);
             }
-            if (canEscape && ProcessModifier(action, c)) {
+            // T5 case 2: same recovery-via-tone-fix branch as the Telex modifier
+            // path above. VNI uses digits 6/7/8/9 for vowel modifiers; the buffer
+            // can be in the same tone-stop-coda-mismatch state.
+            bool isToneStopCodaMismatch = IsToneStopCodaMismatch();
+            if ((canEscape || isToneStopCodaMismatch) && ProcessModifier(action, c)) {
                 engProt_.bias = LanguageBias::Vietnamese;
                 ApplyAutoUO();
                 UpdateSpellState();
@@ -1144,6 +1174,28 @@ void TypingEngine::RelocateToneToTarget() {
 // back to a state index.
 //-----------------------------------------------------------------------------
 
+bool TypingEngine::IsToneStopCodaMismatch() const noexcept {
+    // T5 (anh 2026-05-07): "tone-stop-coda mismatch" = a syllable invalid
+    // SOLELY because the existing tone (huyền/hỏi/ngã) is incompatible with
+    // a stop final coda (c/ch/p/t). Vietnamese phonotactics: stop codas only
+    // permit sắc and nặng tones; the other three tones force re-evaluation.
+    //
+    // Used by tone and modifier gates as a "user is mid-correction" predicate.
+    // When true, the gate lets through a tone or modifier that would otherwise
+    // be treated as literal — covers the `cafcs → các` and `cafcwj → cặc`
+    // chains where the user mistypes huyền then corrects.
+    if (!HasStopFinalCoda(states_.data(), states_.size())) return false;
+    for (const auto& state : states_) {
+        if (!state.HasTone()) continue;
+        // First tone-bearing vowel determines mismatch — sắc/nặng = compatible,
+        // huyền/hỏi/ngã = mismatch.
+        return state.tone == Tone::Grave
+            || state.tone == Tone::Hook
+            || state.tone == Tone::Tilde;
+    }
+    return false;
+}
+
 size_t TypingEngine::FindToneTarget() const {
     // Cap matches Phonotactics' internal vowel capacity; sequences past the cap
     // are truncated identically on both sides so the index map stays consistent.
@@ -1654,9 +1706,18 @@ bool TypingEngine::WouldBeValidSyllable(size_t targetIdx, Modifier newMod,
         didClear = true;
     }
     auto result = Phonology::ValidateSyllableState(states_.data(), states_.size(), config_.allowZwjf);
+    // T5 case 2 (anh 2026-05-07): if the speculative state is Invalid SOLELY
+    // because of tone-stop-coda mismatch (huyền/hỏi/ngã + stop coda c/ch/p/t),
+    // accept the modifier — the user is mid-correction and the next tone
+    // keystroke recovers via the T5 case 1 branch in the tone gate. Without
+    // this, P5/P6/P7 in HandleHornW reject `càc + w` because `cằc` is still
+    // invalid, and `w` falls through to literal even though the user clearly
+    // wants to type `cặc`/`cẳc`/etc.
+    bool recoverableMismatch = (result == Phonology::SyllableState::Invalid)
+                               && IsToneStopCodaMismatch();
     if (didClear) states_[clearCircumflexIdx].mod = Modifier::Circumflex;
     states_[targetIdx].mod = saved;
-    return result != Phonology::SyllableState::Invalid;
+    return result != Phonology::SyllableState::Invalid || recoverableMismatch;
 }
 
 }  // namespace NextKey

--- a/src/core/engine/TypingEngine.h
+++ b/src/core/engine/TypingEngine.h
@@ -158,6 +158,13 @@ private:
     // Find target for tone/modifier application — delegates to phonotactics_.
     size_t FindToneTarget() const;
 
+    // T5 (anh 2026-05-07): true when the buffer is invalid because the existing
+    // tone (huyền/hỏi/ngã) is incompatible with a stop final coda (c/ch/p/t).
+    // Used by tone and modifier gates as a "mid-correction" predicate — when
+    // true, the user is presumed to be fixing the syllable so we let through
+    // tone replacement / modifier even if the current snapshot is invalid.
+    [[nodiscard]] bool IsToneStopCodaMismatch() const noexcept;
+
     // Auto ươ: convert 'uơ' to 'ươ' when followed by another character
     void ApplyAutoUO();
 

--- a/tests/CombinedEngineTest.cpp
+++ b/tests/CombinedEngineTest.cpp
@@ -375,5 +375,66 @@ TEST_F(CombinedEngineSpellTest, EnglishProtection_TestDigits) {
     // The important thing is the overall word doesn't produce unexpected Vietnamese
 }
 
+// T5 (docs/TODO.md): baseline forward 'casc' → 'các' under spell-check ON.
+TEST_F(CombinedEngineSpellTest, T5_ToneAfterCoda_BaselineForward) {
+    TypeString(*engine_, L"casc");
+    EXPECT_EQ(engine_->Peek(), L"các");
+}
+
+// T5 (docs/TODO.md): user mistypes huyền 'f' on 'ca', adds coda 'c', then
+// corrects with sắc 's'. Engine must replace huyền with sắc on 'à' → 'các'.
+// Spell-check ON — this is where the original bug was reported. If engine
+// alone (TelexEngineTest spell-check OFF) passes but THIS fails, the bug is
+// in the validator (PhonotacticsValidator) blocking the post-replace candidate.
+TEST_F(CombinedEngineSpellTest, T5_ToneReplaceAfterCoda_WithSpellCheck) {
+    TypeString(*engine_, L"cafcs");
+    EXPECT_EQ(engine_->Peek(), L"các")
+        << "After 'cafcs' under spell-check ON, engine must replace huyền\n"
+        << "with sắc on already-toned 'à' → 'các'. Bug per docs/TODO.md.";
+}
+
+// T5 case 2 (anh 2026-05-07): modifier on invalid buffer + tone correction.
+// User types 'cafc' (yields invalid `càc`), then 'w' to change 'a' to 'ă'
+// (yields `cằc` — still invalid since huyền + stop coda), then 'j' to switch
+// tone to nặng → `cặc` (valid: nặng + stop coda). Expects engine to allow
+// the modifier through despite intermediate invalid state, and the tone-
+// replacement gate to recover validity on the final 'j'.
+TEST_F(CombinedEngineSpellTest, T5_ModifierThenToneFix_W_J) {
+    TypeString(*engine_, L"cafcwj");
+    EXPECT_EQ(engine_->Peek(), L"cặc")
+        << "User mistypes huyền+coda invalid (càc), then corrects vowel with\n"
+        << "w (a→ă, still invalid cằc), then tone with j (huyền→nặng = cặc valid).";
+}
+
+// T5 case 2 variant: same scenario with 'aa' (circumflex a→â) instead of 'w'.
+TEST_F(CombinedEngineSpellTest, T5_ModifierThenToneFix_AA_J) {
+    TypeString(*engine_, L"cafcaj");
+    EXPECT_EQ(engine_->Peek(), L"cậc")
+        << "User corrects vowel with aa (a→â) then tone with j (huyền→nặng).";
+}
+
+// T5 case 1 — generic across vowels (anh question 2026-05-07: "mấy chữ như e o có bị không").
+// Verify the tone-replacement-recovers-validity fix works for all main vowels,
+// not just 'a'. ValidateSyllableState is called on the speculative buffer so the
+// recovery condition is purely "speculative result is Valid" — vowel-agnostic.
+TEST_F(CombinedEngineSpellTest, T5_ToneReplaceAfterCoda_E) {
+    // kefcs: k-e-f-c-s → kè coda → kèc invalid (huyền+stop) → 's' replaces → kéc.
+    // Note: 'cefcs' would fail because c/k/qu onset rule blocks 'c+e' (use 'k+e').
+    TypeString(*engine_, L"kefcs");
+    EXPECT_EQ(engine_->Peek(), L"kéc");
+}
+
+TEST_F(CombinedEngineSpellTest, T5_ToneReplaceAfterCoda_O) {
+    // cofcs: c-o-f-c-s → còc invalid → 's' replaces huyền with sắc → cóc (real word: "frog").
+    TypeString(*engine_, L"cofcs");
+    EXPECT_EQ(engine_->Peek(), L"cóc");
+}
+
+TEST_F(CombinedEngineSpellTest, T5_ToneReplaceAfterCoda_OO) {
+    // cooft → coo→ô, f huyền → cồt invalid (huyền+stop) → s replaces → cốt (real word: "core").
+    TypeString(*engine_, L"coofts");
+    EXPECT_EQ(engine_->Peek(), L"cốt");
+}
+
 }  // namespace
 }  // namespace NextKey

--- a/tests/TelexEngineTest.cpp
+++ b/tests/TelexEngineTest.cpp
@@ -1586,6 +1586,26 @@ TEST_F(TelexEngineTest, EdgeCase_ToneReplace_2) {
     EXPECT_EQ(engine_->Peek(), L"ả");
 }
 
+// T5 (docs/TODO.md): tone replacement on already-toned syllable WITH coda.
+// Baseline: forward typing 'casc' should produce 'các' — no replacement involved.
+TEST_F(TelexEngineTest, T5_ToneAfterCoda_BaselineForward) {
+    TypeString(*engine_, L"casc");
+    EXPECT_EQ(engine_->Peek(), L"các");
+}
+
+// T5 (docs/TODO.md): user mistypes 'f' (huyền) on 'ca', adds coda 'c', then
+// corrects with 's' (sắc). 's' must REPLACE huyền with sắc on the toned vowel.
+// Spell-check OFF here — isolates whether the engine alone handles this.
+//   PASS → engine OK; bug lives in PhonotacticsValidator path (CombinedEngineSpellTest).
+//   FAIL → engine tone-replacement logic broken irrespective of validator.
+TEST_F(TelexEngineTest, T5_ToneReplaceAfterCoda_NoSpellCheck) {
+    TypeString(*engine_, L"cafcs");
+    EXPECT_EQ(engine_->Peek(), L"các")
+        << "After 'cafcs', engine should replace huyền with sắc on 'à' → 'các'.\n"
+        << "PASS means engine alone is fine; bug is in validator (CombinedEngineSpellTest).\n"
+        << "FAIL means TypingEngine tone-replacement logic itself is broken.";
+}
+
 TEST_F(TelexEngineTest, EdgeCase_GI_Plus_U) {
     TypeString(*engine_, L"giuw");
     EXPECT_EQ(engine_->Peek(), L"giư");


### PR DESCRIPTION
## Summary

Closes REFACTOR_STATUS §D row **T5** — tone-replacement blocked on already-toned syllable.

The engine treated tone/modifier keys as literal whenever `spellCheckDisabled_` was true (buffer is currently Invalid). This meant when the user mistyped a tone that conflicted with a stop final coda (huyền/hỏi/ngã + c/ch/p/t), there was no path to type out of the invalidity:

| Sequence  | Pre-fix      | Post-fix | Notes |
|-----------|--------------|----------|-------|
| `cafcs`   | `càcs`       | `các`    | T5 original bug — tone replacement |
| `cofcs`   | `còcs`       | `cóc`    | Same pattern, vowel `o` |
| `kefcs`   | `kèfcs` etc. | `kéc`    | Generic across vowels (anh question) |
| `coofts`  | broken       | `cốt`    | With circumflex modifier already applied |
| `cafcwj`  | `càcwj`      | `cặc`    | Case 2 — modifier + tone correction |
| `cafcaj`  | `càcaj`      | `cậc`    | Case 2 with circumflex variant |

## Fix shape

A single shared predicate plus three coordinated gate-relaxations.

```cpp
// New helper — const noexcept, O(N).
bool TypingEngine::IsToneStopCodaMismatch() const noexcept;
```

Returns true iff the buffer is Invalid SOLELY because the existing tone (huyền/hỏi/ngã) is incompatible with a stop final coda (c/ch/p/t).

1. **Tone gate** (PushChar step 1, spellCheckDisabled_ branch) — speculatively replace the existing tone with the requested one and ask the validator: does the syllable become Valid? If yes, allow ProcessTone. Conservative: only when target has an existing tone (so first-application on Invalid is unchanged).
2. **Modifier outer gate** (PushChar steps 2a/2b for Telex and VNI) — when the buffer is in tone-stop-coda mismatch state, allow ProcessModifier even if canEscape conditions don't match.
3. **`WouldBeValidSyllable` extension** — after speculatively applying the modifier, if the result is still Invalid but only due to the same tone-stop-coda pattern, accept it. Without this, HandleHornW's P5/P6/P7 priorities reject `càc + w` because `cằc` is still Invalid, even though the user is clearly fixing the syllable.

## Why this is safe

- All three gate-relaxations hinge on `IsToneStopCodaMismatch()` — a tightly-scoped predicate that ONLY fires for a specific recoverable pattern.
- Hot-path cost: one extra `ValidateSyllableState` call (~hundreds of ns) on the rare `spellCheckDisabled_` path. Well within Rule #11.1 1 ms budget.
- No effect when buffer is Valid (the common case) — gates short-circuit before reaching the new logic.
- Engine-only fix. HookEngine and TSF DLL untouched.
- CODING_RULES checked: PascalCase method, camelCase locals, `[[nodiscard]]` on public bool, `const noexcept`, no MessageBox/throw, no hot-path mutex/IO/blocking.

## Test plan

- [x] Linux NextKeyTests **1515 → 1524 PASS** (+9 T5 tests, no regression)
- [x] Windows MSVC NextKeyTests — clean build under `/WX`, T5 filter 9/9 PASS
- [x] T5 case 1 (tone replace recovers Valid) — covered for vowels a/e/o/ô
- [x] T5 case 2 (modifier + tone fix chain) — covered for `w` and `aa` modifier paths

Test fixtures used:
- `TelexEngineTest` (spell-check OFF) — confirms engine alone works post-fix.
- `CombinedEngineSpellTest` (spell-check ON) — where the bug lives.