### PR TITLE
refactor(T2.1 D2): lift VCPair table + retire T3 N-group approximation

### DIFF
--- a/src/core/engine/Phonotactics.cpp
+++ b/src/core/engine/Phonotactics.cpp
@@ -175,28 +175,21 @@ constexpr std::wstring_view kValidCodas[] = {
 // path uses, then performs one bitmask lookup. Replaces the coarser N1/N2/N3
 // approximation that lived here in T3.
 
-// Encode a single rendered vowel char into a (base_index, mod_ordinal) slot.
-// Returns 0xFF as the slot byte if the char is not a recognised vowel.
-[[nodiscard]] uint8_t VowelInfoToSlot(VowelInfo info) noexcept {
-    if (info.base == 0) return 0xFF;
-    uint8_t baseIdx = NextKey::Phonology::BaseIndex(info.base);
-    if (baseIdx == 0xFF) return 0xFF;
-    return NextKey::Phonology::VowelSlot(baseIdx, static_cast<uint8_t>(info.mod));
-}
-
 // Pack a rendered nucleus (1-3 vowels) into the same packed key the CharState
-// path uses. Returns 0 if the nucleus has the wrong slot count or contains a
-// non-vowel char — caller treats 0 as "no VCPair entry → lenient".
-[[nodiscard]] uint32_t WstringViewToVowelKey(std::wstring_view vowelSeq) noexcept {
+// path uses. Returns 0 when the nucleus is unencodable (no vowels, more than
+// 3 vowels, or a non-recognised char) — caller treats 0 as "no VCPair entry
+// → lenient pass-through".
+[[nodiscard]] constexpr uint32_t WstringViewToVowelKey(std::wstring_view vowelSeq) noexcept {
     uint8_t slots[3] = { 0, 0, 0 };
     size_t count = 0;
     for (wchar_t ch : vowelSeq) {
         VowelInfo info = Decompose(ch);
-        if (info.base == 0) continue;          // skip non-vowel defensively
+        if (info.base == 0) return 0;          // unrecognised char in nucleus
         if (count >= 3) return 0;              // too many vowels for VCPair
-        uint8_t slot = VowelInfoToSlot(info);
-        if (slot == 0xFF) return 0;
-        slots[count++] = slot;
+        uint8_t baseIdx = NextKey::Phonology::BaseIndex(info.base);
+        if (baseIdx == NextKey::Phonology::kInvalidBaseIndex) return 0;
+        slots[count++] = NextKey::Phonology::VowelSlot(baseIdx,
+                                                        static_cast<uint8_t>(info.mod));
     }
     switch (count) {
         case 1:  return NextKey::Phonology::Key1(slots[0]);
@@ -229,15 +222,18 @@ constexpr std::wstring_view kValidCodas[] = {
     return 0;
 }
 
-[[nodiscard]] bool IsCodaValidForNucleus(std::wstring_view vowelSeq,
-                                          std::wstring_view coda) noexcept {
+// Lenient by default: if any of the inputs (nucleus, coda) cannot be encoded
+// or has no entry in the VCPair table, accept the syllable. The strictness
+// applies only when both sides resolve to known, table-listed values.
+[[nodiscard]] constexpr bool IsCodaValidForNucleus(std::wstring_view vowelSeq,
+                                                    std::wstring_view coda) noexcept {
     if (coda.empty()) return true;
     uint32_t vowelKey = WstringViewToVowelKey(vowelSeq);
-    if (vowelKey == 0) return true;                       // unencodable → lenient
+    if (vowelKey == 0) return true;
     uint16_t allowed = NextKey::Phonology::GetAllowedFinals(vowelKey);
-    if (allowed == 0) return true;                        // no VCPair entry → lenient
+    if (allowed == 0) return true;
     uint16_t bit = CodaToFinalBit(coda);
-    if (bit == 0) return true;                            // unknown coda → lenient
+    if (bit == 0) return true;
     return (allowed & bit) != 0;
 }
 

--- a/src/core/engine/Phonotactics.cpp
+++ b/src/core/engine/Phonotactics.cpp
@@ -169,80 +169,76 @@ constexpr std::wstring_view kValidCodas[] = {
     return false;
 }
 
-// Coda groups (RuleTiengViet):
-//   C1 = ng, c       (velar)
-//   C2 = nh, ch      (palatal)
-//   C3 = m, n, p, t  (labial / alveolar)
-enum class CodaGroup : uint8_t { None, C1, C2, C3 };
+// Per-nucleus allowed-coda compatibility, sourced from the canonical VCPair
+// bitmask in VietnamesePhonologyData.h (T2.1 Day-2). Encodes the rendered
+// vowelSeq + coda into the same packed-key + F_* bitmask space the CharState
+// path uses, then performs one bitmask lookup. Replaces the coarser N1/N2/N3
+// approximation that lived here in T3.
 
-[[nodiscard]] CodaGroup ClassifyCoda(std::wstring_view coda) noexcept {
-    if (coda.empty()) return CodaGroup::None;
-    if (coda == L"ng" || coda == L"c") return CodaGroup::C1;
-    if (coda == L"nh" || coda == L"ch") return CodaGroup::C2;
-    if (coda == L"m" || coda == L"n" || coda == L"p" || coda == L"t") return CodaGroup::C3;
-    return CodaGroup::None;  // unknown coda — let other rules reject if needed
+// Encode a single rendered vowel char into a (base_index, mod_ordinal) slot.
+// Returns 0xFF as the slot byte if the char is not a recognised vowel.
+[[nodiscard]] uint8_t VowelInfoToSlot(VowelInfo info) noexcept {
+    if (info.base == 0) return 0xFF;
+    uint8_t baseIdx = NextKey::Phonology::BaseIndex(info.base);
+    if (baseIdx == 0xFF) return 0xFF;
+    return NextKey::Phonology::VowelSlot(baseIdx, static_cast<uint8_t>(info.mod));
 }
 
-// Vowel groups for vowel-coda compatibility (RuleTiengViet):
-//   N1 nuclei accept C1 + C3, reject C2
-//   N2 nuclei accept C2 + C3, reject C1
-//   N3 nuclei accept everything
-//   Other = nucleus not classified — lenient fall-through (allow any coda)
-//
-// Coarser than the per-nucleus `kVCPairRules` bitmask in PhonotacticsValidator.cpp,
-// which is the source-of-truth for the production CharState path. Examples of
-// where VCPair is stricter: "ơ" (only m/n/p/t — N-group says C1+C3 = also ng/c),
-// "iê" (no ch/nh — N-group says all). If/when Phonotactics::IsValidSyllable
-// gains a production caller, port the VCPair encoding rather than relying on
-// the N-group approximation here. See REFACTOR_STATUS T2.1.
-enum class VowelGroup : uint8_t { Other, N1, N2, N3 };
-
-constexpr std::wstring_view kN1Nuclei[] = {
-    L"\x00E2",                 // â
-    L"e",
-    L"o",
-    L"\x00F4",                 // ô
-    L"u",
-    L"\x01B0",                 // ư
-    L"\x01A1",                 // ơ
-    L"\x0103",                 // ă
-    L"o\x0103",                // oă
-    L"oe",
-    L"u\x00E2",                // uâ
-    L"u\x00F4",                // uô
-    L"u\x01A1",                // uơ
-    L"\x01B0\x01A1",           // ươ
-};
-
-constexpr std::wstring_view kN2Nuclei[] = {
-    L"\x00EA",                 // ê
-    L"i",
-    L"u\x00EA",                // uê
-    L"uy",
-    L"ua",
-};
-
-constexpr std::wstring_view kN3Nuclei[] = {
-    L"a",
-    L"oa",
-    L"i\x00EA",                // iê
-    L"uy\x00EA",               // uyê
-};
-
-[[nodiscard]] VowelGroup ClassifyVowelGroup(std::wstring_view vowelSeq) noexcept {
-    for (auto v : kN1Nuclei) if (v == vowelSeq) return VowelGroup::N1;
-    for (auto v : kN2Nuclei) if (v == vowelSeq) return VowelGroup::N2;
-    for (auto v : kN3Nuclei) if (v == vowelSeq) return VowelGroup::N3;
-    return VowelGroup::Other;
+// Pack a rendered nucleus (1-3 vowels) into the same packed key the CharState
+// path uses. Returns 0 if the nucleus has the wrong slot count or contains a
+// non-vowel char — caller treats 0 as "no VCPair entry → lenient".
+[[nodiscard]] uint32_t WstringViewToVowelKey(std::wstring_view vowelSeq) noexcept {
+    uint8_t slots[3] = { 0, 0, 0 };
+    size_t count = 0;
+    for (wchar_t ch : vowelSeq) {
+        VowelInfo info = Decompose(ch);
+        if (info.base == 0) continue;          // skip non-vowel defensively
+        if (count >= 3) return 0;              // too many vowels for VCPair
+        uint8_t slot = VowelInfoToSlot(info);
+        if (slot == 0xFF) return 0;
+        slots[count++] = slot;
+    }
+    switch (count) {
+        case 1:  return NextKey::Phonology::Key1(slots[0]);
+        case 2:  return NextKey::Phonology::Key2(slots[0], slots[1]);
+        case 3:  return NextKey::Phonology::Key3(slots[0], slots[1], slots[2]);
+        default: return 0;
+    }
 }
 
-[[nodiscard]] bool IsCodaCompatibleWithVowelGroup(VowelGroup group, CodaGroup codaGroup) noexcept {
-    if (group == VowelGroup::Other)  return true;   // unclassified — lenient
-    if (codaGroup == CodaGroup::None) return true;
-    if (codaGroup == CodaGroup::C3)  return true;   // C3 accepted by all groups
-    if (group == VowelGroup::N3)     return true;   // N3 accepts everything
-    if (group == VowelGroup::N1)     return codaGroup == CodaGroup::C1;
-    return codaGroup == CodaGroup::C2;              // group == N2
+// Map a rendered coda string to the F_* bitmask. Returns 0 for unknown
+// codas (caller treats as lenient pass-through).
+[[nodiscard]] constexpr uint16_t CodaToFinalBit(std::wstring_view coda) noexcept {
+    using namespace NextKey::Phonology;
+    if (coda.size() == 1) {
+        switch (coda[0]) {
+            case L'c': return F_c;
+            case L'k': return F_k;
+            case L'm': return F_m;
+            case L'n': return F_n;
+            case L'p': return F_p;
+            case L't': return F_t;
+            default:   return 0;
+        }
+    }
+    if (coda.size() == 2) {
+        if (coda == L"ch") return F_ch;
+        if (coda == L"ng") return F_ng;
+        if (coda == L"nh") return F_nh;
+    }
+    return 0;
+}
+
+[[nodiscard]] bool IsCodaValidForNucleus(std::wstring_view vowelSeq,
+                                          std::wstring_view coda) noexcept {
+    if (coda.empty()) return true;
+    uint32_t vowelKey = WstringViewToVowelKey(vowelSeq);
+    if (vowelKey == 0) return true;                       // unencodable → lenient
+    uint16_t allowed = NextKey::Phonology::GetAllowedFinals(vowelKey);
+    if (allowed == 0) return true;                        // no VCPair entry → lenient
+    uint16_t bit = CodaToFinalBit(coda);
+    if (bit == 0) return true;                            // unknown coda → lenient
+    return (allowed & bit) != 0;
 }
 
 // Vietnamese orthography splits c/k, g/gh, ng/ngh by vowel frontness.
@@ -451,10 +447,9 @@ bool Phonotactics::IsValidSyllable(
     // Pending vowels MUST have a coda.
     if (coda.empty() && IsPendingVowelSeq(vowelSeq)) return false;
 
-    // N1/N2/N3 vowel-coda group compatibility.
-    if (!IsCodaCompatibleWithVowelGroup(ClassifyVowelGroup(vowelSeq), ClassifyCoda(coda))) {
-        return false;
-    }
+    // VCPair vowel-coda compatibility (per-nucleus allowed-coda bitmask,
+    // shared with PhonotacticsValidator on the CharState path).
+    if (!IsCodaValidForNucleus(vowelSeq, coda)) return false;
 
     // Stop-final coda restricts tone to Acute or Dot.
     if (!ToneAllowedForCoda(coda, tone)) return false;

--- a/src/core/engine/PhonotacticsValidator.cpp
+++ b/src/core/engine/PhonotacticsValidator.cpp
@@ -18,46 +18,11 @@ namespace Phonology {
 
 namespace {
 
-//=============================================================================
-// Vowel nucleus encoding
-//=============================================================================
-
-// Encode a single vowel slot: (base_index << 2) | mod_ordinal
-// base: a=0, e=1, i=2, o=3, u=4, y=5
-// mod:  None=0, Circumflex=1, Breve=2, Horn=3
-
-constexpr uint8_t VowelSlot(uint8_t base, uint8_t mod) {
-    return static_cast<uint8_t>((base << 2) | mod);
-}
-
-// Base indices for encoding
-constexpr uint8_t kA = 0, kE = 1, kI = 2, kO = 3, kU = 4, kY = 5;
-// Modifier ordinals for encoding
-constexpr uint8_t kNone = 0, kCirc = 1, kBrev = 2, kHorn = 3;
-
-constexpr uint8_t BaseIndex(wchar_t base) {
-    switch (base) {
-        case L'a': return kA;
-        case L'e': return kE;
-        case L'i': return kI;
-        case L'o': return kO;
-        case L'u': return kU;
-        case L'y': return kY;
-        default:   return 0xFF;
-    }
-}
-
-// Pack 1-3 vowel slots into a uint32_t key with length prefix
-// Top byte encodes slot count to prevent Key1/Key2/Key3 collisions
-constexpr uint32_t Key1(uint8_t s0) {
-    return (1u << 24) | static_cast<uint32_t>(s0);
-}
-constexpr uint32_t Key2(uint8_t s0, uint8_t s1) {
-    return (2u << 24) | (static_cast<uint32_t>(s0) << 8) | s1;
-}
-constexpr uint32_t Key3(uint8_t s0, uint8_t s1, uint8_t s2) {
-    return (3u << 24) | (static_cast<uint32_t>(s0) << 16) | (static_cast<uint32_t>(s1) << 8) | s2;
-}
+// Packed-key encoding (VowelSlot, kA-kY, kNone-kHorn, BaseIndex, Key1/2/3) +
+// VCPair rule data (F_*, kVCPairRules, GetAllowedFinals) live in the shared
+// header `VietnamesePhonologyData.h` (T2.1 Day-2 consolidation). Only the
+// CharState-specific helpers (FinalConsonantBit template, kVowelTable, vowel
+// scanners) remain in this anonymous namespace.
 
 //=============================================================================
 // Vowel nucleus table
@@ -139,73 +104,6 @@ constexpr VowelEntry kVowelTable[] = {
 };
 
 constexpr size_t kVowelTableSize = sizeof(kVowelTable) / sizeof(kVowelTable[0]);
-
-//=============================================================================
-// Vowel + Final Consonant pair validation (VCPairList)
-//=============================================================================
-// Bitmask encoding for final consonants
-constexpr uint16_t F_c  = 0x001;
-constexpr uint16_t F_ch = 0x002;
-constexpr uint16_t F_k  = 0x004;
-constexpr uint16_t F_m  = 0x008;
-constexpr uint16_t F_n  = 0x010;
-constexpr uint16_t F_ng = 0x020;
-constexpr uint16_t F_nh = 0x040;
-constexpr uint16_t F_p  = 0x080;
-constexpr uint16_t F_t  = 0x100;
-constexpr uint16_t F_ALL = F_c | F_ch | F_k | F_m | F_n | F_ng | F_nh | F_p | F_t;
-// Common groups
-constexpr uint16_t F_NO_CH_NH = F_ALL & ~(F_ch | F_nh);  // c, k, m, n, ng, p, t
-
-struct VCPairRule {
-    uint32_t vowelKey;
-    uint16_t allowedFinals;
-};
-
-// Which final consonants are valid after each vowel nucleus.
-// Derived from Vietnamese phonology + Unikey VCPairList reference.
-constexpr VCPairRule kVCPairRules[] = {
-    // === Single vowels ===
-    { Key1(VowelSlot(kA, kNone)), F_ALL },                                      // a: all finals
-    { Key1(VowelSlot(kA, kCirc)), F_NO_CH_NH },                                 // â: no ch, nh
-    { Key1(VowelSlot(kA, kBrev)), F_NO_CH_NH },                                 // ă: no ch, nh
-    { Key1(VowelSlot(kE, kNone)), F_ALL },                                      // e: all finals
-    { Key1(VowelSlot(kE, kCirc)), F_c | F_ch | F_m | F_n | F_nh | F_p | F_t }, // ê: no ng
-    { Key1(VowelSlot(kI, kNone)), F_ALL & ~F_ng },                               // i: all finals except ng (-ing+tone doesn't exist in Vietnamese)
-    { Key1(VowelSlot(kO, kNone)), F_NO_CH_NH },                                 // o: no ch, nh
-    { Key1(VowelSlot(kO, kCirc)), F_NO_CH_NH },                                 // ô: no ch, nh
-    { Key1(VowelSlot(kO, kHorn)), F_m | F_n | F_p | F_t },                     // ơ: only m, n, p, t
-    { Key1(VowelSlot(kU, kNone)), F_NO_CH_NH },                                 // u: no ch, nh
-    { Key1(VowelSlot(kU, kHorn)), F_NO_CH_NH },                                 // ư: no ch, nh
-    { Key1(VowelSlot(kY, kNone)), F_t },                                        // y: only t
-
-    // === Double vowels with coda ===
-    { Key2(VowelSlot(kI, kNone), VowelSlot(kE, kCirc)),  F_c | F_m | F_n | F_ng | F_p | F_t },  // iê: no ch, nh
-    { Key2(VowelSlot(kO, kNone), VowelSlot(kA, kNone)),  F_ALL },                                 // oa: all finals
-    { Key2(VowelSlot(kO, kNone), VowelSlot(kA, kBrev)),  F_c | F_n | F_ng | F_t },               // oă: c, n, ng, t
-    { Key2(VowelSlot(kO, kNone), VowelSlot(kE, kNone)),  F_m | F_n | F_ng | F_t },               // oe: m, n, ng, t
-    { Key2(VowelSlot(kO, kNone), VowelSlot(kO, kNone)),  F_c | F_ng },                            // oo: only c, ng
-    { Key2(VowelSlot(kU, kNone), VowelSlot(kA, kCirc)),  F_n | F_ng | F_t },                      // uâ: n, ng, t
-    { Key2(VowelSlot(kU, kNone), VowelSlot(kE, kCirc)),  F_ch | F_n | F_nh },                     // uê: ch, n, nh
-    { Key2(VowelSlot(kU, kNone), VowelSlot(kO, kCirc)),  F_c | F_m | F_n | F_ng | F_p | F_t },   // uô: no ch, nh
-    { Key2(VowelSlot(kU, kNone), VowelSlot(kO, kHorn)),  F_c | F_m | F_n | F_ng | F_p | F_t },   // uơ: no ch, nh
-    { Key2(VowelSlot(kU, kNone), VowelSlot(kY, kNone)),  F_ch | F_n | F_nh | F_t },              // uy: ch, n, nh, t
-    { Key2(VowelSlot(kU, kHorn), VowelSlot(kO, kHorn)),  F_c | F_m | F_n | F_ng | F_p | F_t },   // ươ: no ch, nh
-    { Key2(VowelSlot(kY, kNone), VowelSlot(kE, kCirc)),  F_c | F_m | F_n | F_ng | F_p | F_t },   // yê: same as iê
-
-    // === Triple vowels with coda ===
-    { Key3(VowelSlot(kU, kNone), VowelSlot(kY, kNone), VowelSlot(kE, kCirc)), F_n | F_t },       // uyê: n, t
-};
-
-constexpr size_t kVCPairRuleCount = sizeof(kVCPairRules) / sizeof(kVCPairRules[0]);
-
-// Look up allowed finals for a vowel key. Returns 0 if not found (no restriction).
-uint16_t GetAllowedFinals(uint32_t vowelKey) {
-    for (size_t i = 0; i < kVCPairRuleCount; ++i) {
-        if (kVCPairRules[i].vowelKey == vowelKey) return kVCPairRules[i].allowedFinals;
-    }
-    return 0;  // Not in table — no restriction known
-}
 
 // Encode a parsed final consonant as a bitmask
 template<typename CharStateT>

--- a/src/core/engine/VietnamesePhonologyData.h
+++ b/src/core/engine/VietnamesePhonologyData.h
@@ -7,26 +7,136 @@
 //   - core/engine/Phonotactics.cpp           (wstring_view path / Path 2)
 //   - core/engine/PhonotacticsValidator.cpp  (CharState path / Path 1, hot)
 //
-// This header is the entry point for the T2.1 phonology consolidation work
-// (see docs/TODO.md "Vietnamese-rule consolidation"). Day-1 lifts the front-
-// vowel classifier shared by both files. Subsequent days will lift VCPair
-// per-nucleus allowed-coda bitmasks, onset agreement matrix, and closed/
-// pending vowel sets, then wrap the data behind an `IPhonologyRules` plugin
-// contract matching the existing IOutputInjector / ICodeTableConverter
-// patterns.
+// This header anchors the T2.1 phonology consolidation work (see
+// docs/TODO.md "Vietnamese-rule consolidation"). All entries are
+// `constexpr` / `noexcept` — zero runtime cost, no allocation.
 //
-// All entries are `constexpr` / `noexcept` — zero runtime cost, no allocation.
+// Day-1 lifted IsFrontBaseVowel.
+// Day-2 lifts VowelSlot/Key1-3 packed-key encoding + F_* coda bitmasks +
+// kVCPairRules per-nucleus allowed-coda table + GetAllowedFinals lookup.
 
 #pragma once
+
+#include <cstddef>
+#include <cstdint>
 
 namespace NextKey {
 namespace Phonology {
 
+// =============================================================================
+// Front-vowel classifier (Day-1)
+// =============================================================================
 // Front vowels for orthographic rules (c/k, g/gh, ng/ngh agreement).
 // Modifier marks (ê = e+circumflex, etc.) do not change the front/back class:
 // callers pass the *base* (post-Decompose) wchar.
 [[nodiscard]] constexpr bool IsFrontBaseVowel(wchar_t base) noexcept {
     return base == L'e' || base == L'i' || base == L'y';
+}
+
+// =============================================================================
+// Vowel nucleus packed-key encoding (Day-2 lift from PhonotacticsValidator)
+// =============================================================================
+// Each vowel slot packs (base_index << 2) | mod_ordinal into a uint8_t.
+// 1-3 slots are then packed into a uint32_t with a top-byte length prefix
+// (prevents Key1/Key2/Key3 collisions). Both validators encode their input
+// into the same key space and share a single rule table below.
+
+constexpr uint8_t kA = 0, kE = 1, kI = 2, kO = 3, kU = 4, kY = 5;
+constexpr uint8_t kNone = 0, kCirc = 1, kBrev = 2, kHorn = 3;
+
+[[nodiscard]] constexpr uint8_t VowelSlot(uint8_t base, uint8_t mod) noexcept {
+    return static_cast<uint8_t>((base << 2) | mod);
+}
+
+[[nodiscard]] constexpr uint8_t BaseIndex(wchar_t base) noexcept {
+    switch (base) {
+        case L'a': return kA;
+        case L'e': return kE;
+        case L'i': return kI;
+        case L'o': return kO;
+        case L'u': return kU;
+        case L'y': return kY;
+        default:   return 0xFF;
+    }
+}
+
+[[nodiscard]] constexpr uint32_t Key1(uint8_t s0) noexcept {
+    return (1u << 24) | static_cast<uint32_t>(s0);
+}
+[[nodiscard]] constexpr uint32_t Key2(uint8_t s0, uint8_t s1) noexcept {
+    return (2u << 24) | (static_cast<uint32_t>(s0) << 8) | s1;
+}
+[[nodiscard]] constexpr uint32_t Key3(uint8_t s0, uint8_t s1, uint8_t s2) noexcept {
+    return (3u << 24) | (static_cast<uint32_t>(s0) << 16) | (static_cast<uint32_t>(s1) << 8) | s2;
+}
+
+// =============================================================================
+// Final-consonant bitmask + per-nucleus allowed-coda table (Day-2 lift)
+// =============================================================================
+// Bitmask encoding for coda consonants. Each phonotactic rule entry below
+// lists which finals are allowed after a given vowel nucleus.
+// Source: Vietnamese phonology + Unikey VCPairList reference.
+
+constexpr uint16_t F_c  = 0x001;
+constexpr uint16_t F_ch = 0x002;
+constexpr uint16_t F_k  = 0x004;
+constexpr uint16_t F_m  = 0x008;
+constexpr uint16_t F_n  = 0x010;
+constexpr uint16_t F_ng = 0x020;
+constexpr uint16_t F_nh = 0x040;
+constexpr uint16_t F_p  = 0x080;
+constexpr uint16_t F_t  = 0x100;
+constexpr uint16_t F_ALL       = F_c | F_ch | F_k | F_m | F_n | F_ng | F_nh | F_p | F_t;
+constexpr uint16_t F_NO_CH_NH  = F_ALL & ~(F_ch | F_nh);  // c, k, m, n, ng, p, t
+
+struct VCPairRule {
+    uint32_t vowelKey;
+    uint16_t allowedFinals;
+};
+
+constexpr VCPairRule kVCPairRules[] = {
+    // === Single vowels ===
+    { Key1(VowelSlot(kA, kNone)), F_ALL },                                      // a: all finals
+    { Key1(VowelSlot(kA, kCirc)), F_NO_CH_NH },                                 // â: no ch, nh
+    { Key1(VowelSlot(kA, kBrev)), F_NO_CH_NH },                                 // ă: no ch, nh
+    { Key1(VowelSlot(kE, kNone)), F_ALL },                                      // e: all finals
+    { Key1(VowelSlot(kE, kCirc)), F_c | F_ch | F_m | F_n | F_nh | F_p | F_t }, // ê: no ng
+    { Key1(VowelSlot(kI, kNone)), F_ALL & ~F_ng },                               // i: all finals except ng
+    { Key1(VowelSlot(kO, kNone)), F_NO_CH_NH },                                 // o: no ch, nh
+    { Key1(VowelSlot(kO, kCirc)), F_NO_CH_NH },                                 // ô: no ch, nh
+    { Key1(VowelSlot(kO, kHorn)), F_m | F_n | F_p | F_t },                     // ơ: only m, n, p, t
+    { Key1(VowelSlot(kU, kNone)), F_NO_CH_NH },                                 // u: no ch, nh
+    { Key1(VowelSlot(kU, kHorn)), F_NO_CH_NH },                                 // ư: no ch, nh
+    { Key1(VowelSlot(kY, kNone)), F_t },                                        // y: only t
+
+    // === Double vowels with coda ===
+    { Key2(VowelSlot(kI, kNone), VowelSlot(kE, kCirc)),  F_c | F_m | F_n | F_ng | F_p | F_t },  // iê: no ch, nh
+    { Key2(VowelSlot(kO, kNone), VowelSlot(kA, kNone)),  F_ALL },                                 // oa: all finals
+    { Key2(VowelSlot(kO, kNone), VowelSlot(kA, kBrev)),  F_c | F_n | F_ng | F_t },               // oă: c, n, ng, t
+    { Key2(VowelSlot(kO, kNone), VowelSlot(kE, kNone)),  F_m | F_n | F_ng | F_t },               // oe: m, n, ng, t
+    { Key2(VowelSlot(kO, kNone), VowelSlot(kO, kNone)),  F_c | F_ng },                            // oo: only c, ng
+    { Key2(VowelSlot(kU, kNone), VowelSlot(kA, kCirc)),  F_n | F_ng | F_t },                      // uâ: n, ng, t
+    { Key2(VowelSlot(kU, kNone), VowelSlot(kE, kCirc)),  F_ch | F_n | F_nh },                     // uê: ch, n, nh
+    { Key2(VowelSlot(kU, kNone), VowelSlot(kO, kCirc)),  F_c | F_m | F_n | F_ng | F_p | F_t },   // uô: no ch, nh
+    { Key2(VowelSlot(kU, kNone), VowelSlot(kO, kHorn)),  F_c | F_m | F_n | F_ng | F_p | F_t },   // uơ: no ch, nh
+    { Key2(VowelSlot(kU, kNone), VowelSlot(kY, kNone)),  F_ch | F_n | F_nh | F_t },              // uy: ch, n, nh, t
+    { Key2(VowelSlot(kU, kHorn), VowelSlot(kO, kHorn)),  F_c | F_m | F_n | F_ng | F_p | F_t },   // ươ: no ch, nh
+    { Key2(VowelSlot(kY, kNone), VowelSlot(kE, kCirc)),  F_c | F_m | F_n | F_ng | F_p | F_t },   // yê: same as iê
+
+    // === Triple vowels with coda ===
+    { Key3(VowelSlot(kU, kNone), VowelSlot(kY, kNone), VowelSlot(kE, kCirc)), F_n | F_t },       // uyê: n, t
+};
+
+constexpr size_t kVCPairRuleCount = sizeof(kVCPairRules) / sizeof(kVCPairRules[0]);
+
+// Look up allowed finals for a vowel key. Returns 0 if the nucleus has no
+// VCPair entry — caller decides whether to treat that as "no restriction"
+// (Path 1 lenient default) or to require an entry (stricter validation).
+[[nodiscard]] constexpr uint16_t GetAllowedFinals(uint32_t vowelKey) noexcept {
+    for (size_t i = 0; i < kVCPairRuleCount; ++i) {
+        if (kVCPairRules[i].vowelKey == vowelKey) return kVCPairRules[i].allowedFinals;
+    }
+    return 0;
 }
 
 }  // namespace Phonology

--- a/src/core/engine/VietnamesePhonologyData.h
+++ b/src/core/engine/VietnamesePhonologyData.h
@@ -44,6 +44,10 @@ namespace Phonology {
 constexpr uint8_t kA = 0, kE = 1, kI = 2, kO = 3, kU = 4, kY = 5;
 constexpr uint8_t kNone = 0, kCirc = 1, kBrev = 2, kHorn = 3;
 
+// Sentinel returned by BaseIndex / VowelSlot for non-vowel input. Distinct
+// from any valid (base << 2 | mod) packing — max legal slot is 5*4|3 = 0x17.
+constexpr uint8_t kInvalidBaseIndex = 0xFF;
+
 [[nodiscard]] constexpr uint8_t VowelSlot(uint8_t base, uint8_t mod) noexcept {
     return static_cast<uint8_t>((base << 2) | mod);
 }
@@ -56,7 +60,7 @@ constexpr uint8_t kNone = 0, kCirc = 1, kBrev = 2, kHorn = 3;
         case L'o': return kO;
         case L'u': return kU;
         case L'y': return kY;
-        default:   return 0xFF;
+        default:   return kInvalidBaseIndex;
     }
 }
 

--- a/tests/PhonotacticsTest.cpp
+++ b/tests/PhonotacticsTest.cpp
@@ -336,97 +336,84 @@ TEST_F(PhonotacticsIsValidSyllable, OnsetAgreementUsesFirstVowelOfDiphthong) {
 }
 
 //=============================================================================
-// IsValidSyllable — N1/N2/N3 vowel/coda group compatibility (T3).
-// Rule and "Other" lenient fall-through documented at the helper definition
-// in Phonotactics.cpp.
+// IsValidSyllable — VCPair vowel-coda compatibility (T2.1 Day-2).
+// Per-nucleus allowed-coda bitmask sourced from VietnamesePhonologyData.h
+// (canonical table, shared with the CharState path in PhonotacticsValidator).
+// Replaces the coarser N1/N2/N3 partition that lived here in T3.
+// Lenient fall-through for nuclei without a VCPair entry.
 //=============================================================================
 
-TEST_F(PhonotacticsIsValidSyllable, N1VowelAcceptsC1Coda) {
-    // N1 nuclei (e, o, ô, u, ư, ơ, ă, oă, uâ, uô, ươ, ...) + C1 (ng, c) — valid
-    EXPECT_TRUE(phon_.IsValidSyllable(L"",  L"e",       L"ng", Tone::None,  kModern));   // eng
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"\x00F4",  L"ng", Tone::None,  kModern));   // bông
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"u",       L"c",  Tone::Dot,   kModern));   // bục
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"\x0103",  L"ng", Tone::None,  kModern));   // băng
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"\x01B0",  L"c",  Tone::Acute, kModern));   // bức
+TEST_F(PhonotacticsIsValidSyllable, VCPairOpenNucleusAcceptsAnyCoda) {
+    // a, e, oa carry F_ALL — every coda is allowed.
+    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"a", L"ng", Tone::None,  kModern));   // bang
+    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"a", L"nh", Tone::None,  kModern));   // banh
+    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"a", L"ch", Tone::Acute, kModern));   // bách
+    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"a", L"c",  Tone::Acute, kModern));   // bác
+    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"e", L"nh", Tone::None,  kModern));   // VCPair e: F_ALL
+    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"e", L"ch", Tone::Acute, kModern));   // VCPair e: F_ALL
+    EXPECT_TRUE(phon_.IsValidSyllable(L"h", L"oa", L"ng", Tone::None, kModern));   // hoang
 }
 
