### PR TITLE
refactor(T2): enforce c/k, g/gh, ng/ngh onset agreement in IsValidSyllable

### DIFF
--- a/docs/REFACTOR_STATUS.md
+++ b/docs/REFACTOR_STATUS.md
@@ -1,8 +1,8 @@
 # NexusKey Refactor Status — Living Inventory
 
-> **Last refresh:** 2026-05-07 (post T5 #146, Main `1ade8dc`)
+> **Last refresh:** 2026-05-08 (post T2, Main pending)
 > **Scope:** All architectural / cleanup refactor work. Excludes user-facing features (G-5/G-6 Sciter UI + keymap files, TSF Phase 2/3, etc.) — those track separately.
-> **Sequencing rule (anh decision 2026-05-07):** Complete HookEngine refactor backlog BEFORE picking up TypingEngine TODO items. **Post-H1c the rule is satisfied; T5 also done.** Remaining: T2/T3 (phonotactics correctness) + T6 retest (likely auto-resolved by H1).
+> **Sequencing rule (anh decision 2026-05-07):** Complete HookEngine refactor backlog BEFORE picking up TypingEngine TODO items. **Post-H1c the rule is satisfied; T5 done; T2 done.** Remaining: T3 (phonotactics correctness) + T6 retest (anh confirmed test ổn 2026-05-08, can close).
 
 ---
 
@@ -49,6 +49,7 @@
 | **H1b** `RunTopGuards` extract | #144 `3c06499` | 2026-05-07 | Steps 0/0b/1/1b/1c (TSF early-out / modifier track / toggle keys / excluded-app PID verification, 54 LOC) extracted. Bookkeeping (`otherKeyPressed_/altTapCount_/synth-watchdog`) stays in ProcessKeyDown post-switch — runs only on Fallthrough; excluded-app's same-PID/still-excluded paths set `otherKeyPressed_` themselves before returning Pass. ProcessKeyDown 380 → 327 LOC. `CommitUndoOutcome` renamed to generic `KeyOutcome` for sharing across H1a/H1b/H1c. Chaos 55/55 PASS. |
 | **H1c** `HandlePreDispatch` + `DispatchKeyAction` extract | #145 `659b910` | 2026-05-07 | Steps 3 / 3a-3d (English mode + auto-caps + macro tracking, ~107 LOC) → `HandlePreDispatch`. Steps 4b-10 (tempEngineOff / Ctrl-Alt-Win / alpha / bracket / VNI digit / BS / commit-trigger / fallthrough, ~158 LOC) → `DispatchKeyAction`. Cache shifted from after-step-3 to before HandlePreDispatch — byte-identical because GetKeyState within hook callback is stable. ProcessKeyDown 327 → **79 LOC** orchestrator (-86% cumulative across H1). Chaos 55/55 PASS. **HookEngine refactor backlog effectively closed.** |
 | **T5** Tone replacement on invalid buffer recovers validity | #146 `1ade8dc` | 2026-05-07 | New helper `TypingEngine::IsToneStopCodaMismatch()` + 3 gate-relaxations (tone gate, modifier outer gate, `WouldBeValidSyllable`). Engine no longer treats tone/modifier as literal when current buffer is Invalid solely because of huyền/hỏi/ngã + stop coda — the user is mid-correction; next tone keystroke recovers. Generic across vowels (a/e/o/ô) + Telex/VNI modifier paths. Linux 1524/1524 PASS (+9 T5 tests). Windows MSVC clean. Hot-path cost ~hundreds of ns on rare `spellCheckDisabled_` path, within Rule #11.1 1 ms budget. |
+| **T2** Phonotactics onset/vowel agreement | PR pending | 2026-05-08 | `Phonotactics::IsValidSyllable` no longer ignores `onset` arg. New helper `IsOnsetVowelAgreementValid` enforces c/k, g/gh, ng/ngh front-back agreement against first base vowel of `vowelSeq`; qu intentionally exempted (qua/quan/quát outside the canonical labial-diphthong list). Production zero-touch — interface had no production caller; this closes the contract for future consumers (spell-check overlay, dictionary lookups). Linux 1540/1540 PASS (+16 T2 tests). |
 
 ---
 
@@ -93,7 +94,8 @@
 | ID | Item | Source | Effort | Priority |
 |---|---|---|---|---|
 | ~~T1~~ | ~~**`SpellChecker.{h,cpp}` → `PhonotacticsValidator` rename**~~ | — | DONE | ✅ PR #139 `b115f75` |
-| T2 | **Phonotactics onset agreement** — c/k/qu, g/gh, ng/ngh enforcement (`IsValidSyllable` currently ignores `onset` arg) | Path G G-1 deferred | 2-3h | MEDIUM (correctness) |
+| ~~T2~~ | ~~**Phonotactics onset agreement** — c/k, g/gh, ng/ngh enforcement (qu exempted)~~ | — | DONE | ✅ PR pending |
+| T2.1 | **Onset-rule duplication between `Phonotactics.cpp` and `PhonotacticsValidator.cpp`** — both encode c/k/g/gh/ng/ngh front-back agreement; PV operates on `CharState`, P on `wstring_view`. Shared classifier `IsFrontBaseVowel` exists in both anonymous namespaces. Pre-existing; surfaced during T2. Lift to shared header (e.g. `VietnameseTables.h`) when a third validator wants the rule. | T2 review (simplify reuse agent) | 30-60min | LOW (cleanup) |
 | T3 | **Phonotactics N1/N2/N3 vowel-coda compatibility** — tighter group rules | Path G G-1 deferred | 2-3h | MEDIUM (correctness) |
 | ~~T4~~ | ~~**Verify Hot-path Fix 3 ComposeAll buffer reuse**~~ — VERIFIED 2026-05-07: shipped at `TypingEngine.h:218` (`mutable std::wstring composeBuf_`) + `TypingEngine.cpp:1236-1241` | hot-path-optimization-plan.md | DONE | ✅ |
 | ~~T5~~ | ~~**Bug `cafcs → các`**~~ | — | DONE | ✅ PR #146 `1ade8dc` |

--- a/src/core/engine/Phonotactics.cpp
+++ b/src/core/engine/Phonotactics.cpp
@@ -168,6 +168,39 @@ constexpr std::wstring_view kValidCodas[] = {
     return false;
 }
 
+// Vietnamese orthography splits c/k, g/gh, ng/ngh by vowel frontness.
+// Mirror of the rule encoded against CharState in PhonotacticsValidator.cpp;
+// the two paths differ in input type (rendered text vs engine state) so the
+// shared classifier is the per-base helper below, not the agreement function.
+[[nodiscard]] constexpr bool IsFrontBaseVowel(wchar_t base) noexcept {
+    return base == L'e' || base == L'i' || base == L'y';
+}
+
+[[nodiscard]] bool IsOnsetVowelAgreementValid(
+        std::wstring_view onset,
+        std::wstring_view vowelSeq) noexcept {
+    // qu intentionally exempted: book lists oa/oă/oe/uy/uơ/uô/uê/uâ as the
+    // canonical labial diphthongs after qu, but qua/quan/quát/quanh sit
+    // outside that list and are everyday words.
+    if (onset == L"qu") return true;
+
+    const bool needsAgreement =
+        onset == L"c" || onset == L"k"  ||
+        onset == L"g" || onset == L"gh" ||
+        onset == L"ng" || onset == L"ngh";
+    if (!needsAgreement) return true;
+
+    wchar_t firstBase = 0;
+    for (wchar_t ch : vowelSeq) {
+        VowelInfo info = Decompose(ch);
+        if (info.base != 0) { firstBase = info.base; break; }
+    }
+    if (firstBase == 0) return true;
+
+    const bool wantsFront = (onset == L"k" || onset == L"gh" || onset == L"ngh");
+    return wantsFront == IsFrontBaseVowel(firstBase);
+}
+
 // =============================================================================
 // Core priority logic for tone placement: P1 horn > P2 modified > P3 diphthong /
 // triphthong > P4 rightmost. Operates on a rendered wstring_view of the vowel
@@ -329,12 +362,15 @@ size_t Phonotactics::TonePosition(
 }
 
 bool Phonotactics::IsValidSyllable(
-        std::wstring_view /*onset*/,
+        std::wstring_view onset,
         std::wstring_view vowelSeq,
         std::wstring_view coda,
         Tone tone,
         bool /*modernOrtho*/) const noexcept {
     if (vowelSeq.empty()) return false;
+
+    // Onset / vowel front-back agreement (c/k, g/gh, ng/ngh). qu exempted.
+    if (!IsOnsetVowelAgreementValid(onset, vowelSeq)) return false;
 
     // Closed vowels must NOT have a coda.
     if (!coda.empty() && IsClosedVowelSeq(vowelSeq)) return false;

--- a/tests/PhonotacticsTest.cpp
+++ b/tests/PhonotacticsTest.cpp
@@ -190,6 +190,152 @@ TEST_F(PhonotacticsIsValidSyllable, OpenSyllableAllowsAnyTone) {
 }
 
 //=============================================================================
+// IsValidSyllable — onset / vowel front-back agreement.
+// Rule and qu-exemption rationale documented at the helper definition in
+// Phonotactics.cpp.
+//=============================================================================
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetCAcceptsBackVowels) {
+    // ca, cô, cu, cơ, cư, cân, căn — c + back vowel = valid
+    EXPECT_TRUE(phon_.IsValidSyllable(L"c", L"a",       L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"c", L"\x00F4",  L"",  Tone::None, kModern));   // cô
+    EXPECT_TRUE(phon_.IsValidSyllable(L"c", L"u",       L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"c", L"\x01A1",  L"",  Tone::None, kModern));   // cơ
+    EXPECT_TRUE(phon_.IsValidSyllable(L"c", L"\x01B0",  L"",  Tone::None, kModern));   // cư
+    EXPECT_TRUE(phon_.IsValidSyllable(L"c", L"\x00E2",  L"n", Tone::None, kModern));   // cân
+    EXPECT_TRUE(phon_.IsValidSyllable(L"c", L"\x0103",  L"n", Tone::None, kModern));   // căn
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetCRejectsFrontVowels) {
+    // ce, cê, ci, cy — c + front vowel = invalid (must use k)
+    EXPECT_FALSE(phon_.IsValidSyllable(L"c", L"e",       L"", Tone::None, kModern));
+    EXPECT_FALSE(phon_.IsValidSyllable(L"c", L"\x00EA",  L"", Tone::None, kModern));   // cê
+    EXPECT_FALSE(phon_.IsValidSyllable(L"c", L"i",       L"", Tone::None, kModern));
+    EXPECT_FALSE(phon_.IsValidSyllable(L"c", L"y",       L"", Tone::None, kModern));
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetKAcceptsFrontVowels) {
+    // ke, kê, ki, ky, ken, kim, kênh — k + front vowel = valid
+    EXPECT_TRUE(phon_.IsValidSyllable(L"k", L"e",       L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"k", L"\x00EA",  L"",  Tone::None, kModern));   // kê
+    EXPECT_TRUE(phon_.IsValidSyllable(L"k", L"i",       L"m", Tone::None, kModern));   // kim
+    EXPECT_TRUE(phon_.IsValidSyllable(L"k", L"y",       L"",  Tone::None, kModern));   // ky
+    EXPECT_TRUE(phon_.IsValidSyllable(L"k", L"e",       L"n", Tone::None, kModern));   // ken
+    EXPECT_TRUE(phon_.IsValidSyllable(L"k", L"\x00EA",  L"nh", Tone::None, kModern));  // kênh
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetKRejectsBackVowels) {
+    // ka, kô, ku, kơ, kư, kâu — k + back vowel = invalid
+    EXPECT_FALSE(phon_.IsValidSyllable(L"k", L"a",       L"",  Tone::None, kModern));
+    EXPECT_FALSE(phon_.IsValidSyllable(L"k", L"\x00F4",  L"",  Tone::None, kModern));   // kô
+    EXPECT_FALSE(phon_.IsValidSyllable(L"k", L"u",       L"",  Tone::None, kModern));
+    EXPECT_FALSE(phon_.IsValidSyllable(L"k", L"\x01A1",  L"",  Tone::None, kModern));   // kơ
+    EXPECT_FALSE(phon_.IsValidSyllable(L"k", L"\x01B0",  L"",  Tone::None, kModern));   // kư
+    EXPECT_FALSE(phon_.IsValidSyllable(L"k", L"\x00E2",  L"u", Tone::None, kModern));   // kâu
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetGAcceptsBackVowels) {
+    // ga, gô, gu, gơ, gan — g + back vowel = valid
+    EXPECT_TRUE(phon_.IsValidSyllable(L"g", L"a",       L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"g", L"\x00F4",  L"",  Tone::None, kModern));   // gô
+    EXPECT_TRUE(phon_.IsValidSyllable(L"g", L"u",       L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"g", L"a",       L"n", Tone::None, kModern));   // gan
+    EXPECT_TRUE(phon_.IsValidSyllable(L"g", L"\x01A1",  L"i", Tone::None, kModern));   // gơi-ish
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetGRejectsFrontVowels) {
+    // ge, gê, gi — g + front vowel = invalid (must use gh, or "gi" cluster onset)
+    EXPECT_FALSE(phon_.IsValidSyllable(L"g", L"e",      L"", Tone::None, kModern));
+    EXPECT_FALSE(phon_.IsValidSyllable(L"g", L"\x00EA", L"", Tone::None, kModern));   // gê
+    EXPECT_FALSE(phon_.IsValidSyllable(L"g", L"i",      L"", Tone::None, kModern));
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetGhAcceptsFrontVowels) {
+    // ghe, ghê, ghi, ghen — gh + front vowel = valid
+    EXPECT_TRUE(phon_.IsValidSyllable(L"gh", L"e",      L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"gh", L"\x00EA", L"",  Tone::None, kModern));  // ghê
+    EXPECT_TRUE(phon_.IsValidSyllable(L"gh", L"i",      L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"gh", L"e",      L"n", Tone::None, kModern));  // ghen
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetGhRejectsBackVowels) {
+    // gha, ghu, ghô — gh + back vowel = invalid
+    EXPECT_FALSE(phon_.IsValidSyllable(L"gh", L"a",      L"", Tone::None, kModern));
+    EXPECT_FALSE(phon_.IsValidSyllable(L"gh", L"u",      L"", Tone::None, kModern));
+    EXPECT_FALSE(phon_.IsValidSyllable(L"gh", L"\x00F4", L"", Tone::None, kModern));  // ghô
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetNgAcceptsBackVowels) {
+    // nga, ngô, ngu, ngư, ngon — ng + back = valid
+    EXPECT_TRUE(phon_.IsValidSyllable(L"ng", L"a",       L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"ng", L"\x00F4",  L"",  Tone::None, kModern));  // ngô
+    EXPECT_TRUE(phon_.IsValidSyllable(L"ng", L"u",       L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"ng", L"\x01B0",  L"",  Tone::None, kModern));  // ngư
+    EXPECT_TRUE(phon_.IsValidSyllable(L"ng", L"o",       L"n", Tone::None, kModern));  // ngon
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetNgRejectsFrontVowels) {
+    // nge, ngê, ngi — ng + front = invalid (must use ngh)
+    EXPECT_FALSE(phon_.IsValidSyllable(L"ng", L"e",      L"", Tone::None, kModern));
+    EXPECT_FALSE(phon_.IsValidSyllable(L"ng", L"\x00EA", L"", Tone::None, kModern));   // ngê
+    EXPECT_FALSE(phon_.IsValidSyllable(L"ng", L"i",      L"", Tone::None, kModern));
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetNghAcceptsFrontVowels) {
+    // nghe, nghê, nghi, nghin — ngh + front = valid
+    EXPECT_TRUE(phon_.IsValidSyllable(L"ngh", L"e",      L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"ngh", L"\x00EA", L"",  Tone::None, kModern));  // nghê
+    EXPECT_TRUE(phon_.IsValidSyllable(L"ngh", L"i",      L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"ngh", L"i",      L"n", Tone::None, kModern));  // nghin
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetNghRejectsBackVowels) {
+    // ngha, nghô, nghu — ngh + back = invalid
+    EXPECT_FALSE(phon_.IsValidSyllable(L"ngh", L"a",      L"", Tone::None, kModern));
+    EXPECT_FALSE(phon_.IsValidSyllable(L"ngh", L"\x00F4", L"", Tone::None, kModern));  // nghô
+    EXPECT_FALSE(phon_.IsValidSyllable(L"ngh", L"u",      L"", Tone::None, kModern));
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetQuFreePassByDesign) {
+    // qu agreement intentionally not enforced — see helper rationale comment.
+    EXPECT_TRUE(phon_.IsValidSyllable(L"qu", L"a",      L"",  Tone::None, kModern));   // qua
+    EXPECT_TRUE(phon_.IsValidSyllable(L"qu", L"a",      L"n", Tone::None, kModern));   // quan
+    EXPECT_TRUE(phon_.IsValidSyllable(L"qu", L"\x00EA", L"",  Tone::None, kModern));   // quê
+    EXPECT_TRUE(phon_.IsValidSyllable(L"qu", L"y",      L"",  Tone::None, kModern));   // quy
+    EXPECT_TRUE(phon_.IsValidSyllable(L"qu", L"\x00E2", L"n", Tone::None, kModern));   // quân
+    EXPECT_TRUE(phon_.IsValidSyllable(L"qu", L"\x0103", L"n", Tone::None, kModern));   // quăn
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetGiClusterUnaffected) {
+    // "gi" is its own onset cluster (giáo, giải, giờ) — not subject to g/gh agreement.
+    EXPECT_TRUE(phon_.IsValidSyllable(L"gi", L"a",      L"",  Tone::None, kModern));   // gia
+    EXPECT_TRUE(phon_.IsValidSyllable(L"gi", L"ao",     L"",  Tone::None, kModern));   // giao
+    EXPECT_TRUE(phon_.IsValidSyllable(L"gi", L"\x01A1", L"",  Tone::None, kModern));   // giờ-ish
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OtherOnsetsNotSubjectToAgreement) {
+    // b/d/h/l/m/n/p/r/s/t/v/x and ch/kh/nh/ph/th/tr accept any vowel.
+    EXPECT_TRUE(phon_.IsValidSyllable(L"b",  L"e", L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"b",  L"a", L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"th", L"e", L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"th", L"a", L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"tr", L"a", L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"tr", L"i", L"",  Tone::None, kModern));
+    EXPECT_TRUE(phon_.IsValidSyllable(L"",   L"a", L"n", Tone::None, kModern));   // vowel-initial
+}
+
+TEST_F(PhonotacticsIsValidSyllable, OnsetAgreementUsesFirstVowelOfDiphthong) {
+    // Agreement is checked against the FIRST vowel of vowelSeq.
+    EXPECT_TRUE (phon_.IsValidSyllable(L"ngh", L"i\x00EA", L"u", Tone::None, kModern));   // nghiêu (first 'i' front)
+    EXPECT_FALSE(phon_.IsValidSyllable(L"ng",  L"i\x00EA", L"u", Tone::None, kModern));   // ngiêu invalid
+    EXPECT_TRUE (phon_.IsValidSyllable(L"k",   L"i\x00EA", L"n", Tone::None, kModern));   // kiên
+    EXPECT_FALSE(phon_.IsValidSyllable(L"c",   L"i\x00EA", L"n", Tone::None, kModern));   // ciên invalid
+    EXPECT_FALSE(phon_.IsValidSyllable(L"k",   L"oa",      L"n", Tone::None, kModern));   // koan invalid (first 'o' back)
+    EXPECT_FALSE(phon_.IsValidSyllable(L"gh",  L"oa",      L"",  Tone::None, kModern));   // gh + back invalid
+    EXPECT_TRUE (phon_.IsValidSyllable(L"gh",  L"e",       L"o", Tone::None, kModern));   // gheo first 'e' front
+}
+
+//=============================================================================
 // CanComplete — partial syllable extensibility (auto-exclusion gate)
 //=============================================================================
 


### PR DESCRIPTION
## Summary

Closes T2 from `docs/REFACTOR_STATUS.md` — `Phonotactics::IsValidSyllable` was ignoring its `onset` arg, breaking the contract documented on `IPhonotactics::IsValidSyllable`. This PR teaches it the c/k, g/gh, ng/ngh front-back orthographic rule (qu intentionally exempted).

## What's in scope

- New helper `IsOnsetVowelAgreementValid` (anonymous namespace in `Phonotactics.cpp`) classifies the first base vowel of `vowelSeq` and matches against the onset:
  - `c`  → back only • `k`   → front only
  - `g`  → back only • `gh`  → front only
  - `ng` → back only • `ngh` → front only
  - `qu` → exempted (per anh decision: `qua/quan/quát/quanh` are everyday words but fall outside the book's canonical labial-diphthong list, so strict enforcement would false-reject them)
- 16 GTEST cases under `PhonotacticsIsValidSyllable` covering accept/reject for each onset, qu free-pass, gi cluster unaffected, other onsets unaffected, diphthong first-vowel rule.

## What's NOT in scope

- **Production wiring**: `Phonotactics::IsValidSyllable` has no production caller today (TypingEngine uses the CharState-based `ValidateSyllableState` in `PhonotacticsValidator.cpp`). This PR only closes the interface contract for future consumers (spell-check overlay, dictionary lookups). Anh chose this scope after weighing tradeoffs — wiring would risk chaos regressions and exceeds T2 budget.
- **Cross-validator deduplication**: the same rule already exists at `PhonotacticsValidator.cpp:684-715` on the CharState path. Pre-existing duplication, logged as **T2.1** in `REFACTOR_STATUS.md` for future shared-classifier extraction once a third validator wants the rule.

## Test plan

- [x] Linux `NextKeyTests` 1540/1540 PASS (baseline 1524 + 16 new T2 tests)
- [x] No regressions in existing `PhonotacticsIsValidSyllable` fixture (8 baseline tests still green)
- [x] `nexuskey-review` skill checklist: naming / namespace / modern C++ / testing — all clean
- [x] `simplify` review (3 parallel agents): reuse / quality / efficiency — findings applied (banner WHAT-not-WHY trimmed; ternary → boolean equality)

## Files

- `src/core/engine/Phonotactics.cpp` — helper + wired into `IsValidSyllable`
- `tests/PhonotacticsTest.cpp` — 16 new tests
- `docs/REFACTOR_STATUS.md` — T2 → Section A; T2.1 added to Section D as cleanup followup