### PR TITLE
refactor(T2.1 D4): RulePackId factory + sprint close + handoff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(NEXTKEY_ENGINE_SOURCES
     src/core/engine/VietnamesePhonologyData.h
     src/core/engine/IPhonologyRules.h
     src/core/engine/DefaultPhonologyRules.h
+    src/core/engine/PhonologyRulePackFactory.h
     src/core/engine/PhonotacticsValidator.cpp
     src/core/engine/PhonotacticsValidator.h
     src/core/engine/IPhonotactics.h

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,4 +1,56 @@
-# NexusKey Refactor — handoff (T5 closed; T6 retest or T2/T3 next)
+# NexusKey Refactor — handoff (T2.1 sprint closed; engine + hook backlog clear)
+
+## 2026-05-08 — T2.1 PHONOLOGY CONSOLIDATION SPRINT CLOSED (4 PRs)
+
+**Pickup for teammate:** T2.1 Vietnamese-rule consolidation sprint complete at Day-4. Combined with H1-H7 (ProcessKeyDown decompose + cleanup) shipped 2026-05-07 and T2/T3/T5/T6 done same week, the **HookEngine + TypingEngine architectural backlogs are effectively cleared**. H6 + H8 remain as Sprint 4+ roadmap items (multi-week, deferred). Next decision is feature direction, not refactor — see "Pivot decision" below.
+
+### What T2.1 delivered
+
+Single source of truth for Vietnamese phonological rule data, exposed as a plugin contract mirroring the existing IOutputInjector pattern (`src/app/output/IOutputInjector.h`).
+
+| Day | PR | Merge SHA | Scope |
+|---|---|---|---|
+| **D1** | #150 | `dd58f1e` | New header `core/engine/VietnamesePhonologyData.h`. `IsFrontBaseVowel` lifted from PhonotacticsValidator + Phonotactics anon namespaces → shared header. Both validators consume same classifier. |
+| **D2** | #151 | `b52e29d` | `kVCPairRules` (24-nucleus allowed-coda bitmask) + packed-key encoding (`VowelSlot`, `Key1/2/3`, `BaseIndex`) + F_* coda masks lifted to shared header. PhonotacticsValidator drops -85 LOC of duplicates from anon namespace. Phonotactics (Path 2) gains wstring_view→packed-key encoder; **retires the coarser T3 N1/N2/N3 approximation**, contract now matches Path 1 production semantics. |
+| **D3** | #152 | `9d9b5a5` | `IPhonologyRules` plugin contract interface + `DefaultPhonologyRules` `final` impl + Phonotactics DI ctor (default-binds to DefaultPhonologyRules::Default()). Path 2 routes rule queries through the contract. |
+| **D4** | (PR pending) | — | `PhonologyRulePackId` enum + inline `GetRulePack` factory in new header `PhonologyRulePackFactory.h`. Reserved enum slots commented-out for future packs (StrictTextbook / LenientLoanword / SouthDialect / NorthDialect / CentralDialect). Mirrors OutputInjectorFactory shape. |
+
+**Path 1 (production hot path) intentionally untouched.** `Phonology::ValidateSyllableState` on CharState keeps direct-call free functions (`Phonology::GetAllowedFinals`, `Phonology::IsFrontBaseVowel`) for **0 ns delta** at the keystroke level. Only off-hot-path consumers (Phonotactics class today; future spell-check overlay, dialect toggle UI, dictionary autocomplete) route through `IPhonologyRules`.
+
+### User-visible benefit today: **zero**
+
+T2.1 is architectural-debt payback. App identical pre-D1 → post-D4. No spell-check change, no typing-speed change, no new feature. The plugin contract is ready for the first feature consumer; without one, T2.1's value is purely future-velocity unlock.
+
+5+ pre-existing engine duplications (Decompose vs DecomposeVietChar, kVowelTable vs kClosedVowels/kPendingVowels, kValidOnsets shape) noted by review agents but **not** in T2.1 scope — pickup-when-touching-feature, no standalone sprint justified.
+
+### Verification across the sprint
+
+| Day | Tests | Cumulative |
+|---|---|---|
+| Pre-D1 baseline | 1540 PASS | 1540 |
+| D1 | byte-identical | 1540 |
+| D2 | -11 N-group tests, +7 VCPair tests | 1547 (-4 net but tightened semantics) |
+| D3 | +5 DI tests | 1552 |
+| D4 | +3 factory tests | **1555/1555 PASS** |
+
+### Pivot decision (anh chốt next session)
+
+Hook + Engine architectural backlogs cleared. Three forward directions:
+
+1. **Ship a feature** consuming T2.1 unlock — concretely realize the architectural payback. Candidates ordered by user-visible impact:
+   - **Spell-check overlay** (gạch đỏ in compose buffer) — needs Phonotactics::IsValidSyllable wired into UI render, ~1-2 days.
+   - **Strict / Lenient mode toggle** — UI toggle + 2 IPhonologyRules impls, ~1 day.
+   - **Smart auto-restore** for English-mangled words — ~1 day.
+   - **Dialect rule packs** (Sài Gòn / Hà Nội / Trung) — UI + 3 impls, ~2-3 days.
+   - **Dictionary autocomplete suggestion** — phonotactic filter on candidates, ~3-4 days.
+
+2. **Bug / issue triage** — 11 GitHub issues open. Triage + fix priority bugs.
+
+3. **TSF Phase 2/3** — TSF DLL hybrid update landed 2026-04-22 (`c1e9ce2`); Phase 2 is the user-facing TSF re-enable (currently hook-engine-only per `project_hook_only` memory).
+
+If anh has no near-term plan to ship 1+ feature in (1), T2.1 was YAGNI under the Don't-design-for-hypothetical rule in CLAUDE.md. Worth being honest about that and either committing to a feature or accepting the architecture-debt-payback rationale standalone.
+
+---
 
 ## 2026-05-07 — T5 `cafcs → các` FIX MERGED (PR #146, Main `1ade8dc`)
 

--- a/docs/REFACTOR_STATUS.md
+++ b/docs/REFACTOR_STATUS.md
@@ -1,8 +1,8 @@
 # NexusKey Refactor Status — Living Inventory
 
-> **Last refresh:** 2026-05-08 (post T2 #147 + T3 #149 merge, Main `e908621`)
+> **Last refresh:** 2026-05-08 (T2.1 sprint close — D1/D2/D3 merged + D4 PR-pending, Main `9d9b5a5`)
 > **Scope:** All architectural / cleanup refactor work. Excludes user-facing features (G-5/G-6 Sciter UI + keymap files, TSF Phase 2/3, etc.) — those track separately.
-> **Sequencing rule (anh decision 2026-05-07):** Complete HookEngine refactor backlog BEFORE picking up TypingEngine TODO items. **Post-H1c the rule is satisfied; T5 done; T2/T3 done.** Remaining: T6 retest (anh confirmed test ổn 2026-05-08, can close); T2.1 phonology-plugin consolidation (principle-grade per design philosophy 2026-05-08).
+> **Sequencing rule (anh decision 2026-05-07):** Complete HookEngine refactor backlog BEFORE picking up TypingEngine TODO items. **Backlog effectively cleared at architectural level**: H1-H7 + T1-T6 done; H6/H8 are Sprint 4+ roadmap items (multi-week); T2.1 sprint-closed at D4. Engine + Hook architecturally complete pending feature consumers of T2.1 plugin contract.
 
 ---
 
@@ -96,11 +96,11 @@
 |---|---|---|---|---|
 | ~~T1~~ | ~~**`SpellChecker.{h,cpp}` → `PhonotacticsValidator` rename**~~ | — | DONE | ✅ PR #139 `b115f75` |
 | ~~T2~~ | ~~**Phonotactics onset agreement** — c/k, g/gh, ng/ngh enforcement (qu exempted)~~ | — | DONE | ✅ PR #147 `d723e03` |
-| T2.1 | **Phonotactics rule duplication between `Phonotactics.cpp` (Path 2) and `PhonotacticsValidator.cpp` (Path 1)** — both encode the same Vietnamese phonotactic rules: (a) c/k/g/gh/ng/ngh onset agreement (T2 / PV:684-715), (b) per-nucleus allowed-coda restrictions (T3 N1/N2/N3 / PV:159-204 `kVCPairRules` bitmask). PV bitmask is granular per-nucleus and **stricter** than T3's coarse 3-group bucketing; the wstring_view layer's N-group is an approximation. Lift to shared rule tables (e.g. `VietnameseTables.h`) when a third validator wants the rule, and prefer the bitmask granularity in any unified table. Pre-existing; surfaced during T2/T3 reviews. | T2 + T3 simplify reuse agents | 1-2h | LOW (cleanup) |
+| ~~T2.1~~ | ~~**Vietnamese-rule consolidation sprint (Day-1 → Day-4)**~~ — D1 `IsFrontBaseVowel` lift to `VietnamesePhonologyData.h` (#150 `dd58f1e`); D2 `kVCPairRules` + packed-key encoding lift, retire T3 N-group machinery on Path 2 (#151 `b52e29d`); D3 `IPhonologyRules` plugin contract + `DefaultPhonologyRules` final impl + Phonotactics DI ctor (#152 `9d9b5a5`); D4 `PhonologyRulePackId` enum + `GetRulePack` factory hook for future rule packs. Path 1 hot path intentionally untouched (direct-call free functions kept for 0 ns delta). 5+ pre-existing engine dups (Decompose vs DecomposeVietChar, kVowelTable vs kClosed/Pending, kValidOnsets shape, etc.) noted but **not** in T2.1 scope — pickup-when-touching-feature. | T2 + T3 simplify reuse agents → anh philosophy 2026-05-08 (nhanh / gọn / nhẹ / mượt / plugin / không phân mảnh) | DONE | ✅ #150 + #151 + #152 + D4 PR pending |
 | ~~T3~~ | ~~**Phonotactics N1/N2/N3 vowel-coda compatibility**~~ | — | DONE | ✅ PR #149 `e908621` (rebased reopen of #148) |
 | ~~T4~~ | ~~**Verify Hot-path Fix 3 ComposeAll buffer reuse**~~ — VERIFIED 2026-05-07: shipped at `TypingEngine.h:218` (`mutable std::wstring composeBuf_`) + `TypingEngine.cpp:1236-1241` | hot-path-optimization-plan.md | DONE | ✅ |
 | ~~T5~~ | ~~**Bug `cafcs → các`**~~ | — | DONE | ✅ PR #146 `1ade8dc` |
-| T6 | **Bug Issue #117 `Lỗi → Lôĩ`** — fast-typing chaos timing. **Anh decision 2026-05-07 post-H1:** retest first before scheduling fix work — H1's hot-path restructure may have shifted timing enough that the race no longer reproduces. If reproducible post-H1, schedule deep work; if not, monitor + close as auto-resolved. | HANDOFF.md + Issue #117 | Hard — chaos timing | Bug (LOWER, retest gate) |
+| ~~T6~~ | ~~**Bug Issue #117 `Lỗi → Lôĩ`**~~ — anh confirmed retest 2026-05-08 sees no reproduction post-H1 hot-path restructure. Auto-resolved by H1 incidentally; close issue + monitor. | HANDOFF.md + Issue #117 | DONE | ✅ Auto-resolved by H1 |
 
 > **Note on T5/T6:** Bugs strictly speaking, not refactor. Listed here because they touch engine internals. Anh quyết định fix cùng Path G T-batch hay tách bug-fix branch riêng.
 

--- a/src/core/engine/PhonologyRulePackFactory.h
+++ b/src/core/engine/PhonologyRulePackFactory.h
@@ -1,0 +1,53 @@
+// NexusKey - Vietnamese Phonology Rule-Pack Factory
+// Copyright (c) 2024-2026 PhatMT. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-NexusKey-Commercial
+//
+// Factory + identifier enum for IPhonologyRules instances. Decouples callers
+// from concrete rule-pack types so new packs (dialectal, loanword-friendly,
+// strict-textbook, …) plug in by:
+//
+//   1. Implementing IPhonologyRules in a new header,
+//   2. Adding a value to PhonologyRulePackId,
+//   3. Adding a case to the switch in GetRulePack.
+//
+// Mirrors the IOutputInjector / WindowClassification → factory pattern used
+// in src/app/output/OutputInjectorFactory.{h,cpp} (Sprint 2 T3).
+//
+// Today only `Default` ships. Closes the T2.1 phonology consolidation sprint
+// by giving callers a single hook (`Phonology::GetRulePack(id)`) that future
+// features (spell-check overlay, strict/lenient toggle, dialect picker)
+// route through without forking validator code.
+
+#pragma once
+
+#include <cstdint>
+
+#include "DefaultPhonologyRules.h"
+#include "IPhonologyRules.h"
+
+namespace NextKey {
+namespace Phonology {
+
+enum class PhonologyRulePackId : uint8_t {
+    Default = 0,
+    // Reserved future values (kept commented to avoid YAGNI compile cost):
+    // StrictTextbook,
+    // LenientLoanword,
+    // SouthDialect,
+    // NorthDialect,
+    // CentralDialect,
+};
+
+// Returns the canonical rule-pack instance for the given id. Stateless and
+// thread-safe; the returned reference outlives the process. Unknown ids fall
+// back to Default — callers in the field never crash on stale ids.
+[[nodiscard]] inline const IPhonologyRules& GetRulePack(PhonologyRulePackId id) noexcept {
+    switch (id) {
+        case PhonologyRulePackId::Default:
+            return DefaultPhonologyRules::Default();
+    }
+    return DefaultPhonologyRules::Default();
+}
+
+}  // namespace Phonology
+}  // namespace NextKey

--- a/tests/PhonotacticsTest.cpp
+++ b/tests/PhonotacticsTest.cpp
@@ -8,6 +8,7 @@
 #include "core/engine/IPhonologyRules.h"
 #include "core/engine/IPhonotactics.h"
 #include "core/engine/DefaultPhonologyRules.h"
+#include "core/engine/PhonologyRulePackFactory.h"
 #include "core/engine/Phonotactics.h"
 #include "core/engine/TypingEngine.h"
 #include "core/config/TypingConfig.h"
@@ -573,6 +574,32 @@ TEST(PhonotacticsDI, DefaultCtorBindsDefaultRules) {
     EXPECT_FALSE(phon.IsValidSyllable(L"b", L"\x01A1", L"ng", Tone::None, true));   // ơ + ng forbidden
     EXPECT_TRUE (phon.IsValidSyllable(L"k", L"e",      L"",   Tone::None, true));   // k + e ok
     EXPECT_TRUE (phon.IsValidSyllable(L"b", L"a",      L"ng", Tone::None, true));   // a + ng ok
+}
+
+//=============================================================================
+// PhonologyRulePackId factory (T2.1 D4 — sprint close).
+// One factory hook for callers; future RulePackId values plug in via the
+// switch in PhonologyRulePackFactory.h without touching consumers.
+//=============================================================================
+
+TEST(PhonologyRulePackFactory, DefaultIdReturnsDefaultRules) {
+    const IPhonologyRules& fromFactory = GetRulePack(PhonologyRulePackId::Default);
+    const IPhonologyRules& direct      = DefaultPhonologyRules::Default();
+    EXPECT_EQ(&fromFactory, &direct);
+}
+
+TEST(PhonologyRulePackFactory, ReturnIsStableSingleton) {
+    const IPhonologyRules& a = GetRulePack(PhonologyRulePackId::Default);
+    const IPhonologyRules& b = GetRulePack(PhonologyRulePackId::Default);
+    EXPECT_EQ(&a, &b);
+}
+
+TEST(PhonologyRulePackFactory, FactoryUsableAsDIDependency) {
+    // Caller pattern: pull rule pack via factory, hand to Phonotactics ctor.
+    // Mirrors how IOutputInjector consumers construct from the factory result.
+    Phonotactics phon(GetRulePack(PhonologyRulePackId::Default));
+    EXPECT_TRUE (phon.IsValidSyllable(L"b", L"a", L"ng", Tone::None, true));   // a + ng ok
+    EXPECT_FALSE(phon.IsValidSyllable(L"k", L"a", L"",   Tone::None, true));   // k requires front
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

**Day-4 of T2.1 phonology consolidation sprint — the closing slice.** Adds the `PhonologyRulePackId` enum + inline `GetRulePack` factory in a new header (`PhonologyRulePackFactory.h`), refreshes `REFACTOR_STATUS.md` (T2.1 + T6 → DONE; sprint-rule note flipped to "backlog cleared"), and updates `HANDOFF.md` with the sprint summary + pivot decision for the next session.

## Honesty: user-visible benefit today = **zero**

T2.1 is architectural-debt payback. App identical pre-D1 → post-D4. No spell-check change, no typing speedup, no new feature. The plugin contract is now ready — but its value is unlocked only when the first feature consumer ships (spell-check overlay, dialect toggle, dictionary autocomplete). Documented in HANDOFF.md so the next session inherits the YAGNI risk explicitly.

## CODE_GOVERNANCE Q1-Q5

| Q | Answer |
|---|---|
| **Q1 Layer** | Engine layer — extends D3 plugin contract. ✓ |
| **Q2 Perf** | 0 ns delta. Factory called at construction time, not hot path. |
| **Q3 Native** | N/A. |
| **Q4 No-Lock** | inline noexcept switch; no mutex/alloc/exception. ✓ |
| **Q5 Trade-off** | **Gain**: explicit RulePackId surface; new packs plug in via switch case + new IPhonologyRules impl, no validator fork; closes T2.1 cleanly. **Give up**: small enum + factory; YAGNI risk acknowledged (enum slots reserved as comments rather than concrete values). |

## What's in scope

- New header `src/core/engine/PhonologyRulePackFactory.h` — `PhonologyRulePackId` enum + inline `GetRulePack` factory
- `tests/PhonotacticsTest.cpp` — 3 new factory tests
- `CMakeLists.txt` — header listed
- `docs/REFACTOR_STATUS.md` — T2.1 row marked DONE, T6 row flipped to DONE (auto-resolved by H1 per anh retest 2026-05-08), sequencing-rule header note refreshed
- `HANDOFF.md` — 2026-05-08 entry covering D1/D2/D3/D4 + pivot decision

## What's NOT in scope

- Path 1 hot-path migration to IPhonologyRules — intentionally kept on direct-call free functions for 0 ns delta. Future feature work decides whether to migrate.
- Concrete alternative rule packs (StrictTextbook / LenientLoanword / dialect variants) — reserved as enum-slot comments only; require a feature driver before implementing.
- 5+ pre-existing engine duplications (Decompose dup, kVowelTable vs kClosed/Pending, kValidOnsets shape) — pickup-when-touching-feature, no standalone sprint justified.

## Test plan

- [x] CMake reconfigure
- [x] Linux `NextKeyTests` 1555/1555 PASS (D3 baseline 1552 + 3 factory tests)
- [x] All 1540 pre-T2.1-baseline tests still green; net +15 across the sprint (D1 byte-identical, D2 -4 net via test reshape, D3 +5, D4 +3)
- [x] `nexuskey-review` checklist (naming / namespace / modern C++ / testing) — clean

## Sprint summary

| Day | PR | Merge SHA | Scope |
|---|---|---|---|
| D1 | #150 | `dd58f1e` | `IsFrontBaseVowel` lift to `VietnamesePhonologyData.h` |
| D2 | #151 | `b52e29d` | `kVCPairRules` + packed-key encoding lift; Path 2 retire T3 N-group |
| D3 | #152 | `9d9b5a5` | `IPhonologyRules` plugin contract + `DefaultPhonologyRules` + Phonotactics DI ctor |
| D4 | (this PR) | — | `PhonologyRulePackId` enum + `GetRulePack` factory + sprint close |