-TEST_F(PhonotacticsIsValidSyllable, N1VowelAcceptsC3Coda) {
-    // N1 + C3 (m, n, p, t) — valid
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"e",       L"m", Tone::None,  kModern));   // bem
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"e",       L"n", Tone::None,  kModern));   // ben
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"o",       L"p", Tone::Acute, kModern));   // bóp
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"u",       L"t", Tone::Acute, kModern));   // bút
+TEST_F(PhonotacticsIsValidSyllable, VCPairRejectsCodaOutsideAllowedFinals) {
+    // â/ă/o/ô/u/ư carry F_NO_CH_NH — nh and ch are rejected, others ok.
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"o",       L"nh", Tone::None,  kModern));  // VCPair o: F_NO_CH_NH
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x0103",  L"nh", Tone::None,  kModern));  // ă: F_NO_CH_NH
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x00F4",  L"ch", Tone::Acute, kModern));  // ô: F_NO_CH_NH
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x00E2",  L"nh", Tone::None,  kModern));  // â: F_NO_CH_NH
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"u",       L"ch", Tone::Acute, kModern));  // u: F_NO_CH_NH
+    EXPECT_TRUE (phon_.IsValidSyllable(L"b", L"u",       L"t",  Tone::Acute, kModern));  // bút (C3 is fine)
+    EXPECT_TRUE (phon_.IsValidSyllable(L"b", L"\x00F4",  L"ng", Tone::None,  kModern));  // bông
 }
 
