### PR TITLE
refactor(T2.1 D1): lift IsFrontBaseVowel to shared phonology data header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(NEXTKEY_ENGINE_SOURCES
     src/core/engine/EngineHelpers.h
     src/core/engine/EnglishProtection.h
     src/core/engine/VietnameseTables.h
+    src/core/engine/VietnamesePhonologyData.h
     src/core/engine/PhonotacticsValidator.cpp
     src/core/engine/PhonotacticsValidator.h
     src/core/engine/IPhonotactics.h

--- a/src/core/engine/Phonotactics.cpp
+++ b/src/core/engine/Phonotactics.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <string_view>
 
+#include "VietnamesePhonologyData.h"
 #include "VietnameseTables.h"
 
 namespace NextKey {
@@ -245,12 +246,8 @@ constexpr std::wstring_view kN3Nuclei[] = {
 }
 
 // Vietnamese orthography splits c/k, g/gh, ng/ngh by vowel frontness.
-// Mirror of the rule encoded against CharState in PhonotacticsValidator.cpp;
-// the two paths differ in input type (rendered text vs engine state) so the
-// shared classifier is the per-base helper below, not the agreement function.
-[[nodiscard]] constexpr bool IsFrontBaseVowel(wchar_t base) noexcept {
-    return base == L'e' || base == L'i' || base == L'y';
-}
+// Front-vowel classifier lives in VietnamesePhonologyData.h, shared with the
+// CharState path in PhonotacticsValidator.cpp (T2.1 consolidation Day-1).
 
 [[nodiscard]] bool IsOnsetVowelAgreementValid(
         std::wstring_view onset,
@@ -274,7 +271,7 @@ constexpr std::wstring_view kN3Nuclei[] = {
     if (firstBase == 0) return true;
 
     const bool wantsFront = (onset == L"k" || onset == L"gh" || onset == L"ngh");
-    return wantsFront == IsFrontBaseVowel(firstBase);
+    return wantsFront == NextKey::Phonology::IsFrontBaseVowel(firstBase);
 }
 
 // =============================================================================

--- a/src/core/engine/PhonotacticsValidator.cpp
+++ b/src/core/engine/PhonotacticsValidator.cpp
@@ -9,6 +9,7 @@
 
 #include "PhonotacticsValidator.h"
 #include "TypingEngine.h"
+#include "VietnamesePhonologyData.h"
 #include <algorithm>
 #include <cwctype>
 
@@ -693,7 +694,7 @@ SyllableState ValidateImpl(const CharStateT* states, size_t count, bool allowZwj
 
     if (initialLen < count && states[initialLen].IsVowel()) {
         wchar_t firstVowel = states[initialLen].base;
-        bool isFrontVowel = (firstVowel == L'e' || firstVowel == L'i' || firstVowel == L'y');
+        bool isFrontVowel = Phonology::IsFrontBaseVowel(firstVowel);
 
         if (initialLen == 1) {
             wchar_t c0 = states[0].base;

--- a/src/core/engine/VietnamesePhonologyData.h
+++ b/src/core/engine/VietnamesePhonologyData.h
@@ -1,0 +1,33 @@
+// NexusKey - Vietnamese Phonology Shared Data
+// Copyright (c) 2024-2026 PhatMT. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-NexusKey-Commercial
+//
+// Single source of truth for Vietnamese phonological rule data consumed by
+// the project's two phonotactics validators:
+//   - core/engine/Phonotactics.cpp           (wstring_view path / Path 2)
+//   - core/engine/PhonotacticsValidator.cpp  (CharState path / Path 1, hot)
+//
+// This header is the entry point for the T2.1 phonology consolidation work
+// (see docs/TODO.md "Vietnamese-rule consolidation"). Day-1 lifts the front-
+// vowel classifier shared by both files. Subsequent days will lift VCPair
+// per-nucleus allowed-coda bitmasks, onset agreement matrix, and closed/
+// pending vowel sets, then wrap the data behind an `IPhonologyRules` plugin
+// contract matching the existing IOutputInjector / ICodeTableConverter
+// patterns.
+//
+// All entries are `constexpr` / `noexcept` — zero runtime cost, no allocation.
+
+#pragma once
+
+namespace NextKey {
+namespace Phonology {
+
+// Front vowels for orthographic rules (c/k, g/gh, ng/ngh agreement).
+// Modifier marks (ê = e+circumflex, etc.) do not change the front/back class:
+// callers pass the *base* (post-Decompose) wchar.
+[[nodiscard]] constexpr bool IsFrontBaseVowel(wchar_t base) noexcept {
+    return base == L'e' || base == L'i' || base == L'y';
+}
+
+}  // namespace Phonology
+}  // namespace NextKey


### PR DESCRIPTION
## Summary

**Day-1 of T2.1 phonology consolidation sprint.** Promoted to principle-grade per anh design philosophy (2026-05-08): *nhanh - gọn - nhẹ - mượt - plugin, không code phân mảnh*.

This PR establishes the **shared phonology data file** (`core/engine/VietnamesePhonologyData.h`) and lifts a single concrete duplication (`IsFrontBaseVowel`) as the foundation step. Subsequent days (D2-D4) will lift VCPair bitmask, define the `IPhonologyRules` plugin contract, and add RulePackId hooks.

## CODE_GOVERNANCE Q1-Q5 gate

| Q | Answer |
|---|---|
| **Q1 Layer** | Engine layer (`core/engine/`), peer of `VietnameseTables.h`. Correct layer. |
| **Q2 Perf** | 0 ns delta. constexpr inline function; codegen byte-identical. |
| **Q3 Native** | N/A — pure data/helper relocation, no OS API alternative. |
| **Q4 No-Lock** | constexpr noexcept. No mutex, allocation, exception. ✓ |
| **Q5 Trade-off** | **Gain**: one source of truth for front-vowel classifier; foundation for D2-D4 migration; aligns with "không phân mảnh" philosophy. **Give up**: 1 new header file; D1 is a baby step (intentional). |

## What's in scope

- New header `src/core/engine/VietnamesePhonologyData.h` (8 LOC inside the `NextKey::Phonology` namespace).
- `Phonotactics.cpp` anonymous namespace drops local `IsFrontBaseVowel`; now consumes `Phonology::IsFrontBaseVowel`.
- `PhonotacticsValidator.cpp:696` inline `bool isFrontVowel = (... e || i || y)` → shared call.
- `CMakeLists.txt`: header listed alongside other engine headers.

## What's NOT in scope

- VCPair bitmask migration (Day-2)
- `IPhonologyRules` plugin contract (Day-3)
- RulePackId / dialect variants (Day-4)
- T3's N-group → VCPair replacement (Day-2 dependency)
- English-protection coda lexicon reuse (Day-3 work)

## Test plan

- [x] CMake reconfigure (per `feedback_cmake_reconfigure`)
- [x] Linux `NextKeyTests` 1551/1551 PASS (no test count change — pure relocation, behaviour byte-identical)
- [x] No new tests required: existing T2 onset agreement tests + PhonotacticsValidator tests cover both consumers of `IsFrontBaseVowel`. Any divergence would surface there.

## Followup tracking

- `docs/REFACTOR_STATUS.md` T2.1 row remains the inventory entry; will flip to DONE after Day-4 lands.
- `docs/TODO.md` "Vietnamese-rule consolidation" entry stays open as the multi-day sprint anchor.