### PR TITLE
refactor(tsf): extract ShouldAutoCap + unify with IPC anchor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,6 +451,7 @@ set(NEXTKEY_TEST_SOURCES
     tests/HookEngineAtomicTests.cpp
     tests/TypingConfigRCUTests.cpp
     tests/MainThreadWorkerTests.cpp
+    tests/AutoCapDecisionTest.cpp
     src/app/system/UpdateSecurity.cpp
     src/app/system/MainThreadWorker.cpp
 )

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -430,19 +430,17 @@ multi-word macro keys via phrase-prefix buffer preservation. Rules doc:
 
 ### Tech debt surfaced
 
-- [ ] **Extract `ApplyAutoCapsMacro` to pure function** — `src/app/system/HookEngine.cpp:2778-2826`
-  Auto-caps transform (expansionAllLower check, allUpper/firstUpper detection,
-  `CharUpperBuffW` loop) is inline in `TryExpandMacro` and therefore untestable
-  from Linux. Mirror of `src/core/MacroPrefix.h`: extract to `src/core/MacroCase.h`
-  with a Linux stub for `CharUpperBuffW` (or inject the case-fold fn) and add
-  gtest covering the four-quadrant matrix (stored-case × typed-case) flagged in
-  party-mode review.
+- [x] ~~**Extract `ApplyAutoCapsMacro` to pure function**~~ — LANDED via
+  `core/MacroCase.{h,cpp}::Plan()` with a `CaseMapper` DI seam (production wraps
+  `CharUpperBuffW`/`CharLowerBuffW`, tests use ASCII mappers). Auto-cap transform
+  (expansionAllLower / allUpper / firstUpper) lives in `Plan()`. Coverage:
+  `tests/MacroCaseTest.cpp` (459 lines).
 
-- [ ] **Zero unit tests on `TryExpandMacro` match logic** — `src/app/system/HookEngine.cpp:2699-2747`
-  Two-step find (`find(rawBuffer)` → `find(lowerKey)`), `matchedExact` flag, and
-  P1/P2/P3/P4 priority ordering have no coverage. Extract the matching contract
-  into a pure `ResolveMacroMatch(buffer, previousComp, trigger, table) ->
-  {iterator, matchedExact, matchedViaComposition}` and table-test it on Linux.
+- [x] ~~**Zero unit tests on `TryExpandMacro` match logic**~~ — LANDED.
+  `Macro::Plan()` in `core/MacroCase.cpp` now owns the priority-ordered match
+  (P1 raw exact → P2 lowered → P3/P4 composition). `TryExpandMacro` in
+  HookEngine becomes a thin caller. `tests/MacroCaseTest.cpp` covers the
+  matching contract on Linux.
 
 - [ ] **Composition-path (P3/P4) auto-caps asymmetry** — `src/app/system/HookEngine.cpp:2732-2745, 2786`
   Auto-caps explicitly gated on `!matchedViaComposition` — typing `CHOOL` via
@@ -452,12 +450,15 @@ multi-word macro keys via phrase-prefix buffer preservation. Rules doc:
   in `docs/macro-case-rules.md`, or mirror the auto-caps logic on composition
   matches too.
 
-- [ ] **`\n` escape handling in auto-caps loop is incomplete** — `src/app/system/HookEngine.cpp:2806-2813`
-  Loop skips the 2-char `\n` escape when uppercasing. Does not handle `\t`,
-  `\\`, or any other escape. Verify what `LoadMacros` actually does with
-  escapes at load:
-    - if decoded at load → the `\n` skip is dead code; remove it.
-    - if passed through verbatim → `\t` under auto-upper corrupts to `\T`.
+- [x] ~~**`\n` escape handling in auto-caps loop is incomplete**~~ — AUDITED 2026-05-08.
+  `ConfigManager::LoadMacros` passes values verbatim from TOML — no escape
+  decoding at load. Only `\n` is treated as an escape downstream
+  (`MacroCase.cpp::ExpandEscapesForClipboard` and `BuildSegments`). `\t`,
+  `\\`, etc. are NEVER expanded — they pass through as literal characters.
+  So the auto-caps loop's `\n` skip is correct (preserves the only special
+  escape), and `\t` "corruption to `\T`" is a non-issue because `\t` was
+  never a tab to begin with. No code action needed; this is a feature gap
+  (escape support beyond `\n` was never wired), not a bug.
 
 - [ ] **`VkToMacroChar` syscalls per commit trigger** — `src/app/system/HookEngine.cpp:2851-2888`
   Calls `GetAsyncKeyState ×3`, `GetKeyState`, `MapVirtualKeyW ×2`,