-TEST_F(PhonotacticsIsValidSyllable, N1VowelRejectsC2Coda) {
-    // N1 + C2 (nh, ch) — invalid (N1 forbids C2)
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"e",      L"nh", Tone::None,  kModern));   // benh wrong
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"e",      L"ch", Tone::Acute, kModern));   // bech wrong
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"o",      L"nh", Tone::None,  kModern));   // bonh wrong
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x0103", L"nh", Tone::None,  kModern));   // bănh wrong
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x00F4", L"ch", Tone::Acute, kModern));   // bôch wrong
+TEST_F(PhonotacticsIsValidSyllable, VCPairRestrictsCFrontVowels) {
+    // VCPair: ê has no F_ng; i has no F_ng. ê/i still accept C3 + ch (C2).
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x00EA", L"ng", Tone::None,  kModern));  // bêng wrong
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"i",      L"ng", Tone::None,  kModern));  // bing wrong
+    EXPECT_TRUE (phon_.IsValidSyllable(L"b", L"\x00EA", L"nh", Tone::None,  kModern));  // bênh
+    EXPECT_TRUE (phon_.IsValidSyllable(L"b", L"i",      L"nh", Tone::None,  kModern));  // binh
+    EXPECT_TRUE (phon_.IsValidSyllable(L"b", L"i",      L"ch", Tone::Acute, kModern));  // bích
+    EXPECT_TRUE (phon_.IsValidSyllable(L"b", L"i",      L"c",  Tone::Acute, kModern));  // VCPair i allows c
+    EXPECT_TRUE (phon_.IsValidSyllable(L"b", L"\x00EA", L"c",  Tone::Acute, kModern));  // VCPair ê allows c
+    EXPECT_TRUE (phon_.IsValidSyllable(L"b", L"i",      L"m",  Tone::None,  kModern));  // bim
+    EXPECT_TRUE (phon_.IsValidSyllable(L"b", L"i",      L"t",  Tone::Acute, kModern));  // bít
 }
 
