### PR TITLE
fix(hook): query focused-child thread for keyboard layout in multi-process apps

### DIFF
--- a/src/app/system/HookEngine.cpp
+++ b/src/app/system/HookEngine.cpp
@@ -2552,6 +2552,16 @@ void HookEngine::CheckLayoutChange() {
     HWND fg = GetForegroundWindow();
     if (!fg) return;
     DWORD tid = GetWindowThreadProcessId(fg, nullptr);
+
+    // Multi-process apps (MS Teams/Electron/WebView2): the focused input element
+    // may live on a different thread (renderer) than the top-level window.
+    // Keyboard layout is per-thread, so query the focused child's thread instead.
+    GUITHREADINFO gti = { sizeof(gti) };
+    if (GetGUIThreadInfo(tid, &gti) && gti.hwndFocus && gti.hwndFocus != fg) {
+        DWORD focusTid = GetWindowThreadProcessId(gti.hwndFocus, nullptr);
+        if (focusTid != 0) tid = focusTid;
+    }
+
     bool compatible = !IsIncompatibleLayout(GetKeyboardLayout(tid));
     if (compatible != cachedIsCompatLayout_) {
         cachedIsCompatLayout_ = compatible;


### PR DESCRIPTION
## Summary

Fix layout auto-disable misfiring in MS Teams / Electron / WebView2 hosts where the focused input element lives on a different thread than the top-level HWND.

## Why

\`GetKeyboardLayout()\` is per-thread. In multi-process apps:
- Top-level HWND → chrome/host thread
- Focused input element → renderer thread (different layout context)

Pre-fix \`CheckLayoutChange()\` queried the foreground thread's layout, so it returned the host's layout — not what the user is actually typing into. Layout auto-disable then evaluated the wrong thread.

## How

Use \`GetGUIThreadInfo(fgTid)\` to find the focused HWND. If it differs from \`fg\` and lives on a different thread, query *that* thread's layout instead. Defensive: only reassign \`tid\` when \`hwndFocus\` is non-null, differs from \`fg\`, and \`GetWindowThreadProcessId\` returns valid.

## Hot-path impact

+2 cheap Win32 syscalls on the \`CheckLayoutChange\` path. Per Rule 11.3 the call sites are all cold:
- Modifier-combo release (Ctrl+Shift / Alt+Shift hotkey detection) — semi-hot, fires on key release subset only
- 200ms periodic timer — cold
- \`OnFocusChanged\` × 2 — cold

NOT on the LL hook keystroke hot path.

## Test plan

- [x] Code review per nexuskey-review checklist (naming, error handling, hot-path, comments)
- [x] Linux build unaffected — \`HookEngine.cpp\` excluded from Linux test target (Win32-only file)
- [ ] Windows manual smoke: type Vietnamese in MS Teams / Electron app to verify layout-aware auto-disable now reflects the renderer thread's layout (anh runs locally)