### PR TITLE
refactor(T2.1 D3): IPhonologyRules plugin contract + Path 2 adapter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ set(NEXTKEY_ENGINE_SOURCES
     src/core/engine/EnglishProtection.h
     src/core/engine/VietnameseTables.h
     src/core/engine/VietnamesePhonologyData.h
+    src/core/engine/IPhonologyRules.h
+    src/core/engine/DefaultPhonologyRules.h
     src/core/engine/PhonotacticsValidator.cpp
     src/core/engine/PhonotacticsValidator.h
     src/core/engine/IPhonotactics.h

--- a/src/core/engine/DefaultPhonologyRules.h
+++ b/src/core/engine/DefaultPhonologyRules.h
@@ -1,0 +1,35 @@
+// NexusKey - Default Vietnamese Phonology Rule Pack
+// Copyright (c) 2024-2026 PhatMT. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-NexusKey-Commercial
+//
+// DefaultPhonologyRules — canonical Vietnamese rule pack reading from
+// VietnamesePhonologyData.h. Singleton via Default(); both phonotactics
+// validators (Path 1, Path 2) bind to this when no custom rules are
+// injected. Marked `final` so callers see direct devirtualised calls.
+
+#pragma once
+
+#include "IPhonologyRules.h"
+#include "VietnamesePhonologyData.h"
+
+namespace NextKey {
+namespace Phonology {
+
+class DefaultPhonologyRules final : public IPhonologyRules {
+public:
+    [[nodiscard]] bool IsFrontBaseVowel(wchar_t base) const noexcept override {
+        return ::NextKey::Phonology::IsFrontBaseVowel(base);
+    }
+
+    [[nodiscard]] uint16_t AllowedFinalsForVowelKey(uint32_t vowelKey) const noexcept override {
+        return ::NextKey::Phonology::GetAllowedFinals(vowelKey);
+    }
+
+    [[nodiscard]] static const DefaultPhonologyRules& Default() noexcept {
+        static const DefaultPhonologyRules instance;
+        return instance;
+    }
+};
+
+}  // namespace Phonology
+}  // namespace NextKey

--- a/src/core/engine/IPhonologyRules.h
+++ b/src/core/engine/IPhonologyRules.h
@@ -1,0 +1,48 @@
+// NexusKey - Vietnamese Phonology Rule-Pack Contract
+// Copyright (c) 2024-2026 PhatMT. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-NexusKey-Commercial
+//
+// IPhonologyRules — pluggable rule-data provider for Vietnamese phonotactics.
+//
+// Mirrors the IOutputInjector pattern (src/app/output/IOutputInjector.h):
+// abstract contract + `final` default impl + factory/`Default()` singleton.
+// Both phonotactics validators (Path 1 CharState in PhonotacticsValidator.cpp,
+// Path 2 wstring_view in Phonotactics.cpp) consume rule data through this
+// contract instead of reaching into VietnamesePhonologyData.h directly. The
+// `final` qualifier on impls enables devirtualization at known static types.
+//
+// Future rule-pack variants (dialectal Vietnamese, alternate orthographies,
+// loanword-friendly modes) plug in by providing another impl + factory entry.
+//
+// Day-3 wires this into Path 2 (Phonotactics class). Path 1 is unchanged
+// for now — its hot path consumes the same data via free functions in
+// VietnamesePhonologyData.h. D4 candidate to migrate Path 1 with care.
+
+#pragma once
+
+#include <cstdint>
+
+namespace NextKey {
+namespace Phonology {
+
+class IPhonologyRules {
+public:
+    virtual ~IPhonologyRules() = default;
+
+    // Front-vowel classifier (Day-1 lift). Modifier marks (ê, â) do not
+    // change the front/back class — pass the *base* (post-Decompose) wchar.
+    [[nodiscard]] virtual bool IsFrontBaseVowel(wchar_t base) const noexcept = 0;
+
+    // Allowed-coda bitmask for a packed vowel-nucleus key (Day-2 lift).
+    // Returns 0 when the nucleus has no entry — caller treats as "no
+    // restriction → lenient pass-through".
+    [[nodiscard]] virtual uint16_t AllowedFinalsForVowelKey(uint32_t vowelKey) const noexcept = 0;
+
+protected:
+    IPhonologyRules() = default;
+    IPhonologyRules(const IPhonologyRules&) = default;
+    IPhonologyRules& operator=(const IPhonologyRules&) = default;
+};
+
+}  // namespace Phonology
+}  // namespace NextKey

--- a/src/core/engine/Phonotactics.cpp
+++ b/src/core/engine/Phonotactics.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <string_view>
 
+#include "DefaultPhonologyRules.h"
 #include "VietnamesePhonologyData.h"
 #include "VietnameseTables.h"
 
@@ -225,12 +226,15 @@ constexpr std::wstring_view kValidCodas[] = {
 // Lenient by default: if any of the inputs (nucleus, coda) cannot be encoded
 // or has no entry in the VCPair table, accept the syllable. The strictness
 // applies only when both sides resolve to known, table-listed values.
-[[nodiscard]] constexpr bool IsCodaValidForNucleus(std::wstring_view vowelSeq,
-                                                    std::wstring_view coda) noexcept {
+// Rule data is resolved through the injected IPhonologyRules pack so future
+// dialectal variants (RulePackId factory) plug in without forking this code.
+[[nodiscard]] bool IsCodaValidForNucleus(const IPhonologyRules& rules,
+                                          std::wstring_view vowelSeq,
+                                          std::wstring_view coda) noexcept {
     if (coda.empty()) return true;
     uint32_t vowelKey = WstringViewToVowelKey(vowelSeq);
     if (vowelKey == 0) return true;
-    uint16_t allowed = NextKey::Phonology::GetAllowedFinals(vowelKey);
+    uint16_t allowed = rules.AllowedFinalsForVowelKey(vowelKey);
     if (allowed == 0) return true;
     uint16_t bit = CodaToFinalBit(coda);
     if (bit == 0) return true;
@@ -242,6 +246,7 @@ constexpr std::wstring_view kValidCodas[] = {
 // CharState path in PhonotacticsValidator.cpp (T2.1 consolidation Day-1).
 
 [[nodiscard]] bool IsOnsetVowelAgreementValid(
+        const IPhonologyRules& rules,
         std::wstring_view onset,
         std::wstring_view vowelSeq) noexcept {
     // qu intentionally exempted: book lists oa/oă/oe/uy/uơ/uô/uê/uâ as the
@@ -263,7 +268,7 @@ constexpr std::wstring_view kValidCodas[] = {
     if (firstBase == 0) return true;
 
     const bool wantsFront = (onset == L"k" || onset == L"gh" || onset == L"ngh");
-    return wantsFront == NextKey::Phonology::IsFrontBaseVowel(firstBase);
+    return wantsFront == rules.IsFrontBaseVowel(firstBase);
 }
 
 // =============================================================================
@@ -414,6 +419,12 @@ struct ParsedSyllable {
 // IPhonotactics implementation
 // =============================================================================
 
+Phonotactics::Phonotactics() noexcept
+    : rules_(DefaultPhonologyRules::Default()) {}
+
+Phonotactics::Phonotactics(const IPhonologyRules& rules) noexcept
+    : rules_(rules) {}
+
 const Phonotactics& Phonotactics::Default() noexcept {
     static const Phonotactics instance;
     return instance;
@@ -435,7 +446,7 @@ bool Phonotactics::IsValidSyllable(
     if (vowelSeq.empty()) return false;
 
     // Onset / vowel front-back agreement (c/k, g/gh, ng/ngh). qu exempted.
-    if (!IsOnsetVowelAgreementValid(onset, vowelSeq)) return false;
+    if (!IsOnsetVowelAgreementValid(rules_, onset, vowelSeq)) return false;
 
     // Closed vowels must NOT have a coda.
     if (!coda.empty() && IsClosedVowelSeq(vowelSeq)) return false;
@@ -445,7 +456,7 @@ bool Phonotactics::IsValidSyllable(
 
     // VCPair vowel-coda compatibility (per-nucleus allowed-coda bitmask,
     // shared with PhonotacticsValidator on the CharState path).
-    if (!IsCodaValidForNucleus(vowelSeq, coda)) return false;
+    if (!IsCodaValidForNucleus(rules_, vowelSeq, coda)) return false;
 
     // Stop-final coda restricts tone to Acute or Dot.
     if (!ToneAllowedForCoda(coda, tone)) return false;

--- a/src/core/engine/Phonotactics.h
+++ b/src/core/engine/Phonotactics.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "IPhonologyRules.h"
 #include "IPhonotactics.h"
 #include "PhonotacticsValidator.h"  // SyllableState + ValidateSyllableState (same Phonology namespace)
 
@@ -17,15 +18,24 @@ namespace Phonology {
 
 class Phonotactics final : public IPhonotactics {
 public:
-    Phonotactics() noexcept = default;
+    /// Default ctor binds to `DefaultPhonologyRules::Default()` — the canonical
+    /// Vietnamese rule pack from VietnamesePhonologyData.h.
+    Phonotactics() noexcept;
+
+    /// DI ctor: caller injects a custom IPhonologyRules pack. Useful for
+    /// dialectal rule packs and unit-test stubs. The reference must outlive
+    /// the Phonotactics instance.
+    explicit Phonotactics(const IPhonologyRules& rules) noexcept;
+
     ~Phonotactics() override = default;
 
     Phonotactics(const Phonotactics&) = delete;
     Phonotactics& operator=(const Phonotactics&) = delete;
 
-    /// Returns the process-wide default Phonotactics instance. Stateless and
-    /// thread-safe; used as the implicit dependency for callers that don't
-    /// inject a custom IPhonotactics (e.g. TypingEngine's single-arg ctor).
+    /// Returns the process-wide default Phonotactics instance bound to
+    /// DefaultPhonologyRules. Stateless and thread-safe; used as the implicit
+    /// dependency for callers that don't inject a custom IPhonotactics
+    /// (e.g. TypingEngine's single-arg ctor).
     [[nodiscard]] static const Phonotactics& Default() noexcept;
 
     [[nodiscard]] size_t TonePosition(
@@ -42,6 +52,9 @@ public:
 
     [[nodiscard]] bool CanComplete(
         std::wstring_view partial) const noexcept override;
+
+private:
+    const IPhonologyRules& rules_;
 };
 
 }  // namespace Phonology

--- a/src/core/engine/PhonotacticsValidator.cpp
+++ b/src/core/engine/PhonotacticsValidator.cpp
@@ -23,6 +23,11 @@ namespace {
 // header `VietnamesePhonologyData.h` (T2.1 Day-2 consolidation). Only the
 // CharState-specific helpers (FinalConsonantBit template, kVowelTable, vowel
 // scanners) remain in this anonymous namespace.
+//
+// TODO(T2.1 D4): migrate this hot-path validator to consume rule data through
+// `IPhonologyRules` (see IPhonologyRules.h) so future RulePackId variants can
+// plug in without a parallel rewrite. D3 wired the contract on Path 2 only;
+// preserving Path 1's direct-call hot path until D4 lands the careful migration.
 
 //=============================================================================
 // Vowel nucleus table

--- a/tests/PhonotacticsTest.cpp
+++ b/tests/PhonotacticsTest.cpp
@@ -5,7 +5,9 @@
 // completability. Operates on rendered Vietnamese text (wstring_view).
 
 #include <gtest/gtest.h>
+#include "core/engine/IPhonologyRules.h"
 #include "core/engine/IPhonotactics.h"
+#include "core/engine/DefaultPhonologyRules.h"
 #include "core/engine/Phonotactics.h"
 #include "core/engine/TypingEngine.h"
 #include "core/config/TypingConfig.h"
@@ -487,6 +489,90 @@ TEST(PhonotacticsDefault, ReturnsStableSingleton) {
     const Phonotactics& a = Phonotactics::Default();
     const Phonotactics& b = Phonotactics::Default();
     EXPECT_EQ(&a, &b);
+}
+
+//=============================================================================
+// IPhonologyRules DI plumbing — verifies T2.1 D3:
+// Phonotactics accepts a custom IPhonologyRules pack, rule queries flow through
+// the contract, default ctor binds to DefaultPhonologyRules.
+//=============================================================================
+
+TEST(DefaultPhonologyRules, IsSingleton) {
+    const DefaultPhonologyRules& a = DefaultPhonologyRules::Default();
+    const DefaultPhonologyRules& b = DefaultPhonologyRules::Default();
+    EXPECT_EQ(&a, &b);
+}
+
+TEST(DefaultPhonologyRules, MatchesFreeFunctionContracts) {
+    // Default impl should produce the same answers as the free functions in
+    // VietnamesePhonologyData.h (it just forwards).
+    const DefaultPhonologyRules& rules = DefaultPhonologyRules::Default();
+    EXPECT_TRUE (rules.IsFrontBaseVowel(L'e'));
+    EXPECT_TRUE (rules.IsFrontBaseVowel(L'i'));
+    EXPECT_TRUE (rules.IsFrontBaseVowel(L'y'));
+    EXPECT_FALSE(rules.IsFrontBaseVowel(L'a'));
+    EXPECT_FALSE(rules.IsFrontBaseVowel(L'o'));
+    EXPECT_FALSE(rules.IsFrontBaseVowel(L'u'));
+    // Sample VCPair lookup: a → F_ALL (all 9 finals).
+    uint32_t aKey = Key1(VowelSlot(kA, kNone));
+    EXPECT_EQ(rules.AllowedFinalsForVowelKey(aKey), F_ALL);
+    // ơ → F_m | F_n | F_p | F_t only.
+    uint32_t oHornKey = Key1(VowelSlot(kO, kHorn));
+    EXPECT_EQ(rules.AllowedFinalsForVowelKey(oHornKey), F_m | F_n | F_p | F_t);
+}
+
+namespace {
+// Stub flipping the front/back classification (a becomes front, i becomes back).
+// Used to prove the injected pack — not the default singleton — is consulted.
+class FlippedFrontVowelRules final : public IPhonologyRules {
+public:
+    [[nodiscard]] bool IsFrontBaseVowel(wchar_t base) const noexcept override {
+        return !DefaultPhonologyRules::Default().IsFrontBaseVowel(base);
+    }
+    [[nodiscard]] uint16_t AllowedFinalsForVowelKey(uint32_t key) const noexcept override {
+        return DefaultPhonologyRules::Default().AllowedFinalsForVowelKey(key);
+    }
+};
+
+// Stub returning no VCPair entry for any nucleus (forces lenient pass-through
+// on every IsCodaValidForNucleus call).
+class NoCodaRestrictionRules final : public IPhonologyRules {
+public:
+    [[nodiscard]] bool IsFrontBaseVowel(wchar_t base) const noexcept override {
+        return DefaultPhonologyRules::Default().IsFrontBaseVowel(base);
+    }
+    [[nodiscard]] uint16_t AllowedFinalsForVowelKey(uint32_t /*key*/) const noexcept override {
+        return 0;
+    }
+};
+}  // namespace
+
+TEST(PhonotacticsDI, CustomRulesFlipOnsetAgreement) {
+    FlippedFrontVowelRules flipped;
+    Phonotactics phon(flipped);
+    // Default: ke is valid (k wants front, e is front). Flipped: e is back → invalid.
+    EXPECT_FALSE(phon.IsValidSyllable(L"k", L"e", L"", Tone::None, true));
+    // Default: ka is invalid (k wants front, a is back). Flipped: a is front → valid.
+    EXPECT_TRUE (phon.IsValidSyllable(L"k", L"a", L"", Tone::None, true));
+}
+
+TEST(PhonotacticsDI, CustomRulesDropsVCPairRestrictions) {
+    NoCodaRestrictionRules lenient;
+    Phonotactics phon(lenient);
+    // Default: ơng invalid (ơ allows only m/n/p/t). Custom: returns 0 → lenient → valid.
+    EXPECT_TRUE(phon.IsValidSyllable(L"b", L"\x01A1", L"ng", Tone::None, true));
+    // Default: yng invalid (y allows only t). Custom: lenient → valid.
+    EXPECT_TRUE(phon.IsValidSyllable(L"",  L"y",      L"ng", Tone::None, true));
+}
+
+TEST(PhonotacticsDI, DefaultCtorBindsDefaultRules) {
+    // Default-constructed Phonotactics enforces canonical Vietnamese rules.
+    Phonotactics phon;
+    EXPECT_FALSE(phon.IsValidSyllable(L"k", L"a",      L"",   Tone::None, true));   // k requires front
+    EXPECT_FALSE(phon.IsValidSyllable(L"c", L"i",      L"",   Tone::None, true));   // c requires back
+    EXPECT_FALSE(phon.IsValidSyllable(L"b", L"\x01A1", L"ng", Tone::None, true));   // ơ + ng forbidden
+    EXPECT_TRUE (phon.IsValidSyllable(L"k", L"e",      L"",   Tone::None, true));   // k + e ok
+    EXPECT_TRUE (phon.IsValidSyllable(L"b", L"a",      L"ng", Tone::None, true));   // a + ng ok
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

**Day-3 of T2.1 phonology consolidation sprint.** Defines the `IPhonologyRules` rule-data plugin contract mirroring the existing `IOutputInjector` pattern (`src/app/output/IOutputInjector.h`): abstract interface + `final` default impl + `Default()` singleton. Phonotactics class (Path 2) becomes the first consumer.

## Honesty: user-visible benefit today = **zero**

This PR ships infrastructure. App identical pre-D3 → post-D3. The user does NOT get:
- Better spell checking (Path 1 production validator unchanged)
- Faster typing (hot path 0 ns delta)
- Any new feature

The architectural payback is for **future** features that consume `IPhonologyRules`:
- Spell-check overlay (gạch đỏ trong compose buffer)
- Strict / Lenient mode toggle (rule-pack swap)
- Dialect rule packs (Sài Gòn / Hà Nội / Trung)
- Dictionary autocomplete suggestion

T2.1 sprint scope was approved as architectural-debt-payback. D4 (next) closes the sprint.

## CODE_GOVERNANCE Q1-Q5 gate

| Q | Answer |
|---|---|
| **Q1 Layer** | Engine layer — new headers peer of existing `IPhonotactics.h`, `VietnamesePhonologyData.h`. ✓ |
| **Q2 Perf** | Path 1 hot path: **0 ns delta** (untouched in D3, D4 candidate but likely kept direct-call). Path 2 (no production caller): +1-2 ns per query for vcall (devirtualizable since impl `final`). **Net 0 ns hot-path delta.** |
| **Q3 Native** | N/A — interface design. |
| **Q4 No-Lock** | virtual const noexcept throughout. No mutex/alloc/exception. ✓ |
| **Q5 Trade-off** | **Gain**: plugin contract realized for rule-data layer; future `RulePackId` variants plug in by implementing IPhonologyRules. **Give up**: 2 new headers + thin adapter in `Phonotactics`; Path 1 hot path deferred to D4 (likely kept direct-call). |

## What's in scope

- `src/core/engine/IPhonologyRules.h` — abstract contract: `IsFrontBaseVowel(wchar_t)`, `AllowedFinalsForVowelKey(uint32_t)`
- `src/core/engine/DefaultPhonologyRules.h` — `final` impl forwarding to free functions in `VietnamesePhonologyData.h`; `Default()` static singleton
- `src/core/engine/Phonotactics.h/.cpp` — gains DI ctor `Phonotactics(const IPhonologyRules&)`; default ctor binds to `DefaultPhonologyRules::Default()`; `rules_` member; anon-ns helpers `IsCodaValidForNucleus` + `IsOnsetVowelAgreementValid` now take `const IPhonologyRules&` and route lookups through the contract
- `src/core/engine/PhonotacticsValidator.cpp` — adds TODO note pointing at D4 migration path; code unchanged
- `tests/PhonotacticsTest.cpp` — adds 5 new tests covering singleton stability, contract forwarding, and DI behaviour with two distinct stubs (flipped front/back classifier; no-VCPair-restriction stub)
- `CMakeLists.txt` — new headers listed

## Test plan

- [x] Linux `NextKeyTests` 1552/1552 PASS (1547 baseline + 5 new DI tests)
- [x] Path 1 production tests unchanged (CharState validator behaviour byte-identical)
- [x] DI verified via two contrasting stubs (flipped agreement; lenient pass-through) — both prove the injected pack is consulted instead of the default singleton

## Followup

**D4 (sprint close)**: `RulePackId` factory hook for future dialect/script variants. Likely keeps Path 1 hot path direct-call (zero ns delta) and routes only off-hot-path consumers through `IPhonologyRules`.