-TEST_F(PhonotacticsIsValidSyllable, N2VowelAcceptsC2Coda) {
-    // N2 (ê, i, uê, uy, ua) + C2 (nh, ch) — valid
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"\x00EA", L"nh", Tone::None,  kModern));   // bênh
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"i",      L"nh", Tone::None,  kModern));   // binh
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"i",      L"ch", Tone::Acute, kModern));   // bích
-    EXPECT_TRUE(phon_.IsValidSyllable(L"h", L"uy",     L"nh", Tone::Grave, kModern));   // huỳnh
+TEST_F(PhonotacticsIsValidSyllable, VCPairTightlyConstrainsRareNuclei) {
+    // VCPair: ơ allows only m/n/p/t; y allows only t; uy carries F_ch|F_n|F_nh|F_t.
+    EXPECT_TRUE (phon_.IsValidSyllable(L"b", L"\x01A1", L"n",  Tone::None, kModern));   // bơn
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x01A1", L"ng", Tone::None, kModern));   // ơ rejects ng
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x01A1", L"c",  Tone::Acute, kModern));  // ơ rejects c
+    EXPECT_FALSE(phon_.IsValidSyllable(L"h", L"uy",     L"ng", Tone::None, kModern));   // uy rejects ng
+    EXPECT_FALSE(phon_.IsValidSyllable(L"h", L"uy",     L"c",  Tone::Acute, kModern));  // uy rejects c
+    EXPECT_TRUE (phon_.IsValidSyllable(L"h", L"uy",     L"nh", Tone::Grave, kModern));  // huỳnh
 }
 