@@ -611,13 +612,12 @@ User feedback batch (v2.1.19 Hybrid-TSF testing). Fixed items landed in commits
   const wchar_t* IMPORT = L"import"; ... }` in a shared header so typos become
   compile errors. Pairs with the helper extraction above.
 
-- [ ] **Extract `ShouldAutoCap` logic to pure function** — `src/tsf/CompositionEditSession.h:312`
-  Auto-cap decision (skip whitespace + check punct/newline + `skippedWhitespace`
-  gate) is currently inside `InspectPrecedingTextEditSession::DoEditSession`
-  which needs TSF APIs → untestable on Linux. Extract to free
-  `bool ComputeShouldAutoCap(const wchar_t* buf, size_t len) noexcept` and
-  call from the edit session. Lets Linux tests cover the 3rd auto-cap site
-  (currently only the Hook-anchor `DeriveAnchorFromPreceding` has tests).
+- [x] ~~**Extract `ShouldAutoCap` logic to pure function**~~ — LANDED 2026-05-08.
+  `core/AutoCapDecision.h::ComputeShouldAutoCap(buf, len)` extracted from
+  `InspectPrecedingTextEditSession::DoEditSession`. 8 new tests in
+  `tests/AutoCapDecisionTest.cpp` cover empty/whitespace/newline/sentence
+  punct + space/.com domain/mid-word/non-sentence punct/newline-wins/Vietnamese.
+  Linux GTest 1555 → 1563 PASS.
 
 ---
 

--- a/docs/plans/2026-05-08-cleanup-handoff.md
+++ b/docs/plans/2026-05-08-cleanup-handoff.md
@@ -1,0 +1,105 @@
+# Post-v3 Cleanup Handoff — 2026-05-08
+
+Quick handoff for whoever picks up after this session. Token budget hit; stopping clean.
+
+## What landed (5 PRs merged on Main)
+
+| PR | Branch | What |
+|---|---|---|
+| #154 | `feature/v3-hook-self-healer-watchdog` | v3.0.0 — Hook self-healer + watchdog (opt-in default OFF, tray toggle, single-instance mutex). Smoke 1/2/3 PASS. |
+| #155 | `chore/cleanup-post-v3` | Drop dead `IsElectronByMarker` block (37 LOC), unused `Psapi.h`/`psapi.lib` in watchdog, unused `<memory>` in HookSelfHealer, retire stale `T2.1 D4` TODO label. |
+| #156 | `chore/outlook-anh-em-revert-and-mouse-race` | Revert `isOutlookApp_` passthrough gate (Outlook AutoCorrect, not us — user-confirmed). Mark Pre-T3 Minor 1 (mouse race) as already-landed via Sprint 3 H3 atomic migration. |
+| #157 | `chore/batch1-cleanup` | Multi-monitor centering helper (`NextKey::GetCenteredPos` in `helpers/AppHelpers.h`), 9 dialogs migrated. TSF_LOG → single OutputDebugStringW call. TrackedSendInput consolidation: drop HookEngine member, route 6 callers through `Output::Internal::TrackedSendInput`. |
+
+## Branch open + uncommitted state
+
+**Branch ready to push: `chore/batch2-shouldautocap-extract`** (not pushed yet — let teammate review first).
+
+Two commits:
+1. `refactor(tsf): extract ShouldAutoCap rule into Linux-portable header` — `core/AutoCapDecision.h::ComputeShouldAutoCap(buf, len)` + 8 tests in `tests/AutoCapDecisionTest.cpp`. Linux 1555 → 1563 PASS.
+2. `docs(todo): mark Batch 2 items as landed/audited` — TODO.md cleanup for ApplyAutoCapsMacro / TryExpandMacro tests / `\n` escape audit / ShouldAutoCap.
+
+**Stash kept** from earlier in session: `stash@{0}: WIP: sustained.toml corpus tweak — outside v3 scope`. Anh decides separately.
+
+## What's NEXT in the cleanup plan
+
+The session's batch plan was 4 batches. Status:
+
+### ✅ Batch 1 — DONE (PR #157)
+- Multi-monitor centering helper + 9 dialog migration
+- TSF_LOG atomic single call
+- TrackedSendInput consolidation
+
+### 🟡 Batch 2 — Mostly DONE
+- ✅ ApplyAutoCapsMacro extract → already landed via `Macro::Plan` (was stale TODO)
+- ✅ TryExpandMacro match tests → already landed via `MacroCaseTest.cpp` (459 LOC)
+- ✅ `\n` escape audit → no action needed (current behavior correct, see TODO.md note)
+- ✅ ShouldAutoCap extract → just landed on `chore/batch2-shouldautocap-extract`
+
+**Push + PR + merge `chore/batch2-shouldautocap-extract` to wrap Batch 2.** Suggested command:
+```bash
+git push -u origin chore/batch2-shouldautocap-extract
+gh pr create --base Main --head chore/batch2-shouldautocap-extract \
+  --title "refactor(tsf): extract ShouldAutoCap rule + Linux tests" \
+  --body "Pure auto-cap decision moved into core/AutoCapDecision.h (8 tests). TODO.md cleanup for already-landed Batch 2 items."
+gh pr merge --merge --admin --delete-branch
+```
+
+### ⏳ Batch 3 — Pending decisions
+- **M2 — `kFoo` vs `UPPER_SNAKE` constants naming convention.** Needs 3-collaborator decision per `docs/TODO.md`. Recommendation: formalize the k-prefix in Rule 9.1 (it's the de facto pattern). Either way, picks one and renames or updates the rule.
+
+### 🔵 Batch 4 — DEFERRED (no driver)
+- **Phonotactics Path 1 → IPhonologyRules migration.** TODO label retired in PR #155. Reopen only when a dialectal rule pack is needed.
+
+## Items still open in `docs/TODO.md` after this session
+
+Reading top-down:
+
+| Section | Status notes |
+|---|---|
+| 🟡 v3 Watchdog Smoke 4 + 5 + 6 | Defer until logout/login or AV scan window. Code shipped. |
+| 🔴 Vietnamese-rule consolidation phonology plugin | **STALE** post-T2.1 sprint close. Most of what this entry asked for landed in Main commits `48d25b1`/`59fd807`/`3f86c40`/`1bfffb7`. Recommend rewriting this entry to reflect what's done vs what remains (Path 1 migration only). |
+| 🟡 Items deferred from cleanup PR (Pre-T3 Minor 1, M2, M3, typing bug `cafcs`) | Minor 1 + M3 LANDED. M2 still pending decision. `cafcs` typing bug ostensibly fixed by T5 (`211f2e8`) — verify. |
+| Typing bug `cafcs → các` | Verify post-T5 fix on Windows. |
+| Outlook "Anh em" Fix | RESOLVED via PR #156 revert. TODO entry can be marked landed. |
+| Macro Case-Matching follow-ups | All 5 sub-items still open (`TryExpandMacro` syscalls, P3/P4 composition asymmetry, escape gap, release-note). Lower priority. |
+| Auto-caps + TSF Apps Feedback | Edge revive bugs ("user said skip"), Windows Search Vietnamese, ShouldAutoCap extract LANDED. |
+| Hotkey Refactor deferred | All low-priority polish items. |
+| TSF Readonly Context Phase 2/3 | "tạm chưa có ai dùng nhiều, để đó vậy" per user. |
+| Earlier review sections | Mostly fixed, residual items low-priority. |
+
+## Branch hygiene
+
+After Batch 2 PR merges, local branches list:
+
+| Branch | Status |
+|---|---|
+| `Main` | tracking `origin/Main` |
+| `feat/save-feat` | NOT merged ("stuck at classic UI") — leave |
+| `feature/typing-engine-unification` | merged into Main, safe to delete |
+| `pr-151` | merged into Main, safe to delete |
+| `sprint-3/fsm-engine` | NOT merged ("Sprint 3 paused, Path G replaces") — leave |
+
+User asked Claude not to auto-delete (per session memory). Suggested cleanup if teammate wants:
+```bash
+git branch -d feature/typing-engine-unification pr-151
+```
+
+## Decisions made in this session (durable)
+
+1. **Watchdog opt-in (default OFF)** — User design choice. Tray toggle is single source of truth. No migration code (branch was unreleased). Codified in `feedback_design_philosophy.md` memory.
+2. **Outlook revert** — User confirmed "Anh em" symptom is Outlook AutoCorrect, not the IME path. Removed `isOutlookApp_` passthrough gate; kept `needBaitChar_` for the BS U+202F quirk (orthogonal, real).
+3. **Pre-T3 Minor 1 (mouse race)** — Already addressed via Sprint 3 H3 atomic migration (`58d8f88`). Companion `cachedFocusedClass_` tuple race documented as benign in `HookEngine.h:474-479`. No further action.
+4. **Option A (kill-twice-stop watchdog) — REVERTED** — 60s threshold never fires (heartbeat timeout 90s > threshold). Tray toggle covers user disable.
+
+## How to resume
+
+Continue on Main. Next obvious task (in priority order):
+
+1. **Push + merge `chore/batch2-shouldautocap-extract`** — already-tested, low risk.
+2. **Decide M2 (k-prefix vs UPPER_SNAKE).** Update Rule 9.1 in `docs/CODING_RULES/9-naming-conventions.md` to formalize whichever pattern wins. Either way, ~30 min of work.
+3. **Verify cafcs typing bug** post-T5 fix on Windows. If still broken, follow `nexuskey-typing-bugs` skill.
+4. **Smoke 4/5/6** for v3 watchdog when next logout/login window opens.
+5. **TODO.md tidy-up** — rewrite the "🔴 Vietnamese-rule consolidation" top entry to reflect post-T2.1 reality (most done, Path 1 migration is the only remainder).
+
+Linux GTest baseline: 1563 / 1563 PASS as of session end.

--- a/src/core/AutoCapDecision.h
+++ b/src/core/AutoCapDecision.h
@@ -1,0 +1,47 @@
+// NexusKey - Auto-Capitalization Decision
+// Copyright (c) 2024-2026 PhatMT. All rights reserved.
+// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-NexusKey-Commercial
+//
+// Pure decision: given a snapshot of text up to (but not including) the
+// caret, should the next typed letter be auto-capitalized?
+//
+// Linux-portable so the rule has Linux GTest coverage even though the
+// only consumer (TSF `InspectPrecedingTextEditSession`) needs Win32
+// edit sessions to obtain the buffer.
+
+#pragma once
+
+#include <cstddef>
+
+namespace NextKey {
+
+/// Returns true when the next typed character should be capitalized.
+///
+/// Rule:
+///   - Empty buffer → true (start of document).
+///   - Only whitespace before caret → true (start of document, modulo
+///     leading spaces).
+///   - Last non-whitespace char is `\n` or `\r` → true (start of line).
+///   - Last non-whitespace char is `.`, `?`, or `!` AND at least one
+///     whitespace separated it from the caret → true (start of new
+///     sentence). The whitespace gate is required so domains glued to
+///     the period (".com", ".vn") are NOT auto-capped.
+///   - Otherwise → false.
+[[nodiscard]] inline bool ComputeShouldAutoCap(const wchar_t* buf, std::size_t len) noexcept {
+    if (len == 0) return true;
+
+    std::size_t i = len;
+    bool skippedWhitespace = false;
+    while (i > 0 && (buf[i - 1] == L' ' || buf[i - 1] == L'\t')) {
+        --i;
+        skippedWhitespace = true;
+    }
+
+    if (i == 0) return true;
+
+    const wchar_t c = buf[i - 1];
+    return (c == L'\n' || c == L'\r') ||
+           ((c == L'.' || c == L'?' || c == L'!') && skippedWhitespace);
+}
+
+}  // namespace NextKey

--- a/src/core/AutoCapDecision.h
+++ b/src/core/AutoCapDecision.h
@@ -3,45 +3,72 @@
 // SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-NexusKey-Commercial
 //
 // Pure decision: given a snapshot of text up to (but not including) the
-// caret, should the next typed letter be auto-capitalized?
+// caret, classify which "should the next char start fresh" trigger applies.
 //
-// Linux-portable so the rule has Linux GTest coverage even though the
-// only consumer (TSF `InspectPrecedingTextEditSession`) needs Win32
-// edit sessions to obtain the buffer.
+// Two consumers share this rule:
+//   1. TSF `InspectPrecedingTextEditSession` (Win32 edit session, wchar_t
+//      buffer) — collapses the trigger into a single auto-cap bool via
+//      `ComputeShouldAutoCap`.
+//   2. IPC anchor `DeriveAnchorFromPreceding` in `core/ipc/SharedState.h`
+//      (uint16_t buffer, cross-process) — splits the trigger into the
+//      `isSentenceStart` / `isLineStart` flags published to HookEngine.
+//
+// Linux-portable so the rule has Linux GTest coverage even though both
+// consumers obtain their buffers via Windows-specific paths.
 
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 namespace NextKey {
 
-/// Returns true when the next typed character should be capitalized.
-///
-/// Rule:
-///   - Empty buffer → true (start of document).
-///   - Only whitespace before caret → true (start of document, modulo
-///     leading spaces).
-///   - Last non-whitespace char is `\n` or `\r` → true (start of line).
-///   - Last non-whitespace char is `.`, `?`, or `!` AND at least one
-///     whitespace separated it from the caret → true (start of new
-///     sentence). The whitespace gate is required so domains glued to
-///     the period (".com", ".vn") are NOT auto-capped.
-///   - Otherwise → false.
-[[nodiscard]] inline bool ComputeShouldAutoCap(const wchar_t* buf, std::size_t len) noexcept {
-    if (len == 0) return true;
+/// Classification of the preceding-text trigger that warrants a fresh start
+/// (capitalize the next letter / mark a new sentence in the IPC anchor).
+enum class CapTrigger : uint8_t {
+    None,         // mid-word / mid-sentence / non-sentence punct — no fresh start
+    DocStart,     // empty buffer or only whitespace — both sentence + line start
+    LineStart,    // last non-whitespace is `\n` or `\r` — line start, not sentence
+    SentenceEnd,  // last non-whitespace is `.`, `?`, or `!` AND at least one
+                  // whitespace separates it from the caret (so domains like
+                  // ".com" / ".vn" do NOT trigger)
+};
+
+/// Classify the trigger by walking back over trailing spaces/tabs and
+/// inspecting the first non-whitespace char. Templated so the IPC path
+/// (uint16_t / UTF-16) and the TSF path (wchar_t) share one implementation.
+template <typename CharT>
+[[nodiscard]] inline CapTrigger ClassifyCapTrigger(const CharT* buf,
+                                                   std::size_t len) noexcept {
+    if (buf == nullptr || len == 0) return CapTrigger::DocStart;
 
     std::size_t i = len;
     bool skippedWhitespace = false;
-    while (i > 0 && (buf[i - 1] == L' ' || buf[i - 1] == L'\t')) {
-        --i;
-        skippedWhitespace = true;
+    while (i > 0) {
+        const CharT c = buf[i - 1];
+        if (c == CharT{' '} || c == CharT{'\t'}) {
+            --i;
+            skippedWhitespace = true;
+        } else {
+            break;
+        }
     }
 
-    if (i == 0) return true;
+    if (i == 0) return CapTrigger::DocStart;
 
-    const wchar_t c = buf[i - 1];
-    return (c == L'\n' || c == L'\r') ||
-           ((c == L'.' || c == L'?' || c == L'!') && skippedWhitespace);
+    const CharT c = buf[i - 1];
+    if (c == CharT{'\n'} || c == CharT{'\r'}) return CapTrigger::LineStart;
+    if ((c == CharT{'.'} || c == CharT{'?'} || c == CharT{'!'}) && skippedWhitespace) {
+        return CapTrigger::SentenceEnd;
+    }
+    return CapTrigger::None;
+}
+
+/// Convenience wrapper for the TSF auto-cap call site: any non-`None`
+/// trigger means the next typed letter should be capitalized.
+[[nodiscard]] inline bool ComputeShouldAutoCap(const wchar_t* buf,
+                                               std::size_t len) noexcept {
+    return ClassifyCapTrigger(buf, len) != CapTrigger::None;
 }
 
 }  // namespace NextKey

--- a/src/core/AutoCapDecision.h
+++ b/src/core/AutoCapDecision.h
@@ -38,8 +38,8 @@ enum class CapTrigger : uint8_t {
 /// inspecting the first non-whitespace char. Templated so the IPC path
 /// (uint16_t / UTF-16) and the TSF path (wchar_t) share one implementation.
 template <typename CharT>
-[[nodiscard]] inline CapTrigger ClassifyCapTrigger(const CharT* buf,
-                                                   std::size_t len) noexcept {
+[[nodiscard]] constexpr CapTrigger ClassifyCapTrigger(const CharT* buf,
+                                                      std::size_t len) noexcept {
     if (buf == nullptr || len == 0) return CapTrigger::DocStart;
 
     std::size_t i = len;
@@ -66,8 +66,8 @@ template <typename CharT>
 
 /// Convenience wrapper for the TSF auto-cap call site: any non-`None`
 /// trigger means the next typed letter should be capitalized.
-[[nodiscard]] inline bool ComputeShouldAutoCap(const wchar_t* buf,
-                                               std::size_t len) noexcept {
+[[nodiscard]] constexpr bool ComputeShouldAutoCap(const wchar_t* buf,
+                                                  std::size_t len) noexcept {
     return ClassifyCapTrigger(buf, len) != CapTrigger::None;
 }
 

--- a/src/core/ipc/SharedState.h
+++ b/src/core/ipc/SharedState.h
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include "core/AutoCapDecision.h"
 #include "core/config/TypingConfig.h"
 
 namespace NextKey {
@@ -94,35 +95,28 @@ inline void DeriveAnchorFromPreceding(const uint16_t* preceding, size_t len,
     out.isWordStart = (last == u' ' || last == u'\t' ||
                        last == u'\n' || last == u'\r') ? 1 : 0;
 
-    // Walk back over spaces/tabs (not newlines — newline is its own trigger).
-    // Track whether any whitespace was skipped: sentence-start requires at least one
-    // space between '.?!' and the cursor, otherwise domains/extensions like ".com"
-    // get force-capped to ".Com".
-    size_t i = len;
-    bool skippedWhitespace = false;
-    while (i > 0) {
-        uint16_t c = preceding[i - 1];
-        if (c == u' ' || c == u'\t') { --i; skippedWhitespace = true; continue; }
-        break;
-    }
-
-    if (i == 0) {
-        // Buffer is only spaces/tabs. Conservative: sentence + line start both true.
-        // (Over-cap in pathological mid-doc whitespace runs is benign.)
-        out.isSentenceStart = 1;
-        out.isLineStart     = 1;
-    } else {
-        uint16_t prev = preceding[i - 1];
-        if (prev == u'\n' || prev == u'\r') {
+    // Sentence/line classification — single source of truth lives in
+    // core/AutoCapDecision.h and is shared with the TSF auto-cap path.
+    switch (ClassifyCapTrigger(preceding, len)) {
+        case CapTrigger::DocStart:
+            // Empty / whitespace-only buffer. Conservative: sentence + line
+            // start both true. (Over-cap in pathological mid-doc whitespace
+            // runs is benign.)
+            out.isSentenceStart = 1;
+            out.isLineStart     = 1;
+            break;
+        case CapTrigger::LineStart:
             out.isSentenceStart = 0;
             out.isLineStart     = 1;
-        } else if ((prev == u'.' || prev == u'?' || prev == u'!') && skippedWhitespace) {
+            break;
+        case CapTrigger::SentenceEnd:
             out.isSentenceStart = 1;
             out.isLineStart     = 0;
-        } else {
+            break;
+        case CapTrigger::None:
             out.isSentenceStart = 0;
             out.isLineStart     = 0;
-        }
+            break;
     }
 
     // currentSyllable: non-whitespace run ending at cursor. Meaningful only when

--- a/src/tsf/CompositionEditSession.h
+++ b/src/tsf/CompositionEditSession.h
@@ -6,6 +6,7 @@
 #include "EditSession.h"
 #include "CompositionManager.h"
 #include "Define.h"
+#include "core/AutoCapDecision.h"
 #include "core/engine/IInputEngine.h"
 #include "core/engine/VietnameseTables.h"
 #include <algorithm>
@@ -309,23 +310,10 @@ public:
             }
         }
 
-        // Auto-cap check: skip trailing whitespace, check for sentence-ending punct.
-        // '.?!' requires at least one whitespace between punct and cursor so that
-        // domains/extensions glued to the period (".com", ".vn") are NOT capped.
-        size_t i = len;
-        bool skippedWhitespace = false;
-        while (i > 0 && (buf[i - 1] == L' ' || buf[i - 1] == L'\t')) {
-            --i;
-            skippedWhitespace = true;
-        }
-
-        if (i == 0) {
-            shouldAutoCap_ = true;
-        } else {
-            wchar_t c = buf[i - 1];
-            shouldAutoCap_ = (c == L'\n' || c == L'\r') ||
-                             ((c == L'.' || c == L'?' || c == L'!') && skippedWhitespace);
-        }
+        // Auto-cap rule extracted to core/AutoCapDecision.h for Linux GTest
+        // coverage (the buffer comes from a Win32 edit session here, but the
+        // decision is pure CPU work over a wchar_t span).
+        shouldAutoCap_ = ComputeShouldAutoCap(buf, len);
 
         return S_OK;
     }

--- a/tests/AutoCapDecisionTest.cpp
+++ b/tests/AutoCapDecisionTest.cpp
@@ -1,0 +1,81 @@
+// NexusKey — ComputeShouldAutoCap unit tests (Linux-portable)
+// SPDX-License-Identifier: GPL-3.0-only
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include "core/AutoCapDecision.h"
+
+namespace NextKey {
+namespace {
+
+// Helper: invoke ComputeShouldAutoCap with a wide string literal.
+[[nodiscard]] bool Decide(const wchar_t* s) {
+    return ComputeShouldAutoCap(s, std::wstring(s).size());
+}
+
+TEST(AutoCapDecision, EmptyBufferIsDocStart) {
+    EXPECT_TRUE(ComputeShouldAutoCap(nullptr, 0));
+    EXPECT_TRUE(Decide(L""));
+}
+
+TEST(AutoCapDecision, OnlyWhitespaceTreatedAsDocStart) {
+    EXPECT_TRUE(Decide(L" "));
+    EXPECT_TRUE(Decide(L"   "));
+    EXPECT_TRUE(Decide(L"\t"));
+    EXPECT_TRUE(Decide(L" \t  "));
+}
+
+TEST(AutoCapDecision, NewlineCapsNextChar) {
+    EXPECT_TRUE(Decide(L"hello\n"));
+    EXPECT_TRUE(Decide(L"hello\r"));
+    // Trailing whitespace after newline still caps (start of line + indent).
+    EXPECT_TRUE(Decide(L"hello\n   "));
+    EXPECT_TRUE(Decide(L"hello\r\n"));
+}
+
+TEST(AutoCapDecision, SentencePunctRequiresTrailingSpace) {
+    // Sentence end with space → caps.
+    EXPECT_TRUE(Decide(L"Hello. "));
+    EXPECT_TRUE(Decide(L"Hello? "));
+    EXPECT_TRUE(Decide(L"Hello! "));
+    EXPECT_TRUE(Decide(L"Hello.   "));
+    EXPECT_TRUE(Decide(L"Hello.\t"));
+
+    // Sentence-end punct WITHOUT trailing whitespace (domain case) → no cap.
+    EXPECT_FALSE(Decide(L"Hello."));
+    EXPECT_FALSE(Decide(L"abc."));    // ".com" / ".vn" pre-caret
+    EXPECT_FALSE(Decide(L"abc?"));
+    EXPECT_FALSE(Decide(L"abc!"));
+}
+
+TEST(AutoCapDecision, MidWordContinuationDoesNotCap) {
+    EXPECT_FALSE(Decide(L"hello"));
+    EXPECT_FALSE(Decide(L"world "));   // 1 trailing space, but no sentence end
+    EXPECT_FALSE(Decide(L"abc def"));
+    EXPECT_FALSE(Decide(L"abc def "));
+}
+
+TEST(AutoCapDecision, NonSentencePunctDoesNotCap) {
+    // Comma, semicolon, colon, parens — not sentence-ending.
+    EXPECT_FALSE(Decide(L"abc, "));
+    EXPECT_FALSE(Decide(L"abc; "));
+    EXPECT_FALSE(Decide(L"abc: "));
+    EXPECT_FALSE(Decide(L"abc) "));
+}
+
+TEST(AutoCapDecision, NewlineWinsOverPunctRule) {
+    // Newline + trailing whitespace → still doc-line start, no punct
+    // requirement applies.
+    EXPECT_TRUE(Decide(L"abc.\n   "));
+    EXPECT_TRUE(Decide(L"abc\n"));
+}
+
+TEST(AutoCapDecision, VietnameseTextNoCap) {
+    EXPECT_FALSE(Decide(L"Tiếng Việt "));
+    EXPECT_TRUE(Decide(L"Hello.  "));
+    EXPECT_TRUE(Decide(L"Xin chào.\n"));
+}
+
+}  // namespace
+}  // namespace NextKey


### PR DESCRIPTION
## Summary

- Extract `ShouldAutoCap` decision from `InspectPrecedingTextEditSession` into Linux-portable `core/AutoCapDecision.h::ComputeShouldAutoCap` (+ 8 GTest cases).
- Unify with `SharedState.h::DeriveAnchorFromPreceding` — both consumers now share one `ClassifyCapTrigger<CharT>` primitive (templated for `wchar_t` TSF path + `uint16_t` IPC path).
- Mark `constexpr` for compile-time eligibility (review polish).
- TODO.md cleanup for already-landed Batch 2 items.

## Why this matters

Same walk-back-whitespace + sentence-end-punct rule was duplicated across two files. Anh's design philosophy ("không code phân mảnh") flags this as principle-grade. Single source of truth means future rule tweaks (e.g. add `…` as sentence-end) touch one place; AutoCapDecision (8 tests, wchar_t) and HookContextAnchorTest (27 tests, uint16_t) both exercise the unified primitive — drift impossible.

## Commits

| SHA | What |
|---|---|
| `d7c51d4` | refactor(tsf): extract ShouldAutoCap rule into Linux-portable header |
| `33fefb9` | docs(todo): mark Batch 2 items as landed/audited |
| `e1c757f` | docs(handoff): post-v3 cleanup status |
| `90a4198` | refactor(ipc): unify DeriveAnchorFromPreceding with ComputeShouldAutoCap |
| `266aadb` | refactor(core): mark ClassifyCapTrigger / ComputeShouldAutoCap constexpr |

## Test plan

- [x] Linux GTest: 1563 / 1563 PASS (1555 baseline + 8 new AutoCapDecision tests)
- [x] AutoCapDecision suite: 8 / 8 PASS (wchar_t path)
- [x] HookContextAnchorTest suite: 27 / 27 PASS (uint16_t path through unified primitive)
- [x] simplify-skill 3-agent review (reuse / quality / efficiency) — clean, 1 polish (`constexpr`) applied
- [ ] Windows build smoke (anh runs locally)