### PR TITLE
chore: post-v3 cleanup — dead code + unused includes

### DIFF
--- a/src/app/system/HookEngine.cpp
+++ b/src/app/system/HookEngine.cpp
@@ -2336,44 +2336,6 @@ static bool IsKnownElectronExe(const wchar_t* filename) noexcept {
     return found;
 }
 
-// ── Auto-detect Electron by app.asar marker (FUTURE USE) ──────────────
-// Uncomment to replace IsKnownElectronExe() with zero-maintenance detection.
-// Checks if resources/app.asar exists next to the exe — all Electron apps ship this.
-// Performance: GetFileAttributesW is metadata-only (~0.05ms SSD), cached per exe path.
-// Risk: network drives can timeout (30s). Guard with GetDriveTypeW before using.
-//
-// #include <unordered_map>
-//
-// static bool IsElectronByMarker(const wchar_t* exeFullPath) {
-//     // Cache: one check per unique exe path, forever (exe won't change at runtime)
-//     static std::unordered_map<std::wstring, bool> cache;
-//     auto it = cache.find(exeFullPath);
-//     if (it != cache.end()) return it->second;
-//
-//     // Guard: skip network/removable drives (GetFileAttributesW can timeout 30s)
-//     if (exeFullPath[0] == L'\\' && exeFullPath[1] == L'\\') {
-//         cache[exeFullPath] = true;  // UNC path — assume Electron (safe default)
-//         return true;
-//     }
-//     wchar_t drive[4] = { exeFullPath[0], L':', L'\\', L'\0' };
-//     UINT driveType = GetDriveTypeW(drive);
-//     if (driveType != DRIVE_FIXED && driveType != DRIVE_RAMDISK) {
-//         cache[exeFullPath] = true;  // Non-fixed drive — assume Electron
-//         return true;
-//     }
-//
-//     // Local fixed drive: safe to check file system
-//     const wchar_t* lastSlash = wcsrchr(exeFullPath, L'\\');
-//     if (!lastSlash) { cache[exeFullPath] = false; return false; }
-//     std::wstring dir(exeFullPath, lastSlash);
-//     std::wstring asarPath = dir + L"\\resources\\app.asar";
-//     bool isElectron = (GetFileAttributesW(asarPath.c_str()) != INVALID_FILE_ATTRIBUTES);
-//     cache[exeFullPath] = isElectron;
-//     return isElectron;
-// }
-// Usage in ClassifyWindow: replace IsKnownElectronExe(exeName.c_str()) with
-// IsElectronByMarker(exeFullPath) — requires GetExePathForHwnd() returning full path.
-
 bool HookEngine::IsTrayOrTaskbarWindow(HWND hwnd) noexcept {
     if (!hwnd) return false;
 

--- a/src/app/system/HookSelfHealer.cpp
+++ b/src/app/system/HookSelfHealer.cpp
@@ -7,6 +7,8 @@
 
 #include "core/Debug.h"
 
+#include <utility>  // std::move
+
 namespace NextKey {
 
 thread_local RawInputSelfHealer* RawInputSelfHealer::tlsActive_ = nullptr;

--- a/src/app/system/HookSelfHealer.h
+++ b/src/app/system/HookSelfHealer.h
@@ -19,7 +19,6 @@
 #endif
 
 #include <functional>
-#include <memory>
 
 namespace NextKey {
 

--- a/src/core/engine/PhonotacticsValidator.cpp
+++ b/src/core/engine/PhonotacticsValidator.cpp
@@ -24,10 +24,12 @@ namespace {
 // CharState-specific helpers (FinalConsonantBit template, kVowelTable, vowel
 // scanners) remain in this anonymous namespace.
 //
-// TODO(T2.1 D4): migrate this hot-path validator to consume rule data through
+// TODO: migrate this hot-path validator to consume rule data through
 // `IPhonologyRules` (see IPhonologyRules.h) so future RulePackId variants can
-// plug in without a parallel rewrite. D3 wired the contract on Path 2 only;
-// preserving Path 1's direct-call hot path until D4 lands the careful migration.
+// plug in without a parallel rewrite. T2.1 D3 wired the contract on Path 2;
+// Path 1's direct-call hot path was preserved at sprint close (D4 shipped
+// the RulePackId factory but did not migrate this validator). Revisit when a
+// dialectal rule pack is actually needed.
 
 //=============================================================================
 // Vowel nucleus table

--- a/src/watchdog/CMakeLists.txt
+++ b/src/watchdog/CMakeLists.txt
@@ -13,9 +13,8 @@ target_compile_definitions(NexusKeyWatchdog PRIVATE
     UNICODE _UNICODE
 )
 
-target_link_libraries(NexusKeyWatchdog PRIVATE
-    psapi.lib
-)
+# No external libs needed — uses only kernel32 (CreateProcessW, CreateMutexW, etc.)
+# and shell APIs (Process32FirstW from TlHelp32) auto-linked via Windows.h.
 
 if(MSVC)
     target_link_options(NexusKeyWatchdog PRIVATE /SUBSYSTEM:WINDOWS,6.01 /RELEASE)

--- a/src/watchdog/main.cpp
+++ b/src/watchdog/main.cpp
@@ -10,7 +10,6 @@
 // to keep AV happy and to be able to launch user-session UI.
 
 #include <Windows.h>
-#include <Psapi.h>
 #include <TlHelp32.h>
 #include <string>
 


### PR DESCRIPTION
## Summary

Post-v3 cleanup batch surfaced during a `src/` scan of files modified between `09735c3` and the v3 merge. Four small, isolated changes:

- **HookEngine.cpp** — drop 37-line commented-out `IsElectronByMarker` block (marked "FUTURE USE" but never implemented; `IsKnownElectronExe()` remains the active path).
- **Watchdog** — drop `#include <Psapi.h>` and `psapi.lib` link. Watchdog uses TlHelp32 (`Process32FirstW`), no Psapi symbols are referenced.
- **HookSelfHealer** — drop unused `<memory>` from the header (no `unique_ptr` / `shared_ptr` ever used). Add explicit `<utility>` to the .cpp where `std::move` is called rather than relying on transitive inclusion.
- **PhonotacticsValidator** — retire the stale `TODO(T2.1 D4)` label. T2.1 D4 closed without migrating Path 1 to `IPhonologyRules` (only the RulePackId factory landed). Reframe as a future-when-needed item gated on dialectal rule packs.

Net: −37 LOC.

## Test plan

- [x] Linux GTest: 1555 / 1555 PASS (no behaviour change — pure cleanup)
- [x] No symbol referenced by the deleted code
- [x] No header file inherits via the dropped `<memory>` include in a way that would break .cpp users (verified by build)