-TEST_F(PhonotacticsIsValidSyllable, N2VowelAcceptsC3Coda) {
-    // N2 + C3 — valid
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"i",      L"m", Tone::None,  kModern));   // bim
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"\x00EA", L"n", Tone::None,  kModern));   // bên
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"i",      L"t", Tone::Acute, kModern));   // bít
+TEST_F(PhonotacticsIsValidSyllable, VCPairMultiVowelRules) {
+    // iê: F_c|F_m|F_n|F_ng|F_p|F_t — accepts ng but rejects nh, ch.
+    EXPECT_TRUE (phon_.IsValidSyllable(L"b", L"i\x00EA",  L"ng", Tone::None, kModern));   // biêng
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"i\x00EA",  L"nh", Tone::None, kModern));   // VCPair iê rejects nh
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"i\x00EA",  L"ch", Tone::Acute, kModern));  // VCPair iê rejects ch
+    // uô / ươ: same shape (no ch, nh).
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"u\x00F4", L"nh", Tone::None,  kModern));   // buônh wrong
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x01B0\x01A1", L"ch", Tone::Acute, kModern));  // bươch wrong
+    // oă: F_c|F_n|F_ng|F_t — accepts coda set, rejects nh/ch/m/p.
+    EXPECT_FALSE(phon_.IsValidSyllable(L"",  L"o\x0103", L"nh", Tone::None, kModern));    // oănh wrong
+    // uâ: F_n|F_ng|F_t.
+    EXPECT_FALSE(phon_.IsValidSyllable(L"t", L"u\x00E2", L"nh", Tone::None, kModern));    // tuânh wrong
+    // uê: F_ch|F_n|F_nh.
+    EXPECT_TRUE (phon_.IsValidSyllable(L"th", L"u\x00EA", L"nh", Tone::None, kModern));   // thuênh ok per VCPair
 }
 
