### PR TITLE
revert+docs: Outlook isOutlookApp_ passthrough gate + TODO Minor 1 close

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -185,8 +185,14 @@ Mechanical / low-risk items addressed in the post-T3 cleanup branch:
 
 These need investigation, design work, or 3-collaborator decisions and were intentionally NOT addressed in the mechanical batch:
 
-### Pre-T3 Minor 1 — `LowLevelMouseProc` race on `cachedFocusedHwnd_`
-Investigation needed: read the exact write set in the mouse callback, decide between (a) atomic migration, (b) defer to `MainThreadWorker`, or (c) document as benign. Detailed in the §"Review (2026-05-05)" section below.
+### ~~Pre-T3 Minor 1 — `LowLevelMouseProc` race on `cachedFocusedHwnd_`~~ — LANDED
+Resolved (Sprint 3 cleanup H3, commit `58d8f88`). `cachedFocusedHwnd_`
+migrated to `std::atomic<HWND>`; mouse path uses `.store(nullptr,
+memory_order_relaxed)` and key thread uses `.load(memory_order_relaxed)`
+per CODING_RULES 11.3 cache-invalidation pattern. The companion
+`cachedFocusedClass_` wstring tuple race is documented as benign in
+`HookEngine.h:474-479` — at worst a 1-keystroke filter miss that the
+next focus change recovers. No further action.
 
 ### ~~Pre-T3 Minor 2 — `QuickSyncFromSharedState` acquires `stateMutex_` on hook hot path (Rule #11.3 violation)~~ — LANDED
 Resolved via lock-free hot-path / locked slow-path split (double-checked
@@ -309,18 +315,15 @@ Because the type is gone, anyone who uncomments these lines triggers a
 - Update audit script Check 1 comment block to point back at the trap
   rationale so future readers don't try to "clean up" again.
 
-### 🟡 Minor 1 — `LowLevelMouseProc` writes `cachedFocusedHwnd_` and calls `ResetComposition` without lock
+### ~~🟡 Minor 1 — `LowLevelMouseProc` writes `cachedFocusedHwnd_` and calls `ResetComposition` without lock~~ — LANDED
 
-**Risk:** Race with `WinEventProc` (main thread) which reads/writes the same
-state. Manifests as transient composition desync after rapid mouse-click
-near a focus boundary.
-
-**Action:** Investigate exact write set in `LowLevelMouseProc`; either
-- Migrate `cachedFocusedHwnd_` to `std::atomic<HWND>`, or
-- Defer the writes via `MainThreadWorker` (Sprint 1 D8-D10 pattern), or
-- Document the race as benign (write-write to same value in practice).
-
-Pick one based on what the writes actually do.
+Resolved (Sprint 3 cleanup H3, commit `58d8f88`). `cachedFocusedHwnd_`
+migrated to `std::atomic<HWND>`. Mouse path uses `.store(nullptr,
+memory_order_relaxed)` to invalidate the cache; key thread uses
+`.load(memory_order_relaxed)` per CODING_RULES 11.3 cache-invalidation
+pattern. Companion `cachedFocusedClass_` wstring tuple race is
+documented as benign in `HookEngine.h:474-479` — at worst a
+1-keystroke filter miss that the next focus change recovers.
 
 ### ✅ ~~🟡 Minor 2 — `ProcessKeyDown` calls `QuickSyncFromSharedState()` which acquires `stateMutex_` on hook thread (Rule #11.2/11.3 violation)~~ — LANDED
 

--- a/src/app/system/HookEngine.cpp
+++ b/src/app/system/HookEngine.cpp
@@ -1647,9 +1647,6 @@ bool HookEngine::HandleAlphaKey(DWORD vkCode, bool shift, bool capsLock) {
     //   - synthEventsPending_ > 0: synthetic events still in flight — passing a physical
     //     key now can cause it to arrive before pending BSes/chars → ghost characters
     //     (observed in Chrome + Facebook Lexical editor).
-    //   - isOutlookApp_: Outlook 2016 RichEdit drops the last char of a word when
-    //     physical Shift+letter precedes subsequent chars (e.g. "Anh em" → "An hem").
-    //     SendInput VK_PACKET path avoids the quirk (issue #97).
     //
     // Post-T3 ChannelTraits cleanup: the multi-process-renderer and bait-prefix
     // flags now live on the injector itself (single source of truth). One
@@ -1659,7 +1656,6 @@ bool HookEngine::HandleAlphaKey(DWORD vkCode, bool shift, bool capsLock) {
     auto inj = injector_.load(std::memory_order_acquire);
     const bool electronApp = inj && inj->HasMultiProcessRenderer();
     const bool baitChar = inj && inj->NeedsBaitCharPrefix();
-    const bool outlookApp = isOutlookApp_.load(std::memory_order_acquire);
     const bool skipEmpty = skipEmptyChar_.load(std::memory_order_acquire);
     // Sprint 2 D4: editMsgPath via SettleBudget==0 proxy (RichEditEm only
     // returns 0ms today). Two reads (passthrough gate + reinjectVk gate)
@@ -1682,7 +1678,6 @@ bool HookEngine::HandleAlphaKey(DWORD vkCode, bool shift, bool capsLock) {
     //     guards the burst-input case.
     if (!autoCapped && currentCodeTable_ == CodeTable::Unicode &&
         !(hadSynthInWord_ && electronApp) &&
-        !outlookApp &&
         !editMsgPath &&
         synthEventsPending_ == 0 &&
         composition.size() == previousComposition_.size() + 1 &&
@@ -2713,7 +2708,6 @@ void HookEngine::OnFocusChanged(HWND triggerHwnd) {
     bool localNeedBait = isBrowser;
     bool localClipboard = isVB6;
     bool localEditMsg = false;
-    bool localOutlook = false;
 
     // Normal apps: check for GPU-rendered or apps needing bait (Excel, Outlook)
     bool isWebView2 = false;
@@ -2731,13 +2725,12 @@ void HookEngine::OnFocusChanged(HWND triggerHwnd) {
                 // transform instead of per BS + per char.
                 localEditMsg = true;
             } else {
-                // Outlook 2016 RichEdit has two orthogonal quirks, both derived from
-                // the same detection: (1) needs a U+202F bait char before BS (same
-                // as Excel), (2) drops the trailing char of a word when physical
-                // Shift+letter precedes other chars — passthrough must be disabled
-                // (issue #97). Single exe scan; both flags fall out.
+                // Outlook 2016 RichEdit needs a U+202F bait char before BS (same
+                // quirk as Excel). The "Anh em → An hem" passthrough flag was
+                // reverted — that symptom is Outlook AutoCorrect rewriting the
+                // text, not our IME path; user-confirmed by reproducing with the
+                // IME off (see docs/TODO.md "Outlook Anh em Fix").
                 const bool isOutlook = exeName.find(L"outlook") != std::wstring::npos;
-                localOutlook = isOutlook;
                 localNeedBait = exeName.find(L"excel") != std::wstring::npos || isOutlook;
 
                 // Tauri / WebView2-embedding apps (e.g. Dorion): detected by
@@ -2763,7 +2756,6 @@ void HookEngine::OnFocusChanged(HWND triggerHwnd) {
     // with their .load(acquire) in ProcessKeyDown).
     skipEmptyChar_.store(localSkipEmpty, std::memory_order_release);
     useClipboardPaste_.store(localClipboard, std::memory_order_release);
-    isOutlookApp_.store(localOutlook, std::memory_order_release);
 
     // Sprint 2 D3: build the IOutputInjector for this classification and
     // RCU-publish to injector_. All four branches now live: RichEdit

--- a/src/app/system/HookEngine.h
+++ b/src/app/system/HookEngine.h
@@ -350,7 +350,6 @@ private:
     std::unordered_set<std::wstring> webView2PositiveCache_;  // full exe path → known WebView2 host (positive-only; see IsWebView2App)
     std::atomic<bool> skipEmptyChar_{false};  // Skip U+202F for Qt/Electron and Console apps
     std::atomic<bool> useClipboardPaste_{false};  // VB6 and legacy ANSI-internal apps need clipboard paste
-    std::atomic<bool> isOutlookApp_{false};   // Outlook 2016 RichEdit drops trailing char of a word when physical Shift+letter precedes it — force SendInput path (issue #97)
     DWORD lastForegroundPid_ = 0;  // PID of last known foreground (updated by OnFocusChanged + timer)
     std::unordered_map<std::wstring, bool> appModeMap_;  // exe name → vietnamese mode
     bool appModeDirty_ = false;  // True when appModeMap_ changed since last TOML save


### PR DESCRIPTION
## Summary

Two small follow-ups from the post-v3 TODO review:

**revert(hook): drop `isOutlookApp_` passthrough gate.** User-confirmed reproduction with the IME off shows 'Anh em' → 'An hem' is Outlook 2016's own AutoCorrect — not the IME. The flag forced the SendInput VK_PACKET path on every Outlook keystroke for a problem we never caused. Reverts the field, the passthrough gate read, and the publish in `ClassifyWindow`. Keeps `needBaitChar_` for Outlook (BS U+202F quirk is real and orthogonal) and the `TryEditMessagePaste` redraw hardening from `e1dab42`.

**docs(todo): mark Pre-T3 Minor 1 as landed.** `cachedFocusedHwnd_` has been `std::atomic<HWND>` since Sprint 3 cleanup H3 (`58d8f88`). The companion `cachedFocusedClass_` wstring tuple race is documented as benign in `HookEngine.h:474-479`. Updated both 'Items deferred' and 'Review (2026-05-05)' references.

## Test plan

- [x] Linux GTest: 1555 / 1555 PASS
- [x] No remaining `isOutlookApp_` references in src/
- [x] No code change for Minor 1 — only docs alignment with already-landed work