### PR TITLE
chore: batch 1 — multi-monitor centering, TSF_LOG atomic, TrackedSendInput consolidation

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -202,8 +202,12 @@ fix landed" entry at top of file.
 ### M2 — Constants naming convention (`kFoo` vs `UPPER_SNAKE`)
 Codebase-wide pattern uses `kFoo` for file-scope `static constexpr`; Rule 9.1 prescribes `UPPER_SNAKE`. Need 3-collaborator decision: update Rule 9.1 to formalize the k-prefix convention, or rename ~10 codebase constants. Recommendation: update the rule.
 
-### M3 — Dual-route `TrackedSendInput` (HookEngine member + `Internal::` free function)
-Both bump `synthEventsPending_` via different mechanisms; no double-counting today but the dual presence is confusing for future readers. Suggested fix: route the 4 VB6/clipboard sites + reinjectVk through `Internal::TrackedSendInput`, then delete `HookEngine::TrackedSendInput` member. ~5 call sites, non-trivial.
+### ~~M3 — Dual-route `TrackedSendInput` (HookEngine member + `Internal::` free function)~~ — LANDED
+Resolved post-v3 cleanup. `HookEngine::TrackedSendInput` deleted; the
+6 in-tree callers (SendBackspaceEvents, SendCharEvents, 3× clipboard
+paste, reinjectVk) now go through `Output::Internal::TrackedSendInput`
+directly. Synth-counter wiring stays via the
+`g_synthCounterCallback` → `OnSynthDispatched` bridge.
 
 ### ~~ChannelTraits + `isElectronApp_` / `needBaitChar_` deletion~~ — LANDED
 Resolved via two virtual trait methods (`HasMultiProcessRenderer()` /
@@ -887,8 +891,8 @@ Full-source review covering engine, config/IPC, TSF, HookEngine, dialogs, Classi
 - [x] `SettingsDialog.cpp:38` — `#define TIMER_RESIZE_WINDOW` should be `static constexpr UINT_PTR` (inconsistent with `TIMER_DEFERRED_SAVE`)
 - [x] `ClassicSettingsDialog.h:118` — Add `static_assert(kSettingsCount <= kMaxControls)` to catch overflow at compile time
 - [x] `ClassicTheme.cpp:19-25` — Duplicate `IsWindows11OrGreater()` — already in `DarkModeHelper.h` which is included
-- [ ] Multi-monitor: 7 Classic dialogs + SettingsDialog + SciterSubDialog use `SM_CXSCREEN` — ignores multi-monitor. Use `MonitorFromWindow` + `GetMonitorInfo` for proper centering. Low priority — works on primary monitor.
-- [ ] `TSF_LOG` (Define.h:14-25) outputs 3 separate `OutputDebugStringW` calls per log line — non-atomic, threads can interleave. Concat into single buffer.
+- [x] ~~Multi-monitor: 7 Classic dialogs + SettingsDialog + SciterSubDialog use `SM_CXSCREEN`~~ — LANDED. `NextKey::GetCenteredPos(referenceHwnd, w, h)` helper in `helpers/AppHelpers.h` uses `MonitorFromWindow` + `GetMonitorInfoW` (rcWork) so dialogs honor the user's monitor + work area. All 9 sites migrated.
+- [x] ~~`TSF_LOG` (Define.h:14-25) outputs 3 separate `OutputDebugStringW` calls per log line~~ — LANDED. Concatenated into a single 640-wchar buffer + one `OutputDebugStringW` call. Truncation handling preserved.
 
 ---
 

--- a/src/app/classic/ClassicAppOverridesDialog.cpp
+++ b/src/app/classic/ClassicAppOverridesDialog.cpp
@@ -65,8 +65,8 @@ bool ClassicAppOverridesDialog::Init(HINSTANCE hInstance, HWND parent, bool forc
     RECT rc = {0, 0, w, h};
     AdjustWindowRectEx(&rc, style, FALSE, WS_EX_TOPMOST);
     int aw = rc.right - rc.left, ah = rc.bottom - rc.top;
-    int sx = GetSystemMetrics(SM_CXSCREEN), sy = GetSystemMetrics(SM_CYSCREEN);
-    SetWindowPos(hwnd_, nullptr, (sx - aw) / 2, (sy - ah) / 2, aw, ah, SWP_NOZORDER);
+    POINT pt = NextKey::GetCenteredPos(hwnd_, aw, ah);
+    SetWindowPos(hwnd_, nullptr, pt.x, pt.y, aw, ah, SWP_NOZORDER);
 
     theme_.Init(hwnd_, forceLightTheme);
     theme_.ApplyWindowAttributes(hwnd_);

--- a/src/app/classic/ClassicConvertToolDialog.cpp
+++ b/src/app/classic/ClassicConvertToolDialog.cpp
@@ -83,8 +83,8 @@ bool ClassicConvertToolDialog::Init(HINSTANCE hInstance, HWND parent, bool force
     RECT rc = {0, 0, w, h};
     AdjustWindowRectEx(&rc, style, FALSE, WS_EX_TOPMOST);
     int aw = rc.right - rc.left, ah = rc.bottom - rc.top;
-    int sx = GetSystemMetrics(SM_CXSCREEN), sy = GetSystemMetrics(SM_CYSCREEN);
-    SetWindowPos(hwnd_, nullptr, (sx - aw) / 2, (sy - ah) / 2, aw, ah, SWP_NOZORDER);
+    POINT pt = NextKey::GetCenteredPos(hwnd_, aw, ah);
+    SetWindowPos(hwnd_, nullptr, pt.x, pt.y, aw, ah, SWP_NOZORDER);
 
     theme_.Init(hwnd_, forceLightTheme);
     theme_.ApplyWindowAttributes(hwnd_);

--- a/src/app/classic/ClassicExcludedAppsDialog.cpp
+++ b/src/app/classic/ClassicExcludedAppsDialog.cpp
@@ -77,8 +77,8 @@ bool ClassicExcludedAppsDialog::Init(HINSTANCE hInstance, HWND parent, bool forc
     RECT rc = {0, 0, w, h};
     AdjustWindowRectEx(&rc, style, FALSE, WS_EX_TOPMOST);
     int aw = rc.right - rc.left, ah = rc.bottom - rc.top;
-    int sx = GetSystemMetrics(SM_CXSCREEN), sy = GetSystemMetrics(SM_CYSCREEN);
-    SetWindowPos(hwnd_, nullptr, (sx - aw) / 2, (sy - ah) / 2, aw, ah, SWP_NOZORDER);
+    POINT pt = NextKey::GetCenteredPos(hwnd_, aw, ah);
+    SetWindowPos(hwnd_, nullptr, pt.x, pt.y, aw, ah, SWP_NOZORDER);
 
     theme_.Init(hwnd_, forceLightTheme);
     theme_.ApplyWindowAttributes(hwnd_);

--- a/src/app/classic/ClassicIconColorDialog.cpp
+++ b/src/app/classic/ClassicIconColorDialog.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "ClassicIconColorDialog.h"
+#include "helpers/AppHelpers.h"
 #include "core/CrashLog.h"
 #include <commdlg.h>
 #include <exception>
@@ -68,8 +69,8 @@ bool ClassicIconColorDialog::Init(HINSTANCE hInstance, HWND parent,
     RECT rc = {0, 0, w, h};
     AdjustWindowRectEx(&rc, style, FALSE, WS_EX_TOPMOST);
     int aw = rc.right - rc.left, ah = rc.bottom - rc.top;
-    int sx = GetSystemMetrics(SM_CXSCREEN), sy = GetSystemMetrics(SM_CYSCREEN);
-    SetWindowPos(hwnd_, nullptr, (sx - aw) / 2, (sy - ah) / 2, aw, ah, SWP_NOZORDER);
+    POINT pt = NextKey::GetCenteredPos(hwnd_, aw, ah);
+    SetWindowPos(hwnd_, nullptr, pt.x, pt.y, aw, ah, SWP_NOZORDER);
 
     theme_.Init(hwnd_, forceLightTheme);
     theme_.ApplyWindowAttributes(hwnd_);

--- a/src/app/classic/ClassicMacroTableDialog.cpp
+++ b/src/app/classic/ClassicMacroTableDialog.cpp
@@ -77,8 +77,8 @@ bool ClassicMacroTableDialog::Init(HINSTANCE hInstance, HWND parent, bool forceL
     RECT rc = {0, 0, w, h};
     AdjustWindowRectEx(&rc, style, FALSE, WS_EX_TOPMOST);
     int aw = rc.right - rc.left, ah = rc.bottom - rc.top;
-    int sx = GetSystemMetrics(SM_CXSCREEN), sy = GetSystemMetrics(SM_CYSCREEN);
-    SetWindowPos(hwnd_, nullptr, (sx - aw) / 2, (sy - ah) / 2, aw, ah, SWP_NOZORDER);
+    POINT pt = NextKey::GetCenteredPos(hwnd_, aw, ah);
+    SetWindowPos(hwnd_, nullptr, pt.x, pt.y, aw, ah, SWP_NOZORDER);
 
     theme_.Init(hwnd_, forceLightTheme);
     theme_.ApplyWindowAttributes(hwnd_);

--- a/src/app/classic/ClassicSettingsDialog.cpp
+++ b/src/app/classic/ClassicSettingsDialog.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "ClassicSettingsDialog.h"
+#include "helpers/AppHelpers.h"
 #include "ClassicExcludedAppsDialog.h"
 #include "ClassicSpellExclusionsDialog.h"
 #include "ClassicAppOverridesDialog.h"
@@ -55,8 +56,6 @@ bool ClassicSettingsDialog::Show(HINSTANCE hInstance, HWND parent) {
     LoadSettings();
 
     DWORD style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX;
-    int screenW = GetSystemMetrics(SM_CXSCREEN);
-    int screenH = GetSystemMetrics(SM_CYSCREEN);
 
     hwnd_ = CreateWindowExW(
         0,
@@ -80,9 +79,8 @@ bool ClassicSettingsDialog::Show(HINSTANCE hInstance, HWND parent) {
     AdjustWindowRect(&rc, style, FALSE);
     int adjWidth  = rc.right - rc.left;
     int adjHeight = rc.bottom - rc.top;
-    int x = (screenW - adjWidth) / 2;
-    int y = (screenH - adjHeight) / 2;
-    SetWindowPos(hwnd_, nullptr, x, y, adjWidth, adjHeight, SWP_NOZORDER | SWP_NOACTIVATE);
+    POINT pt = NextKey::GetCenteredPos(hwnd_, adjWidth, adjHeight);
+    SetWindowPos(hwnd_, nullptr, pt.x, pt.y, adjWidth, adjHeight, SWP_NOZORDER | SWP_NOACTIVATE);
 
     theme_.Init(hwnd_, systemConfig_.forceLightTheme);
     theme_.ApplyWindowAttributes(hwnd_);

--- a/src/app/classic/ClassicSpellExclusionsDialog.cpp
+++ b/src/app/classic/ClassicSpellExclusionsDialog.cpp
@@ -74,8 +74,8 @@ bool ClassicSpellExclusionsDialog::Init(HINSTANCE hInstance, HWND parent, bool f
     RECT rc = {0, 0, w, h};
     AdjustWindowRectEx(&rc, style, FALSE, WS_EX_TOPMOST);
     int aw = rc.right - rc.left, ah = rc.bottom - rc.top;
-    int sx = GetSystemMetrics(SM_CXSCREEN), sy = GetSystemMetrics(SM_CYSCREEN);
-    SetWindowPos(hwnd_, nullptr, (sx - aw) / 2, (sy - ah) / 2, aw, ah, SWP_NOZORDER);
+    POINT pt = NextKey::GetCenteredPos(hwnd_, aw, ah);
+    SetWindowPos(hwnd_, nullptr, pt.x, pt.y, aw, ah, SWP_NOZORDER);
 
     theme_.Init(hwnd_, forceLightTheme);
     theme_.ApplyWindowAttributes(hwnd_);

--- a/src/app/dialogs/SciterSubDialog.cpp
+++ b/src/app/dialogs/SciterSubDialog.cpp
@@ -3,6 +3,7 @@
 
 #include "SciterSubDialog.h"
 #include "../resource.h"
+#include "helpers/AppHelpers.h"
 #include "sciter/ScaleHelper.h"
 #include "sciter/SciterHelper.h"
 #include "system/DarkModeHelper.h"
@@ -157,10 +158,10 @@ SciterSubDialog::SciterSubDialog(const SubDialogConfig& config)
         // which the computed center point alone wouldn't capture.
         monitor = MonitorFromWindow(config_.parentHwnd, MONITOR_DEFAULTTONEAREST);
     } else {
-        int screenWidth = GetSystemMetrics(SM_CXSCREEN);
-        int screenHeight = GetSystemMetrics(SM_CYSCREEN);
-        posX = (screenWidth - winWidth) / 2;
-        posY = (screenHeight - winHeight) / 2;
+        // No parent — center on primary monitor's work area (honors taskbar).
+        POINT pt = NextKey::GetCenteredPos(nullptr, winWidth, winHeight);
+        posX = pt.x;
+        posY = pt.y;
         POINT center{posX + winWidth / 2, posY + winHeight / 2};
         monitor = MonitorFromPoint(center, MONITOR_DEFAULTTONEAREST);
     }

--- a/src/app/dialogs/SettingsDialog.cpp
+++ b/src/app/dialogs/SettingsDialog.cpp
@@ -3,6 +3,7 @@
 
 #include "SettingsDialog.h"
 #include "../resource.h"
+#include "helpers/AppHelpers.h"
 #include "system/StartupHelper.h"
 #include "system/SubprocessHelper.h"
 #include "system/TsfRegistration.h"
@@ -154,13 +155,10 @@ SettingsDialog::SettingsDialog()
     // 13. Finally, move the initialized, rendered, and themed window onscreen
     RECT rc;
     GetWindowRect(get_hwnd(), &rc);
-    int screenWidth = GetSystemMetrics(SM_CXSCREEN);
-    int screenHeight = GetSystemMetrics(SM_CYSCREEN);
     int winWidth = rc.right - rc.left;
     int winHeight = rc.bottom - rc.top;
-    int x = (screenWidth - winWidth) / 2;
-    int y = (screenHeight - winHeight) / 2;
-    SetWindowPos(get_hwnd(), HWND_NOTOPMOST, x, y, 0, 0, SWP_NOSIZE | SWP_SHOWWINDOW);
+    POINT pt = NextKey::GetCenteredPos(get_hwnd(), winWidth, winHeight);
+    SetWindowPos(get_hwnd(), HWND_NOTOPMOST, pt.x, pt.y, 0, 0, SWP_NOSIZE | SWP_SHOWWINDOW);
 
     // Force taskbar presence while DWM transitions are still disabled (avoids flicker)
     SciterHelper::ForceTaskbarPresence(get_hwnd(), IDI_APP);

--- a/src/app/helpers/AppHelpers.h
+++ b/src/app/helpers/AppHelpers.h
@@ -91,6 +91,27 @@ inline std::wstring ToLowerAscii(std::wstring str) noexcept {
     HWND focused = GetFocusedChildHwnd(foreground);
     return focused ? focused : foreground;
 }
+
+/// Multi-monitor-aware top-left for centering a window of given size on the
+/// monitor that contains `referenceHwnd`. Falls back to the primary monitor
+/// when the reference HWND is null/invalid. Honors taskbar / docked panels
+/// by using `rcWork` instead of `rcMonitor`. Replaces the old
+/// `GetSystemMetrics(SM_CXSCREEN/SM_CYSCREEN)` pattern, which always
+/// centers on the primary screen and ignores the work area.
+[[nodiscard]] inline POINT GetCenteredPos(HWND referenceHwnd, int width, int height) noexcept {
+    HMONITOR mon = MonitorFromWindow(referenceHwnd ? referenceHwnd : GetDesktopWindow(),
+                                     MONITOR_DEFAULTTOPRIMARY);
+    MONITORINFO mi = { sizeof(mi) };
+    if (!GetMonitorInfoW(mon, &mi)) {
+        // Last-resort: primary screen metrics, ignore work area.
+        return { (GetSystemMetrics(SM_CXSCREEN) - width) / 2,
+                 (GetSystemMetrics(SM_CYSCREEN) - height) / 2 };
+    }
+    const int sx = mi.rcWork.right - mi.rcWork.left;
+    const int sy = mi.rcWork.bottom - mi.rcWork.top;
+    return { mi.rcWork.left + (sx - width) / 2,
+             mi.rcWork.top + (sy - height) / 2 };
+}
 #endif
 
 }  // namespace NextKey

--- a/src/app/system/HookEngine.cpp
+++ b/src/app/system/HookEngine.cpp
@@ -1960,20 +1960,6 @@ bool HookEngine::IsSyncReplaceChannel() const noexcept {
     return inj && inj->SettleBudget().count() == 0;
 }
 
-/// Send INPUT events via SendInput with correct synthEventsPending_ tracking.
-/// Counter is pre-incremented BEFORE SendInput so the hook callback (which fires
-/// synchronously during SendInput) can decrement it correctly.  Without this,
-/// the counter inflates permanently — see commit message for full explanation.
-/// Caller must set sending_=true before and false after (or wrap multiple calls).
-void HookEngine::TrackedSendInput(INPUT* events, UINT count) noexcept {
-    synthEventsPending_ += static_cast<int>(count);
-    UINT sent = SendInput(count, events, sizeof(INPUT));
-    if (sent < count) {
-        synthEventsPending_ -= static_cast<int>(count - sent);
-        HOOK_LOG(L"  TrackedSendInput: PARTIAL sent=%u of %u (renderer drop?)", sent, count);
-    }
-}
-
 void HookEngine::SendBackspaceEvents(size_t count) {
     WORD bsScan = static_cast<WORD>(MapVirtualKeyW(VK_BACK, MAPVK_VK_TO_VSC));
     std::vector<INPUT> events;
@@ -1982,7 +1968,7 @@ void HookEngine::SendBackspaceEvents(size_t count) {
         AppendVkEvent(events, VK_BACK, bsScan);
     }
     sending_ = true;
-    TrackedSendInput(events.data(), static_cast<UINT>(events.size()));
+    (void)Output::Internal::TrackedSendInput(events.data(), static_cast<UINT>(events.size()));
     sending_ = false;
     RecordSynthDispatch();
 }
@@ -1994,7 +1980,7 @@ void HookEngine::SendCharEvents(const std::wstring& text) {
         AppendUnicodeEvent(events, ch);
     }
     sending_ = true;
-    TrackedSendInput(events.data(), static_cast<UINT>(events.size()));
+    (void)Output::Internal::TrackedSendInput(events.data(), static_cast<UINT>(events.size()));
     sending_ = false;
     RecordSynthDispatch();
 }
@@ -2094,11 +2080,11 @@ void HookEngine::ClipboardPaste(const std::wstring& text) {
 
     sending_ = true;
     if (!preEvents.empty()) {
-        TrackedSendInput(preEvents.data(), static_cast<UINT>(preEvents.size()));
+        (void)Output::Internal::TrackedSendInput(preEvents.data(), static_cast<UINT>(preEvents.size()));
     }
-    TrackedSendInput(inputs, 4);
+    (void)Output::Internal::TrackedSendInput(inputs, 4);
     if (!postEvents.empty()) {
-        TrackedSendInput(postEvents.data(), static_cast<UINT>(postEvents.size()));
+        (void)Output::Internal::TrackedSendInput(postEvents.data(), static_cast<UINT>(postEvents.size()));
     }
     sending_ = false;
     RecordSynthDispatch();
@@ -3169,7 +3155,7 @@ void HookEngine::ReplaceComposition(const std::wstring& newText, DWORD reinjectV
                 evt.ki.wVk = static_cast<WORD>(reinjectVk);
                 evt.ki.wScan = static_cast<WORD>(MapVirtualKeyW(reinjectVk, MAPVK_VK_TO_VSC));
                 evt.ki.dwExtraInfo = NEXUSKEY_EXTRA_INFO;
-                TrackedSendInput(&evt, 1);
+                (void)Output::Internal::TrackedSendInput(&evt, 1);
             }
 
             if (backspaceCount > 0 || !toSend.empty()) {

--- a/src/app/system/HookEngine.h
+++ b/src/app/system/HookEngine.h
@@ -177,9 +177,10 @@ private:
 
     // Output — universal SendInput with KEYEVENTF_UNICODE
     void ReplaceComposition(const std::wstring& newText, DWORD reinjectVk = 0);
-    void TrackedSendInput(INPUT* events, UINT count) noexcept;
     // Sprint 2 D3 removed DispatchSendInput callers; D4 deleted body+decl.
-    // Split-vs-batch lives inside the IOutputInjector impls now.
+    // Split-vs-batch lives inside the IOutputInjector impls now. Synth dispatch
+    // goes through Output::Internal::TrackedSendInput, which routes the
+    // synth-counter via g_synthCounterCallback → OnSynthDispatched.
     void SendBackspaces(size_t count);
     void SendBackspaceEvents(size_t count);
     void SendCharEvents(const std::wstring& text);

--- a/src/tsf/Define.h
+++ b/src/tsf/Define.h
@@ -8,20 +8,30 @@
 #define NEXUSKEY_TSF_VERSION_MINOR 0
 #define NEXUSKEY_TSF_VERSION_PATCH 0
 
-// Debug logging macro with format support
+// Debug logging macro with format support.
+//
+// Single OutputDebugStringW call per log line — concatenating prefix + body +
+// newline into one local buffer first. Three separate OutputDebugStringW calls
+// could interleave under concurrent TSF DLL writers in different processes.
 #ifdef _DEBUG
 #include <cstdio>
 inline void TsfLogImpl(const wchar_t* fmt, ...) {
-    wchar_t prefix[64];
-    _snwprintf_s(prefix, 64, _TRUNCATE, L"[NexusKey:%u] ", GetCurrentProcessId());
-    wchar_t buf[512];
+    wchar_t buf[640];
+    int prefixLen = _snwprintf_s(buf, 640, _TRUNCATE, L"[NexusKey:%u] ",
+                                 GetCurrentProcessId());
+    if (prefixLen < 0) prefixLen = 0;  // _TRUNCATE return: -1 on truncation
     va_list args;
     va_start(args, fmt);
-    _vsnwprintf_s(buf, 512, _TRUNCATE, fmt, args);
+    int bodyLen = _vsnwprintf_s(buf + prefixLen, 640 - prefixLen, _TRUNCATE,
+                                 fmt, args);
     va_end(args);
-    OutputDebugStringW(prefix);
+    if (bodyLen < 0) bodyLen = 640 - prefixLen - 2;  // truncated — fill to room for \n
+    int totalLen = prefixLen + bodyLen;
+    if (totalLen < 639) {
+        buf[totalLen]     = L'\n';
+        buf[totalLen + 1] = L'\0';
+    }
     OutputDebugStringW(buf);
-    OutputDebugStringW(L"\n");
 }
 #define TSF_LOG(...) TsfLogImpl(__VA_ARGS__)
 #else


### PR DESCRIPTION
## Summary

Batch 1 of the post-v3 tech-debt cleanup. Three independent items shipped together because they're each small and touch unrelated subsystems.

**1. Multi-monitor-aware dialog centering** (`refactor(dialogs)`).
`GetSystemMetrics(SM_CXSCREEN/SM_CYSCREEN)` always pins dialogs to the primary monitor and ignores the work area (taskbar / docked panels). Add `NextKey::GetCenteredPos(referenceHwnd, w, h)` to `helpers/AppHelpers.h` — uses `MonitorFromWindow` + `GetMonitorInfoW` against `rcWork`. Migrated 9 dialogs (Sciter SettingsDialog/SciterSubDialog + 7 Classic).

**2. TSF_LOG atomic single call** (`refactor(tsf)`).
`TsfLogImpl` issued three `OutputDebugStringW` calls (prefix / body / newline). Concurrent TSF DLLs across hosts could interleave. Concatenate into a 640-wchar local buffer and emit once. Truncation behavior preserved (newline only appended when there's room).

**3. TrackedSendInput consolidation** (`refactor(hook)`).
HookEngine had a member `TrackedSendInput` that pre-incremented `synthEventsPending_` and called `SendInput` directly, parallel to `Output::Internal::TrackedSendInput` which goes through the `g_synthCounterCallback` bridge wired in `Start()`. Two paths to the same counter — confusing for future readers. Delete the member; route all 6 callers (SendBackspaceEvents, SendCharEvents, 3× clipboard paste, 1× reinjectVk) through `Output::Internal::TrackedSendInput`. Counter wiring stays via `OnSynthDispatched`.

## Test plan

- [x] Linux GTest: 1555 / 1555 PASS after each commit
- [x] No remaining `SM_CXSCREEN` outside the helper's last-resort fallback
- [x] No remaining `HookEngine::TrackedSendInput` references
- [x] Strings table assert (`_COUNT == array size`) still holds