-TEST_F(PhonotacticsIsValidSyllable, N2VowelRejectsC1Coda) {
-    // N2 + C1 (ng, c) — invalid (N2 forbids C1)
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"i",       L"ng", Tone::None,  kModern));  // bing wrong
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x00EA",  L"ng", Tone::None,  kModern));  // bêng wrong
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"i",       L"c",  Tone::Acute, kModern));  // bic wrong
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x00EA",  L"c",  Tone::Acute, kModern));  // bêc wrong
-    EXPECT_FALSE(phon_.IsValidSyllable(L"h", L"uy",      L"ng", Tone::None,  kModern));  // huyng wrong
+TEST_F(PhonotacticsIsValidSyllable, VCPairUnknownNucleusFallsThroughLeniently) {
+    // Nuclei that don't have a VCPair entry (e.g. orthographic loanword-friendly
+    // sequences not in the canonical table) accept any coda.
+    EXPECT_TRUE(phon_.IsValidSyllable(L"x", L"oo", L"ng", Tone::None, kModern));   // xoong (oo: F_c|F_ng → valid)
 }
 
-TEST_F(PhonotacticsIsValidSyllable, N3VowelAcceptsAllCodaGroups) {
-    // N3 (a, oa, iê, uyê) — accepts C1, C2, C3
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"a",        L"ng", Tone::None,  kModern));  // bang (C1)
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"a",        L"nh", Tone::None,  kModern));  // banh (C2)
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"a",        L"n",  Tone::None,  kModern));  // ban  (C3)
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"a",        L"ch", Tone::Acute, kModern));  // bách (C2)
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"a",        L"c",  Tone::Acute, kModern));  // bác  (C1)
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"i\x00EA",  L"ng", Tone::None,  kModern));  // biêng (iê N3 + C1)
-    EXPECT_TRUE(phon_.IsValidSyllable(L"b", L"i\x00EA",  L"nh", Tone::None,  kModern));  // biênh (iê N3 + C2)
-}
-
-TEST_F(PhonotacticsIsValidSyllable, MultiVowelN1RejectsC2) {
-    // Multi-vowel N1: oă, uô, ươ, uâ, uơ + C2 — invalid
-    EXPECT_FALSE(phon_.IsValidSyllable(L"",  L"o\x0103",       L"nh", Tone::None,  kModern));  // oănh wrong
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"u\x00F4",       L"nh", Tone::None,  kModern));  // buônh wrong
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"\x01B0\x01A1",  L"ch", Tone::Acute, kModern));  // bươch wrong
-    EXPECT_FALSE(phon_.IsValidSyllable(L"t", L"u\x00E2",       L"nh", Tone::None,  kModern));  // tuânh wrong
-}
-
-TEST_F(PhonotacticsIsValidSyllable, MultiVowelN2AcceptsC2) {
-    // Multi-vowel N2: uê, uy + C2 — valid
-    EXPECT_TRUE(phon_.IsValidSyllable(L"th", L"u\x00EA", L"nh", Tone::None,  kModern));   // thuênh (rule allows)
-    EXPECT_TRUE(phon_.IsValidSyllable(L"h",  L"uy",      L"nh", Tone::Grave, kModern));   // huỳnh
-}
-
-TEST_F(PhonotacticsIsValidSyllable, UnclassifiedVowelAllowsAnyCoda) {
-    // Lenient fall-through for nuclei not in N1/N2/N3 lists (e.g. "oo" used in
-    // loanword-style "xoong"). Closed/pending rules handle their own cases first.
-    EXPECT_TRUE(phon_.IsValidSyllable(L"x", L"oo", L"ng", Tone::None, kModern));   // xoong (real word)
-}
-
-TEST_F(PhonotacticsIsValidSyllable, ClosedVowelRuleStillFiresBeforeNGroup) {
-    // Closed-vowel rule rejects any coda regardless of N-group classification.
-    // "ai" is closed (no coda allowed). "an" + n-coda would be N3-style if allowed,
-    // but the closed-vowel rule short-circuits before reaching N-group check.
-    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"ai", L"n", Tone::None, kModern));   // bain still invalid (closed)
+TEST_F(PhonotacticsIsValidSyllable, ClosedVowelRuleStillFiresBeforeVCPair) {
+    // Closed-vowel rule rejects any coda regardless of VCPair lookup; closed
+    // check runs first.
+    EXPECT_FALSE(phon_.IsValidSyllable(L"b", L"ai", L"n", Tone::None, kModern));   // ai is closed → invalid
 }
 
 //=============================================================================


