### PR TITLE
feat(output): add ClipboardInjector + per-app send-method override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ add_executable(NextKeyApp WIN32
     src/app/output/OutputInjectorFactory.cpp
     src/app/output/Win32SendInputInjector.h
     src/app/output/Win32SendInputInjector.cpp
+    src/app/output/ClipboardInjector.cpp
     src/app/output/RichEditEmReplaceSelInjector.h
     src/app/output/RichEditEmReplaceSelInjector.cpp
     src/app/output/SplitDispatchInjector.h
@@ -276,6 +277,7 @@ if(NEXUSKEY_LITE_MODE AND WIN32)
         src/app/output/OutputInjectorFactory.cpp
         src/app/output/Win32SendInputInjector.h
         src/app/output/Win32SendInputInjector.cpp
+        src/app/output/ClipboardInjector.cpp
         src/app/output/RichEditEmReplaceSelInjector.h
         src/app/output/RichEditEmReplaceSelInjector.cpp
         src/app/output/SplitDispatchInjector.h
@@ -473,6 +475,7 @@ if(WIN32)
         tests/output/InjectorTraitsTest.cpp
         src/app/output/Internal.cpp
         src/app/output/Win32SendInputInjector.cpp
+        src/app/output/ClipboardInjector.cpp
         src/app/output/RichEditEmReplaceSelInjector.cpp
         src/app/output/SplitDispatchInjector.cpp
         src/app/output/OutputInjectorFactory.cpp

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ NexusKey is built with a lean architecture and no heavy runtime dependencies, ke
 - Testing bởi [Google Test](https://github.com/google/googletest)
 - Tham khảo rule -ing cho spell check của [Gonhanh.org](https://github.com/khaphanspace/gonhanh.org?tab=readme-ov-file#-t%C3%A0i-li%E1%BB%87u-k%E1%BB%B9-thu%E1%BA%ADt)
 - Tham khảo config TSF từ [VietType](https://github.com/dinhngtu/VietType)
+- Tham khảo cách xử lý clipboard input từ [SigmaLib](https://github.com/phamhoangnhat/SigmaLib) của Phạm Hoàng Nhật
+- Tham khảo quy tắt tiếng việt từ [dotnetkey](https://code.google.com/archive/p/dotnetkey/downloads)
 
 ### Top Testers
 Cảm ơn các thành viên cộng đồng đã test và góp ý:

--- a/src/app/classic/ClassicAppOverridesDialog.cpp
+++ b/src/app/classic/ClassicAppOverridesDialog.cpp
@@ -17,6 +17,7 @@ enum {
     IDC_COMBO_APP,
     IDC_COMBO_METHOD,
     IDC_COMBO_ENCODING,
+    IDC_COMBO_SENDMETHOD,
     IDC_BTN_ADD,
     IDC_BTN_PICK,
     IDC_BTN_DELETE,
@@ -104,14 +105,17 @@ void ClassicAppOverridesDialog::CreateControls() {
     LVCOLUMNW col{};
     col.mask = LVCF_TEXT | LVCF_WIDTH;
     col.pszText = const_cast<wchar_t*>(L"Ứng dụng");
-    col.cx = Dpi(140);
+    col.cx = Dpi(120);
     ListView_InsertColumn(listView_, 0, &col);
     col.pszText = const_cast<wchar_t*>(L"Kiểu gõ");
-    col.cx = Dpi(100);
+    col.cx = Dpi(80);
     ListView_InsertColumn(listView_, 1, &col);
     col.pszText = const_cast<wchar_t*>(L"Bảng mã");
-    col.cx = cw - Dpi(140 + 100 + 24);
+    col.cx = Dpi(100);
     ListView_InsertColumn(listView_, 2, &col);
+    col.pszText = const_cast<wchar_t*>(L"Kiểu gửi");
+    col.cx = cw - Dpi(120 + 80 + 100 + 24);
+    ListView_InsertColumn(listView_, 3, &col);
     y += listH + gap;
 
     // Row 1: app combobox + add + pick button
@@ -158,6 +162,7 @@ void ClassicAppOverridesDialog::CreateControls() {
     ComboBox_AddString(comboMethod_, L"Telex");
     ComboBox_AddString(comboMethod_, L"VNI");
     ComboBox_AddString(comboMethod_, L"Simple Telex");
+    ComboBox_AddString(comboMethod_, L"Telex + VNI");
     ComboBox_SetCurSel(comboMethod_, 0);
 
     int col2X = x + lblW + comboW + gap;
@@ -176,12 +181,27 @@ void ClassicAppOverridesDialog::CreateControls() {
     ComboBox_AddString(comboEncoding_, L"Việt CP1258");
     ComboBox_SetCurSel(comboEncoding_, 0);
 
+    // Row 3: Send Method combo + Delete button
+    int y3 = y + rowH + gap;
+    int labelY3 = y3 + (rowH - lblH) / 2;
+
+    CreateWindowExW(0, L"STATIC", L"Kiểu gửi:",
+        WS_CHILD | WS_VISIBLE | SS_LEFT,
+        x, labelY3, lblW, lblH, hwnd_, nullptr, hInstance_, nullptr);
+    comboSendMethod_ = CreateWindowExW(0, L"COMBOBOX", L"",
+        WS_CHILD | WS_VISIBLE | CBS_DROPDOWNLIST | WS_TABSTOP,
+        x + lblW, y3, comboW, Dpi(120), hwnd_, reinterpret_cast<HMENU>(IDC_COMBO_SENDMETHOD), hInstance_, nullptr);
+    SendMessageW(comboSendMethod_, CB_SETITEMHEIGHT, (WPARAM)-1, comboInnerH);
+    ComboBox_AddString(comboSendMethod_, L"Theo mặc định");
+    ComboBox_AddString(comboSendMethod_, L"Clipboard");
+    ComboBox_SetCurSel(comboSendMethod_, 0);
+
     int deleteW = Dpi(70);
     btnDelete_ = CreateWindowExW(0, L"BUTTON", L"Xoá",
         WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_PUSHBUTTON,
-        x + cw - deleteW, y, deleteW, rowH, hwnd_, reinterpret_cast<HMENU>(IDC_BTN_DELETE), hInstance_, nullptr);
+        x + cw - deleteW, y3, deleteW, rowH, hwnd_, reinterpret_cast<HMENU>(IDC_BTN_DELETE), hInstance_, nullptr);
 
-    y += rowH + gap * 2;
+    y = y3 + rowH + gap * 2;
 }
 
 static const wchar_t* MethodName(int8_t m) {
@@ -189,6 +209,7 @@ static const wchar_t* MethodName(int8_t m) {
         case 0: return L"Telex";
         case 1: return L"VNI";
         case 2: return L"Simple Telex";
+        case 3: return L"Telex + VNI";
         default: return L"Mặc định";
     }
 }
@@ -200,6 +221,13 @@ static const wchar_t* EncodingName(int8_t e) {
         case 2: return L"VNI Windows";
         case 3: return L"Unicode tổ hợp";
         case 4: return L"Việt CP1258";
+        default: return L"Mặc định";
+    }
+}
+
+static const wchar_t* SendMethodName(int8_t m) {
+    switch (m) {
+        case 1: return L"Clipboard";
         default: return L"Mặc định";
     }
 }
@@ -220,6 +248,7 @@ void ClassicAppOverridesDialog::PopulateList() {
 
         ListView_SetItemText(listView_, i, 1, const_cast<wchar_t*>(MethodName(sorted[i].second.inputMethod)));
         ListView_SetItemText(listView_, i, 2, const_cast<wchar_t*>(EncodingName(sorted[i].second.encodingOverride)));
+        ListView_SetItemText(listView_, i, 3, const_cast<wchar_t*>(SendMethodName(sorted[i].second.sendMethod)));
     }
 }
 
@@ -233,10 +262,12 @@ void ClassicAppOverridesDialog::AddOverride() {
 
     int methodSel = ComboBox_GetCurSel(comboMethod_);
     int encodingSel = ComboBox_GetCurSel(comboEncoding_);
+    int sendSel = ComboBox_GetCurSel(comboSendMethod_);
 
     AppOverrideEntry entry;
     entry.inputMethod = static_cast<int8_t>(methodSel - 1);   // 0="default"→-1, 1=Telex→0, etc.
     entry.encodingOverride = static_cast<int8_t>(encodingSel - 1);
+    entry.sendMethod = static_cast<int8_t>((sendSel == 1) ? 1 : -1);
 
     entries_[app] = entry;
     PopulateList();
@@ -245,6 +276,7 @@ void ClassicAppOverridesDialog::AddOverride() {
     SetWindowTextW(comboApp_, L"");
     ComboBox_SetCurSel(comboMethod_, 0);
     ComboBox_SetCurSel(comboEncoding_, 0);
+    ComboBox_SetCurSel(comboSendMethod_, 0);
 }
 
 void ClassicAppOverridesDialog::DeleteSelected() {

--- a/src/app/classic/ClassicAppOverridesDialog.h
+++ b/src/app/classic/ClassicAppOverridesDialog.h
@@ -36,7 +36,7 @@ private:
     int Dpi(int value) const noexcept;
 
     static constexpr int kWidth = 490;
-    static constexpr int kHeight = 295;
+    static constexpr int kHeight = 330;
     static constexpr int kPadding = 12;
     static constexpr int kBtnHeight = 28;
     static constexpr int kBtnGap = 6;
@@ -51,6 +51,7 @@ private:
     HWND comboApp_ = nullptr;
     HWND comboMethod_ = nullptr;
     HWND comboEncoding_ = nullptr;
+    HWND comboSendMethod_ = nullptr;
     HWND btnAdd_ = nullptr;
     HWND btnPick_ = nullptr;
     HWND btnDelete_ = nullptr;

--- a/src/app/dialogs/AppOverridesDialog.cpp
+++ b/src/app/dialogs/AppOverridesDialog.cpp
@@ -62,7 +62,8 @@ bool AppOverridesDialog::handle_event(HELEMENT he, BEHAVIOR_EVENT_PARAMS& params
                     if (!appName.empty()) {
                         int8_t enc = static_cast<int8_t>(readInt("#val-encoding-override", -1));
                         int8_t mth = static_cast<int8_t>(readInt("#val-input-method", -1));
-                        addEntry(appName, enc, mth);
+                        int8_t snd = static_cast<int8_t>(readInt("#val-send-method", -1));
+                        addEntry(appName, enc, mth, snd);
                     }
                 } else if (action == L"delete-app") {
                     if (!appName.empty()) {
@@ -103,16 +104,18 @@ void AppOverridesDialog::populateList() {
         call_function("addAppToList",
             sciter::value(name.c_str()),
             sciter::value(static_cast<int>(entry.inputMethod)),
-            sciter::value(static_cast<int>(entry.encodingOverride)));
+            sciter::value(static_cast<int>(entry.encodingOverride)),
+            sciter::value(static_cast<int>(entry.sendMethod)));
     }
     call_function("forceRefresh");
 }
 
-void AppOverridesDialog::addEntry(const std::wstring& name, int8_t encoding, int8_t inputMethod) {
+void AppOverridesDialog::addEntry(const std::wstring& name, int8_t encoding, int8_t inputMethod, int8_t sendMethod) {
     std::wstring lower = ToLowerAscii(name);
     AppOverrideEntry entry;
     entry.encodingOverride = encoding;
     entry.inputMethod = inputMethod;
+    entry.sendMethod = sendMethod;
 
     bool isUpdate = (entries_.find(lower) != entries_.end());
     entries_[lower] = entry;
@@ -123,7 +126,8 @@ void AppOverridesDialog::addEntry(const std::wstring& name, int8_t encoding, int
     call_function("addAppToList",
         sciter::value(lower.c_str()),
         sciter::value(static_cast<int>(inputMethod)),
-        sciter::value(static_cast<int>(encoding)));
+        sciter::value(static_cast<int>(encoding)),
+        sciter::value(static_cast<int>(sendMethod)));
     call_function("clearInput");
     call_function("forceRefresh", sciter::value(true));
     persistAndSignal();

--- a/src/app/dialogs/AppOverridesDialog.h
+++ b/src/app/dialogs/AppOverridesDialog.h
@@ -23,7 +23,7 @@ protected:
 
 private:
     void populateList();
-    void addEntry(const std::wstring& name, int8_t encoding, int8_t inputMethod);
+    void addEntry(const std::wstring& name, int8_t encoding, int8_t inputMethod, int8_t sendMethod);
     void removeEntry(const std::wstring& name);
     void persistAndSignal();
 

--- a/src/app/output/ClipboardInjector.cpp
+++ b/src/app/output/ClipboardInjector.cpp
@@ -1,0 +1,242 @@
+// src/app/output/ClipboardInjector.cpp
+#include "ClipboardInjector.h"
+#include "Internal.h"
+#include <vector>
+#include <string>
+
+namespace NextKey::Output {
+
+// Single-instance assumption: HookEngine constructs one ClipboardInjector
+// per focus change (replacing the previous injector_ shared_ptr). The save
+// → write → restore lifecycle is bounded by the SetTimer 200ms callback
+// (RestoreTimerProc), so file-scope state is safe; if multi-instance is
+// ever needed (e.g., parallel hook threads), promote to class members.
+//
+// Only CF_UNICODETEXT is preserved across the restore cycle — images and
+// other formats on the clipboard are lost after the first injection.
+// Acceptable trade-off for opt-in clipboard-based injection.
+//
+// SECURITY: Clipboard listeners (apps using `SetClipboardViewer` /
+// `AddClipboardFormatListener`) WILL see our injected text — the
+// `ExcludeClipboardContentFromMonitor` flag only blocks Windows Clipboard
+// History, not third-party listeners. Unavoidable when using the clipboard
+// for IPC; same exposure surface as if the user had typed the text via
+// clipboard paste themselves.
+namespace {
+std::wstring g_originalClipText;
+bool         g_hasOriginalClip = false;
+UINT_PTR     g_restoreTimerId  = 0;
+}  // namespace
+
+static VOID CALLBACK RestoreTimerProc(HWND, UINT, UINT_PTR idEvent, DWORD) {
+    if (idEvent != g_restoreTimerId) return;
+    KillTimer(nullptr, g_restoreTimerId);
+    g_restoreTimerId = 0;
+
+    if (!g_hasOriginalClip) return;
+
+    if (OpenClipboard(nullptr)) {
+        EmptyClipboard();
+        if (!g_originalClipText.empty()) {
+            size_t byteCount = (g_originalClipText.length() + 1) * sizeof(wchar_t);
+            HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, byteCount);
+            if (hMem) {
+                void* p = GlobalLock(hMem);
+                memcpy(p, g_originalClipText.data(), byteCount);
+                GlobalUnlock(hMem);
+                // SetClipboardData transfers HGLOBAL ownership on success;
+                // on failure the caller still owns it (Win32 docs).
+                if (!SetClipboardData(CF_UNICODETEXT, hMem)) {
+                    GlobalFree(hMem);
+                }
+            }
+        }
+        CloseClipboard();
+    }
+
+    g_originalClipText.clear();
+    g_hasOriginalClip = false;
+}
+
+bool ClipboardInjector::Replace(std::size_t bsCount, std::wstring_view text) noexcept {
+    if (bsCount == 0 && text.empty()) return true;
+
+    // Fast path: backspace-only — no clipboard IPC needed
+    if (text.empty()) {
+        std::vector<INPUT> inputs;
+        inputs.reserve(bsCount * 2);
+        for (std::size_t i = 0; i < bsCount; ++i) {
+            INPUT in{};
+            in.type = INPUT_KEYBOARD;
+            in.ki.wVk = VK_BACK;
+            in.ki.wScan = static_cast<WORD>(::MapVirtualKeyW(VK_BACK, MAPVK_VK_TO_VSC));
+            in.ki.dwExtraInfo = Internal::kNexusKeyExtraInfo;
+            inputs.push_back(in);
+            in.ki.dwFlags = KEYEVENTF_KEYUP;
+            inputs.push_back(in);
+        }
+        return Internal::TrackedSendInput(inputs.data(), static_cast<UINT>(inputs.size()));
+    }
+
+    // ── Full clipboard injection path ──
+
+    // Cancel pending restore timer (we'll set a new one after this paste)
+    if (g_restoreTimerId) {
+        KillTimer(nullptr, g_restoreTimerId);
+        g_restoreTimerId = 0;
+    }
+
+    // 1. Save original clipboard text — only on the FIRST injection per word.
+    if (!g_hasOriginalClip) {
+        g_originalClipText.clear();
+        if (OpenClipboard(nullptr)) {
+            HANDLE hData = GetClipboardData(CF_UNICODETEXT);
+            if (hData) {
+                const wchar_t* pText = static_cast<const wchar_t*>(GlobalLock(hData));
+                if (pText) {
+                    g_originalClipText = pText;
+                    GlobalUnlock(hData);
+                }
+            }
+            CloseClipboard();
+        }
+        g_hasOriginalClip = true;
+    }
+
+    // 2. Write our text to the clipboard.
+    //
+    // PERF NOTE (Rule 11.3): OpenClipboard is a kernel call that may block
+    // briefly if another process holds the clipboard. This runs on the LL
+    // hook callback path; combined with the 15ms settle Sleep below it
+    // approaches but stays under Windows' default 300ms LowLevelHooksTimeout.
+    // Acceptable for opt-in per-app injection; if a host repeatedly trips
+    // the timeout, surface as a watchdog log + advise switching the app
+    // override back to SendInput.
+    if (OpenClipboard(nullptr)) {
+        EmptyClipboard();
+
+        size_t byteCount = (text.length() + 1) * sizeof(wchar_t);
+        HGLOBAL hText = GlobalAlloc(GMEM_MOVEABLE, byteCount);
+        if (hText) {
+            void* p = GlobalLock(hText);
+            memcpy(p, text.data(), text.length() * sizeof(wchar_t));
+            static_cast<wchar_t*>(p)[text.length()] = L'\0';
+            GlobalUnlock(hText);
+            if (!SetClipboardData(CF_UNICODETEXT, hText)) {
+                GlobalFree(hText);  // ownership stays with us on failure
+            }
+        }
+
+        // Exclude from Windows Clipboard History (does not affect 3rd-party
+        // clipboard listeners — see file-top SECURITY note).
+        static UINT excludeFormat = RegisterClipboardFormatW(L"ExcludeClipboardContentFromMonitor");
+        if (excludeFormat) {
+            HGLOBAL hEmpty = GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, 1);
+            if (hEmpty) {
+                if (!SetClipboardData(excludeFormat, hEmpty)) {
+                    GlobalFree(hEmpty);
+                }
+            }
+        }
+
+        CloseClipboard();
+    }
+
+    // 3. Build input sequence: Backspaces + Ctrl+V
+    std::vector<INPUT> inputs;
+    inputs.reserve(bsCount * 2 + 4);
+
+    for (std::size_t i = 0; i < bsCount; ++i) {
+        INPUT in{};
+        in.type = INPUT_KEYBOARD;
+        in.ki.wVk = VK_BACK;
+        in.ki.wScan = static_cast<WORD>(::MapVirtualKeyW(VK_BACK, MAPVK_VK_TO_VSC));
+        in.ki.dwExtraInfo = Internal::kNexusKeyExtraInfo;
+        inputs.push_back(in);
+        in.ki.dwFlags = KEYEVENTF_KEYUP;
+        inputs.push_back(in);
+    }
+
+    INPUT ctrlDown{};
+    ctrlDown.type = INPUT_KEYBOARD;
+    ctrlDown.ki.wVk = VK_CONTROL;
+    ctrlDown.ki.wScan = static_cast<WORD>(::MapVirtualKeyW(VK_CONTROL, MAPVK_VK_TO_VSC));
+    ctrlDown.ki.dwExtraInfo = Internal::kNexusKeyExtraInfo;
+    inputs.push_back(ctrlDown);
+
+    INPUT vDown{};
+    vDown.type = INPUT_KEYBOARD;
+    vDown.ki.wVk = 'V';
+    vDown.ki.wScan = static_cast<WORD>(::MapVirtualKeyW('V', MAPVK_VK_TO_VSC));
+    vDown.ki.dwExtraInfo = Internal::kNexusKeyExtraInfo;
+    inputs.push_back(vDown);
+
+    INPUT vUp{};
+    vUp.type = INPUT_KEYBOARD;
+    vUp.ki.wVk = 'V';
+    vUp.ki.wScan = static_cast<WORD>(::MapVirtualKeyW('V', MAPVK_VK_TO_VSC));
+    vUp.ki.dwFlags = KEYEVENTF_KEYUP;
+    vUp.ki.dwExtraInfo = Internal::kNexusKeyExtraInfo;
+    inputs.push_back(vUp);
+
+    INPUT ctrlUp{};
+    ctrlUp.type = INPUT_KEYBOARD;
+    ctrlUp.ki.wVk = VK_CONTROL;
+    ctrlUp.ki.wScan = static_cast<WORD>(::MapVirtualKeyW(VK_CONTROL, MAPVK_VK_TO_VSC));
+    ctrlUp.ki.dwFlags = KEYEVENTF_KEYUP;
+    ctrlUp.ki.dwExtraInfo = Internal::kNexusKeyExtraInfo;
+    inputs.push_back(ctrlUp);
+
+    bool result = Internal::TrackedSendInput(inputs.data(), static_cast<UINT>(inputs.size()));
+
+    // 4. Brief settle so the target app processes Ctrl+V before the next
+    // keystroke arrives. Load-bearing — without this the next physical key
+    // can race the paste and split the word. 15ms keeps the LL hook callback
+    // under the default LowLevelHooksTimeout of 300ms (combined with the
+    // OpenClipboard call above ~30-50ms worst-case).
+    Sleep(15);
+
+    // 5. Schedule lazy restore — fires 200ms after the LAST injection.
+    g_restoreTimerId = SetTimer(nullptr, 0, 200, RestoreTimerProc);
+    if (g_restoreTimerId == 0) {
+        // Timer failed — restore immediately as fallback
+        if (g_hasOriginalClip && OpenClipboard(nullptr)) {
+            EmptyClipboard();
+            if (!g_originalClipText.empty()) {
+                size_t byteCount = (g_originalClipText.length() + 1) * sizeof(wchar_t);
+                HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, byteCount);
+                if (hMem) {
+                    void* p = GlobalLock(hMem);
+                    memcpy(p, g_originalClipText.data(), byteCount);
+                    GlobalUnlock(hMem);
+                    if (!SetClipboardData(CF_UNICODETEXT, hMem)) {
+                        GlobalFree(hMem);
+                    }
+                }
+            }
+            CloseClipboard();
+            g_originalClipText.clear();
+            g_hasOriginalClip = false;
+        }
+    }
+
+    return result;
+}
+
+void ClipboardInjector::SendKey(unsigned short vkCode) noexcept {
+    INPUT in[2] = {};
+    in[0].type = INPUT_KEYBOARD;
+    in[0].ki.wVk = vkCode;
+    in[0].ki.wScan = static_cast<WORD>(::MapVirtualKeyW(vkCode, MAPVK_VK_TO_VSC));
+    in[0].ki.dwExtraInfo = Internal::kNexusKeyExtraInfo;
+
+    in[1].type = INPUT_KEYBOARD;
+    in[1].ki.wVk = vkCode;
+    in[1].ki.wScan = static_cast<WORD>(::MapVirtualKeyW(vkCode, MAPVK_VK_TO_VSC));
+    in[1].ki.dwFlags = KEYEVENTF_KEYUP;
+    in[1].ki.dwExtraInfo = Internal::kNexusKeyExtraInfo;
+
+    (void)Internal::TrackedSendInput(in, 2);
+}
+
+} // namespace NextKey::Output

--- a/src/app/output/ClipboardInjector.h
+++ b/src/app/output/ClipboardInjector.h
@@ -1,0 +1,23 @@
+// src/app/output/ClipboardInjector.h
+#pragma once
+
+#include "IOutputInjector.h"
+#include <windows.h>
+#include <chrono>
+
+namespace NextKey::Output {
+
+class ClipboardInjector final : public IOutputInjector {
+public:
+    ClipboardInjector() noexcept = default;
+    ~ClipboardInjector() override = default;
+
+    bool Replace(std::size_t bsCount, std::wstring_view text) noexcept override;
+    void SendKey(unsigned short vkCode) noexcept override;
+
+    std::chrono::milliseconds SettleBudget() const noexcept override {
+        return std::chrono::milliseconds{150};
+    }
+};
+
+} // namespace NextKey::Output

--- a/src/app/output/OutputInjectorFactory.cpp
+++ b/src/app/output/OutputInjectorFactory.cpp
@@ -13,6 +13,7 @@
 #include "Win32SendInputInjector.h"
 #include "RichEditEmReplaceSelInjector.h"
 #include "SplitDispatchInjector.h"
+#include "ClipboardInjector.h"
 
 namespace NextKey::Output {
 
@@ -32,10 +33,15 @@ WindowClassification ClassifyWindow(HWND /*hwnd*/) noexcept {
 std::shared_ptr<IOutputInjector> Create(
         const WindowClassification& c) noexcept {
     // Priority order:
-    //   if c.isRichEditD2DPT  → RichEditEmReplaceSelInjector  [D2]
-    //   if c.isElectron       → SplitDispatchInjector(6)       [D3]
-    //   if c.isConsole        → SplitDispatchInjector(5)       [D3]
-    //   default               → Win32SendInputInjector(c.isChromium)
+    //   if c.useClipboard    → ClipboardInjector              [Sprint 2 follow-up]
+    //   if c.isRichEditD2DPT → RichEditEmReplaceSelInjector  [D2]
+    //   if c.isElectron      → SplitDispatchInjector(6)       [D3]
+    //   if c.isConsole       → SplitDispatchInjector(5)       [D3]
+    //   default              → Win32SendInputInjector(c.isChromium)
+    
+    if (c.useClipboard) {
+        return std::make_shared<ClipboardInjector>();
+    }
     if (c.isRichEditD2DPT) {
         return std::make_shared<RichEditEmReplaceSelInjector>();
     }

--- a/src/app/output/OutputInjectorFactory.h
+++ b/src/app/output/OutputInjectorFactory.h
@@ -21,6 +21,7 @@ struct WindowClassification {
     bool isElectron      = false;  // Discord / Slack / VSCode etc
     bool isConsole       = false;  // CMD / PowerShell
     bool isChromium      = false;  // Chrome / Edge — bait-char hint
+    bool useClipboard    = false;  // User configured clipboard fallback
 };
 
 // Phase 1 — classify focused window. No shared writes.

--- a/src/app/system/HookEngine.cpp
+++ b/src/app/system/HookEngine.cpp
@@ -2489,11 +2489,14 @@ void HookEngine::ReloadAppOverrides() {
     auto overrides = ConfigManager::LoadAppOverrides(ConfigManager::GetConfigPath());
     appEncodingOverrides_.clear();
     appInputMethodOverrides_.clear();
+    appSendMethodOverrides_.clear();
     for (auto& [exe, entry] : overrides) {
         if (entry.encodingOverride >= 0)
             appEncodingOverrides_[exe] = entry.encodingOverride;
         if (entry.inputMethod >= 0)
             appInputMethodOverrides_[exe] = entry.inputMethod;
+        if (entry.sendMethod >= 0)
+            appSendMethodOverrides_[exe] = entry.sendMethod;
     }
 }
 
@@ -2704,11 +2707,19 @@ void HookEngine::OnFocusChanged(HWND triggerHwnd) {
     bool localNeedBait = isBrowser;
     bool localClipboard = isVB6;
     bool localEditMsg = false;
+    bool localUseClipboardInjector = false;
+
+    std::wstring exeName = GetExeNameForHwnd(activeHwnd);
+    if (!exeName.empty()) {
+        auto it = appSendMethodOverrides_.find(exeName);
+        if (it != appSendMethodOverrides_.end()) {
+            if (it->second == 1) localUseClipboardInjector = true;
+        }
+    }
 
     // Normal apps: check for GPU-rendered or apps needing bait (Excel, Outlook)
     bool isWebView2 = false;
     if (!localSkipEmpty && !localNeedBait && !localClipboard) {
-        std::wstring exeName = GetExeNameForHwnd(activeHwnd);
         if (!exeName.empty()) {
             if (_wcsicmp(exeName.c_str(), L"zed.exe") == 0) {
                 localSkipEmpty = true;
@@ -2766,12 +2777,13 @@ void HookEngine::OnFocusChanged(HWND triggerHwnd) {
         c.isElectron      = localElectronApp;
         c.isConsole       = localConsole;
         c.isChromium      = localNeedBait;  // bait-char hint (Chromium autocomplete-dismiss)
+        c.useClipboard    = localUseClipboardInjector;
         injector_.store(NextKey::Output::Create(c), std::memory_order_release);
     }
 
-    HOOK_LOG(L"  AppDetect: console=%d skipEmpty=%d electron=%d webview2=%d bait=%d clipboard=%d editMsg=%d",
+    HOOK_LOG(L"  AppDetect: console=%d skipEmpty=%d electron=%d webview2=%d bait=%d clipboard=%d editMsg=%d useClipInj=%d",
              localConsole ? 1 : 0, localSkipEmpty ? 1 : 0, localElectronApp ? 1 : 0,
-             isWebView2 ? 1 : 0, localNeedBait ? 1 : 0, localClipboard ? 1 : 0, localEditMsg ? 1 : 0);
+             isWebView2 ? 1 : 0, localNeedBait ? 1 : 0, localClipboard ? 1 : 0, localEditMsg ? 1 : 0, localUseClipboardInjector ? 1 : 0);
 
     // Re-install hooks to guarantee NexusKey remains at the top of the hook chain.
     // We only do this for Chromium-based architectures (Electron, WebView2, Browsers)

--- a/src/app/system/HookEngine.h
+++ b/src/app/system/HookEngine.h
@@ -360,6 +360,7 @@ private:
     CodeTable currentCodeTable_ = CodeTable::Unicode;
     CodeTable globalCodeTable_ = CodeTable::Unicode;     // config value, restored when no override
     std::unordered_map<std::wstring, int8_t> appEncodingOverrides_;   // exe → encoding override (-1=inherit)
+    std::unordered_map<std::wstring, int8_t> appSendMethodOverrides_; // exe → send method override (-1=inherit)
     InputMethod globalInputMethod_ = InputMethod::Telex; // config value, restored when no override
     std::unordered_map<std::wstring, int8_t> appInputMethodOverrides_; // exe → method override (-1=inherit)
 

--- a/src/app/ui/appoverrides/appoverrides.css
+++ b/src/app/ui/appoverrides/appoverrides.css
@@ -112,15 +112,20 @@
 .list-col-name {
     flex: 1;
     min-width: 0;
-    max-width: 100px;
+    max-width: 80px;
 }
 
 .list-col-inputmethod {
-    width: 80px;
+    width: 60px;
     text-align: center;
 }
 
 .list-col-encoding {
+    width: 60px;
+    text-align: center;
+}
+
+.list-col-sendmethod {
     width: 65px;
     text-align: center;
 }
@@ -156,7 +161,7 @@
 .app-item-name {
     flex: 1;
     min-width: 0;
-    max-width: 100px;
+    max-width: 80px;
     font-size: 12px;
     font-weight: 500;
     color: var(--text-primary);
@@ -167,13 +172,20 @@
 }
 
 .app-item-inputmethod {
-    width: 80px;
+    width: 60px;
     font-size: 11px;
     text-align: center;
     color: var(--text-secondary);
 }
 
 .app-item-encoding {
+    width: 60px;
+    font-size: 11px;
+    text-align: center;
+    color: var(--text-secondary);
+}
+
+.app-item-sendmethod {
     width: 65px;
     font-size: 11px;
     text-align: center;

--- a/src/app/ui/appoverrides/appoverrides.html
+++ b/src/app/ui/appoverrides/appoverrides.html
@@ -57,19 +57,29 @@
                 <div class="setting-row">
                     <span class="setting-label" data-i18n="ao.input_method">Kiểu gõ</span>
                     <select class="setting-select" id="input-method">
+                        <option value="-1">Mặc định</option>
                         <option value="0">Telex</option>
                         <option value="1">VNI</option>
                         <option value="2">Simple Telex</option>
+                        <option value="3">Telex + VNI</option>
                     </select>
                 </div>
                 <div class="setting-row">
                     <span class="setting-label" data-i18n="ao.encoding">Bảng mã</span>
                     <select class="setting-select" id="encoding-override">
+                        <option value="-1">Mặc định</option>
                         <option value="0">Unicode</option>
                         <option value="1">TCVN3</option>
                         <option value="2">VNI Windows</option>
                         <option value="3">Unicode hợp thành</option>
                         <option value="4">Vietnamese Locale</option>
+                    </select>
+                </div>
+                <div class="setting-row">
+                    <span class="setting-label" data-i18n="ao.send_method">Kiểu gửi</span>
+                    <select class="setting-select" id="send-method">
+                        <option value="-1">Mặc định</option>
+                        <option value="1">Clipboard</option>
                     </select>
                 </div>
                 <div class="button-row">
@@ -85,6 +95,7 @@
                     <span class="list-col-name" data-i18n="ao.list_app">Ứng dụng</span>
                     <span class="list-col-inputmethod" data-i18n="ao.list_method">Kiểu gõ</span>
                     <span class="list-col-encoding" data-i18n="ao.list_encoding">Bảng mã</span>
+                    <span class="list-col-sendmethod" data-i18n="ao.list_sendmethod">Kiểu gửi</span>
                     <span class="list-col-action"></span>
                 </div>
                 <div class="app-list" id="app-list">
@@ -98,6 +109,7 @@
         <input type="hidden" id="val-app-name" value="">
         <input type="hidden" id="val-input-method" value="0">
         <input type="hidden" id="val-encoding-override" value="0">
+        <input type="hidden" id="val-send-method" value="-1">
     </div>
 </body>
 

--- a/src/app/ui/appoverrides/appoverrides.js
+++ b/src/app/ui/appoverrides/appoverrides.js
@@ -10,19 +10,25 @@ document.ready = function () {
 
 // ===== Input Method Labels =====
 var inputMethodLabels = {
-    "-1": "-",
+    "-1": "Mặc định",
     0: "Telex",
     1: "VNI",
-    2: "Simple Telex"
+    2: "Simple Telex",
+    3: "Telex + VNI"
 };
 
 var encodingLabels = {
-    "-1": "-",
+    "-1": "Mặc định",
     0: "Unicode",
     1: "TCVN3",
     2: "VNI Win",
     3: "UNI Cmp",
     4: "VN Locale"
+};
+
+var sendMethodLabels = {
+    "-1": "Mặc định",
+    1: "Clipboard"
 };
 
 // ===== Running Apps Dropdown =====
@@ -132,11 +138,13 @@ function onAddApp() {
 
     var inputMethod = document.getElementById("input-method").value;
     var encodingOverride = document.getElementById("encoding-override").value;
+    var sendMethod = document.getElementById("send-method").value;
 
     // Set hidden inputs and trigger action
     document.getElementById("val-app-name").value = appName;
     document.getElementById("val-input-method").value = inputMethod;
     document.getElementById("val-encoding-override").value = encodingOverride;
+    document.getElementById("val-send-method").value = sendMethod;
     triggerAction("add-app");
 }
 
@@ -171,7 +179,7 @@ function clearAppList() {
     if (list) list.innerHTML = "";
 }
 
-function addAppToList(appName, inputMethod, encodingOverride) {
+function addAppToList(appName, inputMethod, encodingOverride, sendMethod) {
     var list = document.getElementById("app-list");
     if (!list) return;
 
@@ -200,6 +208,13 @@ function addAppToList(appName, inputMethod, encodingOverride) {
     encodingSpan.textContent = encodingLabels[encKey] || "-";
     item.appendChild(encodingSpan);
 
+    // SendMethod column
+    var sendSpan = document.createElement("span");
+    sendSpan.className = "app-item-sendmethod";
+    var sndKey = (sendMethod === undefined || sendMethod === null) ? "-1" : String(sendMethod);
+    sendSpan.textContent = sendMethodLabels[sndKey] || "-";
+    item.appendChild(sendSpan);
+
     // Delete button (uses event delegation, no inline handler)
     var deleteBtn = document.createElement("button");
     deleteBtn.className = "app-item-delete";
@@ -226,10 +241,13 @@ function clearInput() {
     if (input) input.value = "";
 
     var methodSelect = document.getElementById("input-method");
-    if (methodSelect) methodSelect.value = "0";
+    if (methodSelect) methodSelect.value = "-1";
 
     var encodingSelect = document.getElementById("encoding-override");
-    if (encodingSelect) encodingSelect.value = "0";
+    if (encodingSelect) encodingSelect.value = "-1";
+
+    var sendSelect = document.getElementById("send-method");
+    if (sendSelect) sendSelect.value = "-1";
 }
 
 function forceRefresh(scrollToBottom) {

--- a/src/core/config/ConfigManager.cpp
+++ b/src/core/config/ConfigManager.cpp
@@ -576,6 +576,7 @@ std::unordered_map<std::wstring, AppOverrideEntry> ConfigManager::LoadAppOverrid
                     AppOverrideEntry e;
                     e.inputMethod = static_cast<int8_t>((*entry)["input_method"].value_or(-1));
                     e.encodingOverride = static_cast<int8_t>((*entry)["encoding"].value_or(-1));
+                    e.sendMethod = static_cast<int8_t>((*entry)["send_method"].value_or(-1));
                     data[Utf8ToWide(std::string(key.str()))] = e;
                 }
             }
@@ -596,6 +597,7 @@ bool ConfigManager::SaveAppOverrides(const std::wstring& path,
             toml::table entry;
             entry.insert_or_assign("input_method", static_cast<int64_t>(e.inputMethod));
             entry.insert_or_assign("encoding", static_cast<int64_t>(e.encodingOverride));
+            entry.insert_or_assign("send_method", static_cast<int64_t>(e.sendMethod));
             section.insert_or_assign(WideToUtf8(exe), std::move(entry));
         }
         tbl.insert_or_assign("app_overrides", std::move(section));

--- a/src/core/config/ConfigManager.h
+++ b/src/core/config/ConfigManager.h
@@ -17,6 +17,7 @@ namespace NextKey {
 struct AppOverrideEntry {
     int8_t inputMethod = -1;       // -1=inherit global, 0=Telex, 1=VNI, 2=SimpleTelex
     int8_t encodingOverride = -1;  // -1=inherit global, 0-4=CodeTable value
+    int8_t sendMethod = -1;        // -1=inherit, 0=SendInput, 1=Clipboard
 };
 
 /// Manages loading and saving of configuration from TOML file


### PR DESCRIPTION
## Summary

New `ClipboardInjector` writes the IME's transformed Vietnamese text via clipboard + Ctrl+V instead of `SendInput` for apps where SendInput-based injection is unreliable. Opt-in per-app via the `send_method` field in TOML `[app_overrides]` (`-1`=inherit, `0`=SendInput, `1`=Clipboard).

## Behavior

- Save existing clipboard CF_UNICODETEXT before first injection per word.
- Write transformed text + Ctrl+V (with `ExcludeClipboardContentFromMonitor` flag to keep out of Win Clipboard History).
- 200ms lazy-restore timer fires after the LAST injection of the word; immediate fallback restore if SetTimer fails.
- Other clipboard formats (images, RTF) are lost across the cycle — acceptable trade-off for opt-in flow.

## UI

- Sciter `AppOverridesDialog`: new 4th column 'Kiểu gửi'; `addEntry` extended to 4-arg with `sendMethod`.
- Classic `ClassicAppOverridesDialog`: same 4th column + combobox, dialog kHeight 295 → 330.
- 'Telex + VNI' added as a 4th input method label.

## Review fixes applied (CODING_RULES + nexuskey-security)

- `SetClipboardData` failure paths now `GlobalFree(hMem)` per Win32 ownership semantics (3 sites).
- File-scope state moved into anonymous namespace with single-instance assumption documented.
- WHY comments on:
  - `Sleep(15)` — load-bearing for paste settle, sized to fit under LL hook 300ms timeout budget.
  - `OpenClipboard` blocking risk on hook hot path — acceptable for opt-in per-app flow.
  - 3rd-party clipboard listeners can still see injection (security note).

## Test plan

- [x] Linux GTest: 1569 / 1569 PASS (ClipboardInjector.cpp gated by `if(WIN32)` in test target — Linux excludes it correctly).
- [ ] Windows manual smoke: per-app override settings → toggle 'Clipboard' for a target app → verify Ctrl+V flow + clipboard restore (anh runs locally).
- [ ] Open follow-up: ClipboardInjector test mock (clipboard global state needs a mock layer).