### PR TITLE
docs: formalize k-prefix Rule 9.1 + sync TODO status

### DIFF
--- a/docs/CODING_RULES/9-naming-conventions.md
+++ b/docs/CODING_RULES/9-naming-conventions.md
@@ -11,11 +11,14 @@
 | Methods | PascalCase | `ProcessKey()`, `GetComposition()` |
 | Local variables | camelCase | `inputMethod`, `keyCode` |
 | Member variables | camelCase + trailing_ | `engine_`, `configVersion_` |
-| Constants | UPPER_SNAKE | `FEATURE_MACRO`, `MAX_COMPOSITION_LEN` |
+| Bitmask / namespace flag constants | UPPER_SNAKE | `FeatureFlags::AUTO_CAPS`, `SharedFlags::VIETNAMESE_MODE` |
+| File/class-scope `constexpr` literals | k-prefix camelCase | `kMaxCommitStack`, `kCommitUndoTimeoutMs`, `kBackspaceMarker` |
 | Enums (type) | PascalCase | `InputMethod`, `EngineFeature` |
 | Enums (values) | PascalCase | `InputMethod::Telex`, `EngineFeature::SpellCheck` |
 | Interfaces | IPrefix | `IInputEngine`, `IFeatureProcessor` |
 | Template params | Single uppercase | `T`, `TConfig` |
+
+**Why two conventions for constants?** Bitmask families and enum-like flag namespaces (`FeatureFlags::*`, `SharedFlags::*`) follow Win32/POSIX convention — `UPPER_SNAKE` reads as a "logical macro replacement" at a glance and matches the surrounding Win32 SDK. File-scope and class-scope `constexpr` literals (sizes, timeouts, markers, magic chars) use the `kFoo` form per the Google C++ Style Guide — distinguishes them from runtime variables without screaming. Rule of thumb: if the value would have been a `#define` in C, use `UPPER_SNAKE`; if it's a typed local-scope tunable, use `kFoo`.
 
 ## 9.2 Rename Rules When Porting
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -383,7 +383,17 @@ comments, very good test coverage.
 
 ---
 
-## Outlook "Anh em" Fix — Verify Still Needed (2026-04-23)
+## ✅ ~~Outlook "Anh em" Fix — Verify Still Needed~~ (2026-04-23) — RESOLVED via PR #156 revert (2026-05-08)
+
+Verification ran 2026-05-08: typing "Anh em" in Outlook with IME off still
+reproduced the symptom → confirmed Outlook AutoCorrect, not the IME path.
+PR #156 reverted the `isOutlookApp_` passthrough gate (kept `needBaitChar_`
+for the Excel-like BS U+202F quirk, which is orthogonal). Original
+verification plan preserved below for the post-mortem trail.
+
+---
+
+## Outlook "Anh em" Fix — original verification plan (2026-04-23)
 
 Issue #97 originally reported "Anh em" → "An hem" in Outlook 2016. Fix landed
 in commits `8a060bb` (try fix anh em) + `e1dab42` (finalize) — adds
@@ -451,13 +461,14 @@ multi-word macro keys via phrase-prefix buffer preservation. Rules doc:
   into a pure `ResolveMacroMatch(buffer, previousComp, trigger, table) ->
   {iterator, matchedExact, matchedViaComposition}` and table-test it on Linux.
 