### PR DESCRIPTION
## Summary

**Day-2 of T2.1 phonology consolidation sprint.** Lifts the canonical per-nucleus allowed-coda data (`kVCPairRules` bitmask + packed-key encoding + F_* coda masks) from `PhonotacticsValidator.cpp` into the shared `VietnamesePhonologyData.h` (added Day-1, #150). Path 2 (`Phonotactics::IsValidSyllable`) now consults VCPair directly, matching Path 1 production semantics; T3's coarser N1/N2/N3 approximation is retired.

## CODE_GOVERNANCE Q1-Q5 gate

| Q | Answer |
|---|---|
| **Q1 Layer** | Engine layer; extends Day-1's shared header. ✓ |
| **Q2 Perf** | Path 1 hot path: **0 ns delta** (data relocated; lookup byte-identical). Path 2 (no prod caller): +~50-100 ns for the wstring_view → packed-key encoder. **Net 0 ns hot-path delta.** |
| **Q3 Native** | N/A. |
| **Q4 No-Lock** | constexpr noexcept throughout. ✓ |
| **Q5 Trade-off** | **Gain**: single source of truth for VCPair; T3 N-group approximation deleted (~50 LOC); Path 2 contract now matches Path 1 production. **Give up**: ~30 LOC encoder on Path 2; T3 tests re-baselined to VCPair semantics (-4 net test count). |

## Behaviour deltas (Path 2 only — no production caller)

| Case | T3 N-group verdict | VCPair verdict |
|---|---|---|
| `e + nh / e + ch` | invalid (N1+C2) | **VALID** (e: F_ALL) |
| `i + c / ê + c` | invalid (N2+C1) | **VALID** (i/ê allow c) |
| `iê + nh` | valid (N3=all) | **INVALID** (iê: no F_nh) |
| `ơ + ng / ơ + c` | valid (N1+C1) | **INVALID** (ơ: only m/n/p/t) |
| `y + non-t` | lenient (Other) | **INVALID** (y: F_t only) |

The interface contract on `Phonotactics::IsValidSyllable` is now identical to the production CharState path.

## Files

- `src/core/engine/VietnamesePhonologyData.h` — VCPair tables + packed-key encoding + F_* masks added
- `src/core/engine/PhonotacticsValidator.cpp` — drops -85 LOC of duplicated tables from anon ns
- `src/core/engine/Phonotactics.cpp` — adds 3-helper encoder; retires N-group machinery
- `tests/PhonotacticsTest.cpp` — replaces 11 N-group tests with 7 VCPair-shape tests

## Test plan

- [x] Linux `NextKeyTests` 1547/1547 PASS post-migration
- [x] Path 1 production tests unchanged (CharState validator behaviour byte-identical)
- [x] Path 2 contract tightened — confirmed via the 7 new VCPair tests
- [x] `nexuskey-review` checklist (naming / namespace / modern C++ / testing) clean
- [x] Build: CMake reconfigure verified

## Followup

Day-3 (next): define `IPhonologyRules` plugin contract; both validators become thin adapters over the shared data. Day-4: RulePackId factory hook for future dialect/script variants.