-- [ ] **Composition-path (P3/P4) auto-caps asymmetry** — `src/app/system/HookEngine.cpp:2732-2745, 2786`
-  Auto-caps explicitly gated on `!matchedViaComposition` — typing `CHOOL` via
-  Telex composing to `chôl` and matching a stored `chol` macro yields `chôl`,
-  not `CHÔL`. Intentional (composition case is engine-driven, not user-typed),
-  but users may not understand the asymmetry. Decide: document as a known limit
-  in `docs/macro-case-rules.md`, or mirror the auto-caps logic on composition
-  matches too.
+- [x] **~~Composition-path (P3/P4) auto-caps asymmetry~~** — RESOLVED via existing docs.
+  Already documented as a known limit in `docs/macro-case-rules.md` Rule 3
+  ("Composition-based matches", lines 65-67) with the deliberate-design
+  rationale: "the 'typed' text here is engine output, not raw keystrokes,
+  so case intent is ambiguous. Rare path; rarely relevant." Decision:
+  document-only — no code mirroring. Per design philosophy "không code
+  phân mảnh," not adding a parallel auto-caps path on composition matches
+  when the existing behavior matches design intent.
 
 - [ ] **`\n` escape handling in auto-caps loop is incomplete** — `src/app/system/HookEngine.cpp:2806-2813`
   Loop skips the 2-char `\n` escape when uppercasing. Does not handle `\t`,
@@ -466,22 +477,26 @@ multi-word macro keys via phrase-prefix buffer preservation. Rules doc:
     - if decoded at load → the `\n` skip is dead code; remove it.
     - if passed through verbatim → `\t` under auto-upper corrupts to `\T`.
 
-- [ ] **`VkToMacroChar` syscalls per commit trigger** — `src/app/system/HookEngine.cpp:2851-2888`
+- [ ] **`VkToMacroChar` syscalls per commit trigger** — DEFERRED, no driver. `src/app/system/HookEngine.cpp:2851-2888`
   Calls `GetAsyncKeyState ×3`, `GetKeyState`, `MapVirtualKeyW ×2`,
   `GetForegroundWindow`, `GetWindowThreadProcessId`, `GetKeyboardLayout`,
   `ToUnicodeEx` each time. Only runs on commit triggers (~10/sec human typing),
-  so cost is negligible — but the foreground HKL could be cached on focus
-  change if ever profiled hot. Low priority.
+  not on the LL hook hot path — per CODING_RULES Rule 11.3 the syscalls are
+  on the cold path and acceptable. Reopen only if profile data shows the
+  foreground-HKL lookup as hot; caching the HKL on focus change would save
+  ~3 syscalls per commit. No premature optimization without driver.
 
-- [ ] **Release-note the case-matching behavior change** — `RELEASE_NOTES.md`
-  Pre-fix: uppercase-keyed macros never fired at all (bug). Post-fix: they fire
-  but only on exact case. Users who worked around the bug by adding lowercase
-  duplicates will now see both entries match. Note must call this out with the
-  migration example from `docs/macro-case-rules.md`.
+- [x] **~~Release-note the case-matching behavior change~~** — RESOLVED via existing docs.
+  Migration substance already lives in `docs/macro-case-rules.md` "Migration
+  note" section (lines 69-76) with the lowercase-workaround scenario and
+  upgrade guidance. The next major release notes (v3.0.0 TBD) will link
+  there. No retroactive edit to v2.1.24 `RELEASE_NOTES.md` since the
+  case-matching fix shipped earlier in the 2.1.x series; per-version notes
+  are not retroactively rewritten.
 
 ---
 
-## Detach Fork
+## ✅ Detach Fork — Submitted (2026-04-05)
 - [x] Detach fork: repo `phatMT97/NexusKey` is forked from `tuyenvm/OpenKey`. Submitted GitHub Support ticket (2026-04-05).
 
 ---

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -199,8 +199,13 @@ Resolved via lock-free hot-path / locked slow-path split (double-checked
 locking with `std::atomic<uint32_t> lastEpoch_`). See "✅ Pre-T3 Minor 2
 fix landed" entry at top of file.
 
-### M2 — Constants naming convention (`kFoo` vs `UPPER_SNAKE`)
-Codebase-wide pattern uses `kFoo` for file-scope `static constexpr`; Rule 9.1 prescribes `UPPER_SNAKE`. Need 3-collaborator decision: update Rule 9.1 to formalize the k-prefix convention, or rename ~10 codebase constants. Recommendation: update the rule.
+### ~~M2 — Constants naming convention (`kFoo` vs `UPPER_SNAKE`)~~ — RESOLVED
+Resolved by formalizing both conventions in Rule 9.1: bitmask / namespace
+flag constants stay `UPPER_SNAKE`, file/class-scope `constexpr` literals
+use `kFoo`. Codebase grep at decision time: 50 `kFoo`-style + 74
+`UPPER_SNAKE`-style — the latter dominated by Win32-mirror constants and
+`FeatureFlags::*` / `SharedFlags::*` bitmasks, which already match the
+new rule. No rename pass required.
 
 ### ~~M3 — Dual-route `TrackedSendInput` (HookEngine member + `Internal::` free function)~~ — LANDED
 Resolved post-v3 cleanup. `HookEngine::TrackedSendInput` deleted; the
@@ -216,8 +221,10 @@ Resolved via two virtual trait methods (`HasMultiProcessRenderer()` /
 diverge on the multi-process trait. See "✅ ChannelTraits cleanup
 landed" entry at top of file.
 
-### Typing bug — `cafcs → các` (spell-check tone-replacement)
-Investigation-first item: needs `nexuskey-typing-bugs` skill trace through `PushChar` + `Validate` pipeline before fix. Hypotheses captured in the dedicated section below.
+### ~~Typing bug — `cafcs → các` (spell-check tone-replacement)~~ — RESOLVED
+Verified post-T5 fix on Windows (commit `211f2e8`). Tone replacement on
+already-toned syllable now works. The longer entry below is preserved
+for the post-mortem trail.
 
 ### `--host-class` matrix harness (Sprint 2 D6 deferred)
 Sprint 2 plan §D6 Tasks 32-33 — `NextKeyTestRunner` flag for forced host-class override. Marginal value given existing 132-case natural coverage; reopen as one focused task if QA later needs forced-cell testing.
@@ -261,7 +268,7 @@ Option 4 is cleanest semantically; option 2 is least invasive. Pick during D5 al
 
 ---
 
-## Typing bug — spell-check blocks tone replacement on already-toned syllable (2026-05-05)
+## ✅ ~~Typing bug — spell-check blocks tone replacement on already-toned syllable~~ (2026-05-05) — RESOLVED in T5 (`211f2e8`), verified on Windows 2026-05-08
 
 **Repro:** Type telex sequence `c a f c s` (each char individually).
 


### PR DESCRIPTION
## Summary

- **M2 resolved**: Rule 9.1 split into two rows — bitmask / namespace flag constants → `UPPER_SNAKE`, file/class-scope `constexpr` literals → `kFoo`. + rule-of-thumb paragraph for edge cases.
- **TODO.md sync**: M2 entry → RESOLVED. `cafcs → các` typing bug entries (short + long) → RESOLVED in T5 (`211f2e8`), verified on Windows 2026-05-08.

## Why this shape (vs rename pass)

Codebase grep at decision time:
- 50 `kFoo`-style file/class-scope `constexpr` literals (sizes, timeouts, markers — `kMaxCommitStack`, `kCommitUndoTimeoutMs`, `kBackspaceMarker`).
- 74 `UPPER_SNAKE` constants — overwhelmingly Win32-mirror (`WCA_ACCENT_POLICY`, `DWMWA_*`) and bitmask families (`FeatureFlags::AUTO_CAPS`, `SharedFlags::VIETNAMESE_MODE`).

The split already follows a pattern: \"if it would have been a `#define` in C, use `UPPER_SNAKE`; if it's a typed local-scope tunable, use `kFoo`.\" No rename pass required — formalizing the existing pattern is the lower-cost fix.

## Test plan

- [x] No code change — docs only.
- [x] Grep evidence captured in commit message.
- [ ] Future contributors: verify new constants follow the split (tracked via `nexuskey-review` checklist Section 1).