### PR TITLE
chore: AGPL source headers + internal/ README polish

### DIFF
--- a/src/app/classic/ClassicAppOverridesDialog.cpp
+++ b/src/app/classic/ClassicAppOverridesDialog.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — App Overrides Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicAppOverridesDialog.h"
 #include "core/CrashLog.h"

--- a/src/app/classic/ClassicAppOverridesDialog.h
+++ b/src/app/classic/ClassicAppOverridesDialog.h
@@ -1,5 +1,5 @@
 // VKey Classic — App Overrides Dialog
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicConvertToolDialog.cpp
+++ b/src/app/classic/ClassicConvertToolDialog.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — Convert Tool Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicConvertToolDialog.h"
 #include "ClassicHotkeyCapture.h"

--- a/src/app/classic/ClassicConvertToolDialog.h
+++ b/src/app/classic/ClassicConvertToolDialog.h
@@ -1,5 +1,5 @@
 // VKey Classic — Convert Tool Dialog
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicDialogUtils.h
+++ b/src/app/classic/ClassicDialogUtils.h
@@ -1,6 +1,6 @@
 // VKey Classic — Shared dialog utilities
 // Process enumeration, window picking, file dialogs
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicExcludedAppsDialog.cpp
+++ b/src/app/classic/ClassicExcludedAppsDialog.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — Excluded Apps Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicExcludedAppsDialog.h"
 #include "core/config/ConfigManager.h"

--- a/src/app/classic/ClassicExcludedAppsDialog.h
+++ b/src/app/classic/ClassicExcludedAppsDialog.h
@@ -1,5 +1,5 @@
 // VKey Classic — Excluded Apps Dialog
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicHotkeyCapture.cpp
+++ b/src/app/classic/ClassicHotkeyCapture.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — Shared hotkey capture modal implementation.
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicHotkeyCapture.h"
 

--- a/src/app/classic/ClassicHotkeyCapture.h
+++ b/src/app/classic/ClassicHotkeyCapture.h
@@ -1,7 +1,7 @@
 // VKey Classic — Shared hotkey capture modal. Used by ClassicHotkeysDialog
 // (full feature: double-tap, modifier-alone) and ClassicConvertToolDialog
 // (combo-only: a chord that includes a non-modifier key).
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicHotkeysDialog.cpp
+++ b/src/app/classic/ClassicHotkeysDialog.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — Unified Hotkey Rebind Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicHotkeysDialog.h"
 

--- a/src/app/classic/ClassicHotkeysDialog.h
+++ b/src/app/classic/ClassicHotkeysDialog.h
@@ -1,5 +1,5 @@
 // VKey Classic — Unified Hotkey Rebind Dialog
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicIconColorDialog.cpp
+++ b/src/app/classic/ClassicIconColorDialog.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — Icon Color Customization Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicIconColorDialog.h"
 #include "helpers/AppHelpers.h"

--- a/src/app/classic/ClassicIconColorDialog.h
+++ b/src/app/classic/ClassicIconColorDialog.h
@@ -1,5 +1,5 @@
 // VKey Classic — Icon Color Customization Dialog
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicMacroTableDialog.cpp
+++ b/src/app/classic/ClassicMacroTableDialog.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — Macro Table Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicMacroTableDialog.h"
 #include "core/config/ConfigManager.h"

--- a/src/app/classic/ClassicMacroTableDialog.h
+++ b/src/app/classic/ClassicMacroTableDialog.h
@@ -1,5 +1,5 @@
 // VKey Classic — Macro Table Dialog
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicSettingsDialog.cpp
+++ b/src/app/classic/ClassicSettingsDialog.cpp
@@ -1,6 +1,6 @@
 // VKey Classic — Settings Dialog Implementation
 // Compact (Unikey-style) + Advanced (EVKey-style) modes
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicSettingsDialog.h"
 #include "helpers/AppHelpers.h"

--- a/src/app/classic/ClassicSettingsDialog.h
+++ b/src/app/classic/ClassicSettingsDialog.h
@@ -1,6 +1,6 @@
 // VKey Classic — Settings Dialog
 // Compact (Unikey-style) + Advanced (EVKey-style) modes
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicSpellExclusionsDialog.cpp
+++ b/src/app/classic/ClassicSpellExclusionsDialog.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — Spell Check Exclusions Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicSpellExclusionsDialog.h"
 #include "core/config/ConfigManager.h"

--- a/src/app/classic/ClassicSpellExclusionsDialog.h
+++ b/src/app/classic/ClassicSpellExclusionsDialog.h
@@ -1,5 +1,5 @@
 // VKey Classic — Spell Check Exclusions Dialog
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicTheme.cpp
+++ b/src/app/classic/ClassicTheme.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — Native Windows Theme Engine
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicTheme.h"
 #include "DarkModeHelper.h"

--- a/src/app/classic/ClassicTheme.h
+++ b/src/app/classic/ClassicTheme.h
@@ -1,5 +1,5 @@
 // VKey Classic — Native Windows Theme Engine
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicTsfAppsDialog.cpp
+++ b/src/app/classic/ClassicTsfAppsDialog.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — TSF Apps Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicTsfAppsDialog.h"
 #include "core/config/ConfigManager.h"

--- a/src/app/classic/ClassicTsfAppsDialog.h
+++ b/src/app/classic/ClassicTsfAppsDialog.h
@@ -1,5 +1,5 @@
 // VKey Classic — TSF Apps Dialog
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/ClassicUserDefinedDialog.cpp
+++ b/src/app/classic/ClassicUserDefinedDialog.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — User Defined Input Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ClassicUserDefinedDialog.h"
 #include "core/config/ConfigManager.h"

--- a/src/app/classic/ClassicUserDefinedDialog.h
+++ b/src/app/classic/ClassicUserDefinedDialog.h
@@ -1,5 +1,5 @@
 // VKey Classic — User Defined Input Dialog Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/classic/resource.h
+++ b/src/app/classic/resource.h
@@ -1,5 +1,5 @@
 // VKey Classic UI — Control IDs
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/AboutDialog.cpp
+++ b/src/app/dialogs/AboutDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - About Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "AboutDialog.h"
 

--- a/src/app/dialogs/AboutDialog.h
+++ b/src/app/dialogs/AboutDialog.h
@@ -1,5 +1,5 @@
 // VKey - About Dialog Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/AppOverridesDialog.cpp
+++ b/src/app/dialogs/AppOverridesDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - App Overrides Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "AppOverridesDialog.h"
 #include "helpers/AppHelpers.h"

--- a/src/app/dialogs/AppOverridesDialog.h
+++ b/src/app/dialogs/AppOverridesDialog.h
@@ -1,5 +1,5 @@
 // VKey - App Overrides Dialog Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/ConvertToolDialog.cpp
+++ b/src/app/dialogs/ConvertToolDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - Convert Tool Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ConvertToolDialog.h"
 #include "core/engine/CodeTableConverter.h"

--- a/src/app/dialogs/ConvertToolDialog.h
+++ b/src/app/dialogs/ConvertToolDialog.h
@@ -1,5 +1,5 @@
 // VKey - Convert Tool Dialog Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/DialogUtils.h
+++ b/src/app/dialogs/DialogUtils.h
@@ -1,5 +1,5 @@
 // VKey - Shared file dialog helpers
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/ExcludedAppsDialog.cpp
+++ b/src/app/dialogs/ExcludedAppsDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - Excluded Apps Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ExcludedAppsDialog.h"
 #include "DialogUtils.h"

--- a/src/app/dialogs/ExcludedAppsDialog.h
+++ b/src/app/dialogs/ExcludedAppsDialog.h
@@ -1,5 +1,5 @@
 // VKey - Excluded Apps Dialog Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/HotkeysDialog.cpp
+++ b/src/app/dialogs/HotkeysDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - Unified Hotkey Rebind Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "HotkeysDialog.h"
 

--- a/src/app/dialogs/HotkeysDialog.h
+++ b/src/app/dialogs/HotkeysDialog.h
@@ -1,5 +1,5 @@
 // VKey - Unified Hotkey Rebind Dialog Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/MacroTableDialog.cpp
+++ b/src/app/dialogs/MacroTableDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - Macro Table Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "MacroTableDialog.h"
 #include "DialogUtils.h"

--- a/src/app/dialogs/MacroTableDialog.h
+++ b/src/app/dialogs/MacroTableDialog.h
@@ -1,5 +1,5 @@
 // VKey - Macro Table Dialog Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/SciterSubDialog.cpp
+++ b/src/app/dialogs/SciterSubDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - Sciter SubDialog Base Class Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "SciterSubDialog.h"
 #include "../resource.h"

--- a/src/app/dialogs/SciterSubDialog.h
+++ b/src/app/dialogs/SciterSubDialog.h
@@ -1,5 +1,5 @@
 // VKey - Sciter SubDialog Base Class
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Base class for simple Sciter subdialogs that run as subprocesses.
 // Extracts all common boilerplate: resource loading, window setup,

--- a/src/app/dialogs/SettingsDialog.cpp
+++ b/src/app/dialogs/SettingsDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - Settings Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "SettingsDialog.h"
 #include "../resource.h"

--- a/src/app/dialogs/SettingsDialog.h
+++ b/src/app/dialogs/SettingsDialog.h
@@ -1,5 +1,5 @@
 // VKey - Settings Dialog Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/SpellExclusionsDialog.cpp
+++ b/src/app/dialogs/SpellExclusionsDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - Spell Check Exclusions Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "SpellExclusionsDialog.h"
 #include "helpers/AppHelpers.h"

--- a/src/app/dialogs/SpellExclusionsDialog.h
+++ b/src/app/dialogs/SpellExclusionsDialog.h
@@ -1,5 +1,5 @@
 // VKey - Spell Check Exclusions Dialog Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/SubDialogConfig.h
+++ b/src/app/dialogs/SubDialogConfig.h
@@ -1,5 +1,5 @@
 // VKey - SubDialog Configuration
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/TsfAppsDialog.cpp
+++ b/src/app/dialogs/TsfAppsDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - TSF Apps Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "TsfAppsDialog.h"
 #include "DialogUtils.h"

--- a/src/app/dialogs/TsfAppsDialog.h
+++ b/src/app/dialogs/TsfAppsDialog.h
@@ -1,5 +1,5 @@
 // VKey - TSF Apps Dialog Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/UserDefinedDialog.cpp
+++ b/src/app/dialogs/UserDefinedDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - User Defined Input Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "UserDefinedDialog.h"
 #include "DialogUtils.h"

--- a/src/app/dialogs/UserDefinedDialog.h
+++ b/src/app/dialogs/UserDefinedDialog.h
@@ -1,5 +1,5 @@
 // VKey - User Defined Input Dialog Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/dialogs/WindowPickerDialog.cpp
+++ b/src/app/dialogs/WindowPickerDialog.cpp
@@ -1,5 +1,5 @@
 // VKey - Window Picker Base Dialog Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "WindowPickerDialog.h"
 #include "helpers/AppHelpers.h"

--- a/src/app/dialogs/WindowPickerDialog.h
+++ b/src/app/dialogs/WindowPickerDialog.h
@@ -1,5 +1,5 @@
 // VKey - Window Picker Base Dialog
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Base class for app-list dialogs that support window picking and
 // running-app enumeration. Eliminates duplicate code across

--- a/src/app/helpers/AppHelpers.h
+++ b/src/app/helpers/AppHelpers.h
@@ -1,5 +1,5 @@
 // VKey - App-Layer Helper Functions
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1,5 +1,5 @@
 // VKey - Core Application Entry Point
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "system/TrayIcon.h"
 #include "system/FloatingIcon.h"

--- a/src/app/main_lite.cpp
+++ b/src/app/main_lite.cpp
@@ -1,5 +1,5 @@
 // VKey Classic — Lite build entry point
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Simplified entry point for the Classic (Win32 native) UI build.
 // No Sciter dependency. Uses HookEngine + TrayIcon + ClassicSettingsDialog.

--- a/src/app/resource.h
+++ b/src/app/resource.h
@@ -1,5 +1,5 @@
 // VKey - Resource Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/sciter/ScaleHelper.h
+++ b/src/app/sciter/ScaleHelper.h
@@ -1,5 +1,5 @@
 // VKey - DPI & Resolution Scale Helper
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Utility for scaling dialog sizes based on DPI and screen resolution.
 // Ensures UI looks correct across different monitors and DPI settings.

--- a/src/app/sciter/SciterArchive.cpp
+++ b/src/app/sciter/SciterArchive.cpp
@@ -1,5 +1,5 @@
 // VKey - Sciter Archive Resource Binding
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // This file includes the packfolder-generated resources and provides
 // a single binding function. Only include resources.cpp here to avoid

--- a/src/app/sciter/SciterArchive.h
+++ b/src/app/sciter/SciterArchive.h
@@ -1,5 +1,5 @@
 // VKey - Sciter Archive Resource Binding
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/sciter/SciterHelper.cpp
+++ b/src/app/sciter/SciterHelper.cpp
@@ -1,5 +1,5 @@
 // VKey - Sciter Window Helper Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "SciterHelper.h"
 #include "system/DarkModeHelper.h"

--- a/src/app/sciter/SciterHelper.h
+++ b/src/app/sciter/SciterHelper.h
@@ -1,5 +1,5 @@
 // VKey - Sciter Window Helper
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Utilities for Sciter window effects: DWM blur, acrylic, window dragging.
 // Dark mode utilities are in system/DarkModeHelper.h

--- a/src/app/system/AdaptiveTick.h
+++ b/src/app/system/AdaptiveTick.h
@@ -1,5 +1,5 @@
 // AdaptiveTick.h - idle-backoff cadence for MainThreadWorker.
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Pure C++, Linux-portable. Maps "milliseconds since last user activity"
 // to the desired MainThreadWorker tick interval. Used by

--- a/src/app/system/CommitState.h
+++ b/src/app/system/CommitState.h
@@ -1,5 +1,5 @@
 // VKey - Commit State (Wave 3 PR 3.4, 2026-05-24)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Owns the per-word commit / undo state machine extracted from HookEngine:
 //   * State enum: Idle → Ready → Primed FSM

--- a/src/app/system/DarkModeHelper.cpp
+++ b/src/app/system/DarkModeHelper.cpp
@@ -1,5 +1,5 @@
 // VKey - Win32 Dark Mode Helper Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "DarkModeHelper.h"
 #include <dwmapi.h>

--- a/src/app/system/DarkModeHelper.h
+++ b/src/app/system/DarkModeHelper.h
@@ -1,5 +1,5 @@
 // VKey - Win32 Dark Mode Helper
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Pure Win32 utilities for dark mode detection and application.
 // No Sciter dependency — safe for LITE_MODE builds.

--- a/src/app/system/DebugLogWarning.h
+++ b/src/app/system/DebugLogWarning.h
@@ -1,5 +1,5 @@
 // VKey - Debug Log enable-confirmation popup
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Shown when the user clicks the "Bật debug log" toggle to ON in either UI
 // (Modern Sciter, Classic Win32). The log captures raw key events and may

--- a/src/app/system/FloatingIcon.cpp
+++ b/src/app/system/FloatingIcon.cpp
@@ -1,5 +1,5 @@
 // VKey - Floating V/E Icon Overlay Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Pure GDI + direct pixel math — no GDI+ dependency.
 // Draggable via WM_NCHITTEST → HTCAPTION.

--- a/src/app/system/FloatingIcon.h
+++ b/src/app/system/FloatingIcon.h
@@ -1,5 +1,5 @@
 // VKey - Floating V/E Icon Overlay
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/system/FocusOwner.cpp
+++ b/src/app/system/FocusOwner.cpp
@@ -1,5 +1,5 @@
 // VKey - Focus Owner Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "FocusOwner.h"
 #include "HookLifecycle.h"  // REINSTALL_REASON_CHROMIUM / _JAVA

--- a/src/app/system/FocusOwner.h
+++ b/src/app/system/FocusOwner.h
@@ -1,5 +1,5 @@
 // VKey - Focus Owner (Wave 3 PR 3.2, 2026-05-24)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Owns the focus-tracking subsystem extracted from HookEngine:
 //   * WinEvent hooks (EVENT_SYSTEM_FOREGROUND + EVENT_SYSTEM_MINIMIZEEND)

--- a/src/app/system/HeartbeatPublisher.cpp
+++ b/src/app/system/HeartbeatPublisher.cpp
@@ -1,5 +1,5 @@
 // VKey - Heartbeat Publisher Implementation (Windows-only)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "HeartbeatPublisher.h"
 

--- a/src/app/system/HeartbeatPublisher.h
+++ b/src/app/system/HeartbeatPublisher.h
@@ -1,5 +1,5 @@
 // VKey - Heartbeat Publisher (Windows-only)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Publishes a 30s heartbeat to a named event so VKeyWatchdog.exe
 // can detect process liveness. Also publishes a graceful-shutdown flag

--- a/src/app/system/HookCommandMailbox.cpp
+++ b/src/app/system/HookCommandMailbox.cpp
@@ -1,5 +1,5 @@
 // VKey - Hook command mailbox impl (Phase 2a)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // See HookCommandMailbox.h for the design contract. This .cpp is
 // intentionally minimal — all the load-bearing logic is the memory-order

--- a/src/app/system/HookCommandMailbox.h
+++ b/src/app/system/HookCommandMailbox.h
@@ -1,5 +1,5 @@
 // VKey - Hook command mailbox (Phase 2a — single-writer composition state)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Phase 2 of the 2026-05-19 architecture review design
 // (docs/plans/2026-05-19-architecture-review-design.md §Phase 2).

--- a/src/app/system/HookEngine.cpp
+++ b/src/app/system/HookEngine.cpp
@@ -1,5 +1,5 @@
 // VKey - Keyboard Hook Engine Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "HookEngine.h"
 #include "HotkeyManager.h"  // Wave 1 — DispatchHotkeyFromHookThread

--- a/src/app/system/HookEngine.h
+++ b/src/app/system/HookEngine.h
@@ -1,5 +1,5 @@
 // VKey - Keyboard Hook Engine
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Single-process Vietnamese input using WH_KEYBOARD_LL.
 // Replaces TSF DLL for MVP — no COM registration, no admin elevation.

--- a/src/app/system/HookLifecycle.cpp
+++ b/src/app/system/HookLifecycle.cpp
@@ -1,5 +1,5 @@
 // VKey - Hook Lifecycle Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "HookLifecycle.h"
 #include "HotkeyManager.h"  // WM_APP_HOTKEY_FIRED + DispatchHotkeyFromHookThread

--- a/src/app/system/HookLifecycle.h
+++ b/src/app/system/HookLifecycle.h
@@ -1,5 +1,5 @@
 // VKey - Hook Lifecycle (Wave 3 PR 3.1, 2026-05-23)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Owns the dedicated WH_KEYBOARD_LL + WH_MOUSE_LL hook thread, the HHOOK
 // handles, the mailbox wake-up plumbing, and the start-time handshake CV.

--- a/src/app/system/HotkeyManager.cpp
+++ b/src/app/system/HotkeyManager.cpp
@@ -1,5 +1,5 @@
 // VKey - Hotkey Manager Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "HotkeyManager.h"
 #include "HookEngine.h"  // VKEY_EXTRA_INFO tag

--- a/src/app/system/HotkeyManager.h
+++ b/src/app/system/HotkeyManager.h
@@ -1,5 +1,5 @@
 // VKey - Hotkey Manager
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/system/HotkeyWiring.cpp
+++ b/src/app/system/HotkeyWiring.cpp
@@ -1,5 +1,5 @@
 // VKey - Hotkey Wiring Helper Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "HotkeyWiring.h"
 #include "HookEngine.h"

--- a/src/app/system/HotkeyWiring.h
+++ b/src/app/system/HotkeyWiring.h
@@ -1,5 +1,5 @@
 // VKey - Hotkey Wiring Helper
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/system/MainThreadWorker.cpp
+++ b/src/app/system/MainThreadWorker.cpp
@@ -1,5 +1,5 @@
 // VKey - MainThreadWorker
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // See MainThreadWorker.h for the Phase C plan.
 

--- a/src/app/system/MainThreadWorker.h
+++ b/src/app/system/MainThreadWorker.h
@@ -1,5 +1,5 @@
 // VKey - MainThreadWorker
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Sprint 1 Phase C — single home for non-hot-path work that previously
 // executed on the hook thread (config reload, focus poll, heartbeat,

--- a/src/app/system/OutputDispatcher.cpp
+++ b/src/app/system/OutputDispatcher.cpp
@@ -1,5 +1,5 @@
 // VKey - Output Dispatcher (Wave 3 PR 3.3, 2026-05-24)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "OutputDispatcher.h"
 

--- a/src/app/system/OutputDispatcher.h
+++ b/src/app/system/OutputDispatcher.h
@@ -1,5 +1,5 @@
 // VKey - Output Dispatcher (Wave 3 PR 3.3, 2026-05-24)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Owns the output-dispatch subsystem extracted from HookEngine:
 //   * IOutputInjector RCU publish (active channel — RichEdit / Win32 / Split)

--- a/src/app/system/PendingDllApply.cpp
+++ b/src/app/system/PendingDllApply.cpp
@@ -1,5 +1,5 @@
 // VKey - Apply deferred TSF DLL swap at EXE startup
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "PendingDllApply.h"
 #include "UpdateInstaller.h"              // TSF_DLL_FILENAME, constants, MakeParkedDllTimestamp

--- a/src/app/system/PendingDllApply.h
+++ b/src/app/system/PendingDllApply.h
@@ -1,5 +1,5 @@
 // VKey - Apply deferred TSF DLL swap at EXE startup
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/system/PerfHistogram.cpp
+++ b/src/app/system/PerfHistogram.cpp
@@ -1,5 +1,5 @@
 // VKey - PerfHistogram impl
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // See PerfHistogram.h for the design contract.
 

--- a/src/app/system/PerfHistogram.h
+++ b/src/app/system/PerfHistogram.h
@@ -1,5 +1,5 @@
 // VKey - Per-stage performance histogram
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Phase 1 of the 2026-05-19 architecture review design
 // (docs/plans/2026-05-19-architecture-review-design.md). Captures p50/p95/p99/

--- a/src/app/system/QuickConvert.cpp
+++ b/src/app/system/QuickConvert.cpp
@@ -1,5 +1,5 @@
 // VKey - Quick Convert Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "QuickConvert.h"
 #include "ToastPopup.h"

--- a/src/app/system/QuickConvert.h
+++ b/src/app/system/QuickConvert.h
@@ -1,5 +1,5 @@
 // VKey - Quick Convert (Hotkey-driven text conversion)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/system/StartupHelper.h
+++ b/src/app/system/StartupHelper.h
@@ -1,5 +1,5 @@
 // VKey - Startup Helper (Windows-only)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Manages run-on-startup registration via Registry (normal) or
 // Task Scheduler (admin/elevated). Pattern from OpenKey.

--- a/src/app/system/SubprocessHelper.h
+++ b/src/app/system/SubprocessHelper.h
@@ -1,5 +1,5 @@
 // VKey - Subprocess Helper
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Shared initialization for Sciter subprocess dialogs + subprocess spawning.
 // Tracks child process handles for cleanup on exit (TerminateProcess).

--- a/src/app/system/SubprocessRunners.cpp
+++ b/src/app/system/SubprocessRunners.cpp
@@ -1,5 +1,5 @@
 // VKey - Subprocess Runner Functions
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "SubprocessRunners.h"
 #include "SubprocessHelper.h"

--- a/src/app/system/SubprocessRunners.h
+++ b/src/app/system/SubprocessRunners.h
@@ -1,5 +1,5 @@
 // VKey - Subprocess Runner Functions
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Each Run*Subprocess() is [[noreturn]] — called from command-line routing
 // in wWinMain, runs a Sciter dialog, then ExitProcess(0).

--- a/src/app/system/ToastPopup.cpp
+++ b/src/app/system/ToastPopup.cpp
@@ -1,5 +1,5 @@
 // VKey - Lightweight Toast Notification Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ToastPopup.h"
 #include "DarkModeHelper.h"

--- a/src/app/system/ToastPopup.h
+++ b/src/app/system/ToastPopup.h
@@ -1,5 +1,5 @@
 // VKey - Lightweight Toast Notification
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/system/TrayIcon.cpp
+++ b/src/app/system/TrayIcon.cpp
@@ -1,5 +1,5 @@
 // VKey - System Tray Icon Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "TrayIcon.h"
 #include "../resource.h"

--- a/src/app/system/TrayIcon.h
+++ b/src/app/system/TrayIcon.h
@@ -1,5 +1,5 @@
 // VKey - System Tray Icon
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/app/system/TsfRegistration.cpp
+++ b/src/app/system/TsfRegistration.cpp
@@ -1,5 +1,5 @@
 // VKey - TSF Registration & Diagnostics
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 // Windows/COM headers MUST come first — <msctf.h> includes <comcat.h>
 // which requires COM base types from <ole2.h>/<objbase.h>

--- a/src/app/system/TsfRegistration.h
+++ b/src/app/system/TsfRegistration.h
@@ -1,5 +1,5 @@
 // VKey - TSF Registration & Diagnostics
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Functions for registering/unregistering the TSF input method DLL,
 // and diagnostic output. Used by EXE to manage DLL registration

--- a/src/app/system/UpdateChecker.cpp
+++ b/src/app/system/UpdateChecker.cpp
@@ -1,5 +1,5 @@
 // VKey - Update Checker Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "UpdateChecker.h"
 #include "UpdateSecurity.h"

--- a/src/app/system/UpdateChecker.h
+++ b/src/app/system/UpdateChecker.h
@@ -1,5 +1,5 @@
 // VKey - Update Checker
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Checks GitHub Releases API for new versions, downloads updates,
 // and shows TaskDialog UI for update notifications.

--- a/src/app/system/UpdateInstaller.cpp
+++ b/src/app/system/UpdateInstaller.cpp
@@ -1,5 +1,5 @@
 // VKey - Self-Update Installer Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "UpdateInstaller.h"
 #include "UpdateSecurity.h"

--- a/src/app/system/UpdateInstaller.h
+++ b/src/app/system/UpdateInstaller.h
@@ -1,5 +1,5 @@
 // VKey - Self-Update Installer
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Handles the --install-update CLI mode: waits for processes to exit,
 // replaces files from ZIP, and relaunches.

--- a/src/app/system/UpdateSecurity.cpp
+++ b/src/app/system/UpdateSecurity.cpp
@@ -1,5 +1,5 @@
 // VKey - Update Security Helpers Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "UpdateSecurity.h"
 

--- a/src/app/system/UpdateSecurity.h
+++ b/src/app/system/UpdateSecurity.h
@@ -1,5 +1,5 @@
 // VKey - Update Security Helpers
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Security hardening for the self-update system:
 // - SHA-256 hash verification of downloaded files (SEC-001)

--- a/src/app/system/WatchdogController.cpp
+++ b/src/app/system/WatchdogController.cpp
@@ -1,5 +1,5 @@
 // VKey - Watchdog Controller implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "system/WatchdogController.h"
 

--- a/src/app/system/WatchdogController.h
+++ b/src/app/system/WatchdogController.h
@@ -1,5 +1,5 @@
 // VKey - Watchdog Controller (Windows-only)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Owns the watchdog lifecycle: heartbeat thread + Task Scheduler entry +
 // VKeyWatchdog.exe child process.

--- a/src/app/system/Win32CaseMapper.h
+++ b/src/app/system/Win32CaseMapper.h
@@ -1,6 +1,6 @@
 // VKey - Win32 locale-aware case mapper for Macro::CaseMapper
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // Production CaseMapper that wraps CharUpperBuffW / CharLowerBuffW.
 // These are locale-aware so Vietnamese diacritics ('ô' ↔ 'Ô') flip

--- a/src/core/AutoCapDecision.h
+++ b/src/core/AutoCapDecision.h
@@ -1,6 +1,6 @@
 // VKey - Auto-Capitalization Decision
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // Pure decision: given a snapshot of text up to (but not including) the
 // caret, classify which "should the next char start fresh" trigger applies.

--- a/src/core/AutoCapStateTransition.h
+++ b/src/core/AutoCapStateTransition.h
@@ -1,6 +1,6 @@
 // VKey - Auto-Capitalization Keystroke State Machine
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // Pure transition function: given the current state and a key event, returns
 // the next state. Used by HookEngine::HandlePreDispatch (step 3a) when there

--- a/src/core/CjkSwitchDecision.h
+++ b/src/core/CjkSwitchDecision.h
@@ -1,5 +1,5 @@
 // VKey - Pure decision function for CJK auto-switch state machine
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Extracted from HookEngine::OnLayoutChanged so the state-machine logic can
 // be unit-tested on Linux (HookEngine.cpp itself is Windows-only).

--- a/src/core/CommitUndoExemption.h
+++ b/src/core/CommitUndoExemption.h
@@ -1,5 +1,5 @@
 // VKey - Commit-undo cancellation exemption rule
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // Pure predicate: given a keystroke, returns true if the key should be
 // EXEMPT from the cancel-Primed branches in

--- a/src/core/CrashLog.cpp
+++ b/src/core/CrashLog.cpp
@@ -1,5 +1,5 @@
 // VKey - Always-on crash exception logger
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "CrashLog.h"
 

--- a/src/core/CrashLog.h
+++ b/src/core/CrashLog.h
@@ -1,5 +1,5 @@
 // VKey - Always-on crash exception logger
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Appends a single-line record to `<exe_dir>\_vkey_crash.log` when an
 // exception reaches a top-level callback / thread entry. Unlike NEXTKEY_LOG

--- a/src/core/Debug.h
+++ b/src/core/Debug.h
@@ -1,5 +1,5 @@
 // VKey - Debug Logging Infrastructure
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Backed by NextKey::Logger — a runtime-gated file sink toggled by the user
 // from Settings → System → "Bật debug log".

--- a/src/core/DigitLedWordDecision.h
+++ b/src/core/DigitLedWordDecision.h
@@ -1,5 +1,5 @@
 // VKey - Pure decision function for "digit-led word" detection
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // A digit-led word is a word that starts with a digit while the input method
 // is VNI / Combined / UserDefined. The entire word — up to the next word

--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -1,5 +1,5 @@
 // VKey - Runtime-gated debug logger
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "core/Logger.h"
 

--- a/src/core/Logger.h
+++ b/src/core/Logger.h
@@ -1,5 +1,5 @@
 // VKey - Runtime-gated debug logger
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Single backend for NEXTKEY_LOG / HOOK_LOG / TSF_LOG. Compiled unconditionally
 // in every build; runtime-gated by an atomic. When disabled, Log() returns

--- a/src/core/MacroCase.cpp
+++ b/src/core/MacroCase.cpp
@@ -1,6 +1,6 @@
 // VKey - Macro expansion decision logic implementation
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 
 #include "core/MacroCase.h"
 

--- a/src/core/MacroCase.h
+++ b/src/core/MacroCase.h
@@ -1,6 +1,6 @@
 // VKey - Macro expansion decision logic
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // Linux-portable macro expansion decision unit. Extracted from
 // HookEngine::TryExpandMacro for unit testability. Win32 case-mapping

--- a/src/core/MacroPrefix.h
+++ b/src/core/MacroPrefix.h
@@ -1,5 +1,5 @@
 // VKey - Macro Phrase-Prefix Matcher
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Pure, platform-free helper used by HookEngine to decide whether a
 // space-terminated word boundary should preserve the macro buffer (because it

--- a/src/core/SmartSwitchManager.cpp
+++ b/src/core/SmartSwitchManager.cpp
@@ -1,5 +1,5 @@
 // VKey - Smart Switch Shared Memory Manager Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "SmartSwitchManager.h"
 

--- a/src/core/SmartSwitchManager.h
+++ b/src/core/SmartSwitchManager.h
@@ -1,5 +1,5 @@
 // VKey - Smart Switch Shared Memory Manager
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/SmartSwitchState.h
+++ b/src/core/SmartSwitchState.h
@@ -1,5 +1,5 @@
 // VKey - Smart Switch Shared Memory State
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Fixed-size struct for shared memory IPC.
 // Stores per-app Vietnamese/English mode using hash-based lookup.

--- a/src/core/Strings.cpp
+++ b/src/core/Strings.cpp
@@ -1,5 +1,5 @@
 // VKey - Localized String Dictionary Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "Strings.h"
 #include <atomic>
@@ -30,7 +30,7 @@ static const wchar_t* const kVietnamese[] = {
     L"Giới thiệu VKey",                          // ABOUT_TITLE
     L"VKey - Bộ gõ Tiếng Việt\n"                 // ABOUT_BODY
     L"Giải pháp gõ Tiếng Việt hiện đại cho Windows.\n\n"
-    L"SPDX-License-Identifier: GPL-3.0-only",
+    L"SPDX-License-Identifier: AGPL-3.0-only",
     L"Cập nhật",                                     // UPDATE_TITLE
     L"Có phiên bản mới!",                            // UPDATE_AVAILABLE_TITLE
     L"Phiên bản mới %s đã sẵn sàng.",               // UPDATE_AVAILABLE_BODY
@@ -95,7 +95,7 @@ static const wchar_t* const kEnglish[] = {
     L"About VKey",                                // ABOUT_TITLE
     L"VKey Vietnamese Input\n"                    // ABOUT_BODY
     L"A modern Vietnamese typing solution for Windows.\n\n"
-    L"SPDX-License-Identifier: GPL-3.0-only",
+    L"SPDX-License-Identifier: AGPL-3.0-only",
     L"Update",                                       // UPDATE_TITLE
     L"Update available!",                            // UPDATE_AVAILABLE_TITLE
     L"Version %s is available.",                     // UPDATE_AVAILABLE_BODY

--- a/src/core/Strings.h
+++ b/src/core/Strings.h
@@ -1,5 +1,5 @@
 // VKey - Localized String Dictionary
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/SystemConfig.h
+++ b/src/core/SystemConfig.h
@@ -1,5 +1,5 @@
 // VKey - System Configuration
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/UIConfig.h
+++ b/src/core/UIConfig.h
@@ -1,5 +1,5 @@
 // VKey - UI Configuration
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/WinStrings.h
+++ b/src/core/WinStrings.h
@@ -1,5 +1,5 @@
 // VKey - Windows UTF-8/Wide String Conversion Utilities
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/config/ConfigEvent.cpp
+++ b/src/core/config/ConfigEvent.cpp
@@ -1,5 +1,5 @@
 // VKey - Config Event Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ConfigEvent.h"
 #include <Windows.h>

--- a/src/core/config/ConfigEvent.h
+++ b/src/core/config/ConfigEvent.h
@@ -1,5 +1,5 @@
 // VKey - Config Event Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/config/ConfigManager.cpp
+++ b/src/core/config/ConfigManager.cpp
@@ -1,5 +1,5 @@
 // VKey - Configuration Manager Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "ConfigManager.h"
 #include "core/Debug.h"

--- a/src/core/config/ConfigManager.h
+++ b/src/core/config/ConfigManager.h
@@ -1,5 +1,5 @@
 // VKey - Configuration Manager
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/config/ConfigSnapshot.h
+++ b/src/core/config/ConfigSnapshot.h
@@ -1,5 +1,5 @@
 // VKey - RCU config snapshot (Phase 3a — config reload out of keydown)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Phase 3 of the 2026-05-19 architecture review design
 // (docs/plans/2026-05-19-architecture-review-design.md §Phase 3).

--- a/src/core/config/ConfigSnapshotBuilder.cpp
+++ b/src/core/config/ConfigSnapshotBuilder.cpp
@@ -1,5 +1,5 @@
 // src/core/config/ConfigSnapshotBuilder.cpp
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // ConfigSnapshotBuilder::BuildFromToml — pure TOML→ConfigSnapshot transform.
 // Lifted from HookEngine::RebuildSnapshotFromToml.

--- a/src/core/config/ConfigSnapshotBuilder.h
+++ b/src/core/config/ConfigSnapshotBuilder.h
@@ -1,5 +1,5 @@
 // src/core/config/ConfigSnapshotBuilder.h
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Pure free function: TOML config file → immutable ConfigSnapshot.
 // Lifted from HookEngine::RebuildSnapshotFromToml (HookEngine.cpp).

--- a/src/core/config/SettingMetadata.h
+++ b/src/core/config/SettingMetadata.h
@@ -1,6 +1,6 @@
 // VKey - Setting Metadata Table
 // Shared mapping for dual-UI (Sciter + Classic Win32) settings binding
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/config/TypingConfig.h
+++ b/src/core/config/TypingConfig.h
@@ -1,5 +1,5 @@
 // VKey - Typing Configuration
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/engine/CodeTableConverter.cpp
+++ b/src/core/engine/CodeTableConverter.cpp
@@ -1,7 +1,7 @@
 // VKey - Code Table Converter Implementation
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 //
 // Mapping tables extracted from OpenKey Vietnamese.cpp _codeTable[0..4].

--- a/src/core/engine/CodeTableConverter.h
+++ b/src/core/engine/CodeTableConverter.h
@@ -1,7 +1,7 @@
 // VKey - Code Table Converter
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 //
 // Converts Unicode Vietnamese characters to legacy encodings

--- a/src/core/engine/DefaultPhonologyRules.h
+++ b/src/core/engine/DefaultPhonologyRules.h
@@ -1,6 +1,6 @@
 // VKey - Default Vietnamese Phonology Rule Pack
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // DefaultPhonologyRules — canonical Vietnamese rule pack reading from
 // VietnamesePhonologyData.h. Singleton via Default(); both phonotactics

--- a/src/core/engine/EngineFactory.cpp
+++ b/src/core/engine/EngineFactory.cpp
@@ -1,7 +1,7 @@
 // VKey - Input Engine Factory Implementation
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 
 #include "EngineFactory.h"

--- a/src/core/engine/EngineFactory.h
+++ b/src/core/engine/EngineFactory.h
@@ -1,7 +1,7 @@
 // VKey - Input Engine Factory
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 
 #pragma once

--- a/src/core/engine/EngineHelpers.h
+++ b/src/core/engine/EngineHelpers.h
@@ -1,7 +1,7 @@
 // VKey - Shared Engine Helper Functions
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 //
 // Template helpers used by TypingEngine (Telex, VNI, and Combined input methods).

--- a/src/core/engine/EnglishProtection.h
+++ b/src/core/engine/EnglishProtection.h
@@ -1,7 +1,7 @@
 // VKey - English Protection Module (Header-Only)
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 //
 // 3-Tier English Protection System:

--- a/src/core/engine/IInputEngine.h
+++ b/src/core/engine/IInputEngine.h
@@ -1,7 +1,7 @@
 // VKey - Input Engine Interface
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 
 #pragma once

--- a/src/core/engine/IPhonologyRules.h
+++ b/src/core/engine/IPhonologyRules.h
@@ -1,6 +1,6 @@
 // VKey - Vietnamese Phonology Rule-Pack Contract
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // IPhonologyRules — pluggable rule-data provider for Vietnamese phonotactics.
 //

--- a/src/core/engine/IPhonotactics.h
+++ b/src/core/engine/IPhonotactics.h
@@ -1,6 +1,6 @@
 // VKey - Vietnamese Phonotactics Interface
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // IPhonotactics — pure rule engine for Vietnamese syllable phonotactics.
 // Encodes RuleTiengViet rules: N1/N2/N3 vowel-coda groups, tone position,

--- a/src/core/engine/PhonologyRulePackFactory.h
+++ b/src/core/engine/PhonologyRulePackFactory.h
@@ -1,6 +1,6 @@
 // VKey - Vietnamese Phonology Rule-Pack Factory
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // Factory + identifier enum for IPhonologyRules instances. Decouples callers
 // from concrete rule-pack types so new packs (dialectal, loanword-friendly,

--- a/src/core/engine/Phonotactics.cpp
+++ b/src/core/engine/Phonotactics.cpp
@@ -1,5 +1,5 @@
 // VKey - Vietnamese Phonotactics Implementation
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 
 #include "Phonotactics.h"
 

--- a/src/core/engine/Phonotactics.h
+++ b/src/core/engine/Phonotactics.h
@@ -1,6 +1,6 @@
 // VKey - Vietnamese Phonotactics Implementation
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // Concrete implementation of IPhonotactics encoding RuleTiengViet rules.
 // Reuses VietnameseTables.h tables (kDiphthongClassic/Modern, IsTriphthong)

--- a/src/core/engine/PhonotacticsValidator.cpp
+++ b/src/core/engine/PhonotacticsValidator.cpp
@@ -1,7 +1,7 @@
 // VKey - PhonotacticsValidator Implementation
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 //
 // Vietnamese syllable structure: [C₁] + V + [C₂]

--- a/src/core/engine/PhonotacticsValidator.h
+++ b/src/core/engine/PhonotacticsValidator.h
@@ -1,7 +1,7 @@
 // VKey - PhonotacticsValidator (Vietnamese Syllable Structure Validation)
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 //
 // Validates that a character buffer forms a valid Vietnamese syllable:

--- a/src/core/engine/TypingAction.h
+++ b/src/core/engine/TypingAction.h
@@ -1,7 +1,7 @@
 // VKey - User-mappable input actions
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 //
 // Action vocabulary for TypingEngine dispatch and (future) per-user keymap.

--- a/src/core/engine/TypingEngine.cpp
+++ b/src/core/engine/TypingEngine.cpp
@@ -1,7 +1,7 @@
 // VKey - Typing Engine Implementation (unified Telex/VNI/Combined)
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 //
 // V3 changes: flat constexpr arrays for O(1) Compose(), stack-allocated

--- a/src/core/engine/TypingEngine.h
+++ b/src/core/engine/TypingEngine.h
@@ -1,7 +1,7 @@
 // VKey - Typing Engine Header (unified Telex/VNI/Combined)
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 
 #pragma once

--- a/src/core/engine/VietnamesePhonologyData.h
+++ b/src/core/engine/VietnamesePhonologyData.h
@@ -1,6 +1,6 @@
 // VKey - Vietnamese Phonology Shared Data
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // Single source of truth for Vietnamese phonological rule data consumed by
 // the project's two phonotactics validators:

--- a/src/core/engine/VietnameseTables.h
+++ b/src/core/engine/VietnameseTables.h
@@ -1,7 +1,7 @@
 // VKey - Shared Vietnamese Lookup Tables
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
-// Dual-licensed: GPL-3.0 for open-source use, commercial license for proprietary use.
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
+// Dual-licensed: AGPL-3.0 for open-source use, commercial license for proprietary use.
 // See LICENSE and LICENSE-COMMERCIAL in the project root.
 //
 // Flat constexpr arrays for O(1) composition lookups.

--- a/src/core/hotkey/HotkeyLabel.cpp
+++ b/src/core/hotkey/HotkeyLabel.cpp
@@ -1,5 +1,5 @@
 // VKey — Hotkey label formatter implementation.
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "core/hotkey/HotkeyLabel.h"
 

--- a/src/core/hotkey/HotkeyLabel.h
+++ b/src/core/hotkey/HotkeyLabel.h
@@ -1,7 +1,7 @@
 // VKey — Hotkey label formatter. Linux-portable: VK codes are plain integers.
 // Single source of truth for VK+mods → "Ctrl+Shift+F5" strings, shared between
 // TrayIcon binding text, Sciter dialog C++ side, and the Classic Win32 UI.
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/hotkey/HotkeyRegistry.cpp
+++ b/src/core/hotkey/HotkeyRegistry.cpp
@@ -1,5 +1,5 @@
 // VKey — Unified hotkey registry implementation.
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "core/hotkey/HotkeyRegistry.h"
 

--- a/src/core/hotkey/HotkeyRegistry.h
+++ b/src/core/hotkey/HotkeyRegistry.h
@@ -1,6 +1,6 @@
 // VKey — Unified hotkey registry (single source of truth for user-rebindable
 // hotkey triggers). Pure Linux-portable: VK codes treated as plain integers.
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/ipc/SecurityHelpers.h
+++ b/src/core/ipc/SecurityHelpers.h
@@ -1,5 +1,5 @@
 // VKey - Security Helper Utilities
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 #include <windows.h>

--- a/src/core/ipc/SharedConstants.h
+++ b/src/core/ipc/SharedConstants.h
@@ -1,5 +1,5 @@
 // VKey - Shared Constants between EXE and TSF DLL
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/ipc/SharedState.h
+++ b/src/core/ipc/SharedState.h
@@ -1,5 +1,5 @@
 // VKey - SharedState Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/core/ipc/SharedStateManager.cpp
+++ b/src/core/ipc/SharedStateManager.cpp
@@ -1,5 +1,5 @@
 // VKey - SharedStateManager Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "SharedStateManager.h"
 

--- a/src/core/ipc/SharedStateManager.h
+++ b/src/core/ipc/SharedStateManager.h
@@ -1,5 +1,5 @@
 // VKey - SharedStateManager
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/ComUtils.h
+++ b/src/tsf/ComUtils.h
@@ -1,5 +1,5 @@
 // VKey - COM Utility Functions
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/CompositionEditSession.h
+++ b/src/tsf/CompositionEditSession.h
@@ -1,5 +1,5 @@
 // VKey - Composition Edit Sessions
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/CompositionManager.cpp
+++ b/src/tsf/CompositionManager.cpp
@@ -1,5 +1,5 @@
 // VKey - Composition Manager Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "stdafx.h"
 #include "CompositionManager.h"

--- a/src/tsf/CompositionManager.h
+++ b/src/tsf/CompositionManager.h
@@ -1,5 +1,5 @@
 // VKey - Composition Manager
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/Define.h
+++ b/src/tsf/Define.h
@@ -1,5 +1,5 @@
 // VKey - TSF Common Definitions
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/DisplayAttribute.h
+++ b/src/tsf/DisplayAttribute.h
@@ -1,5 +1,5 @@
 // VKey - Display Attribute (No Visual Styling)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/EditSession.h
+++ b/src/tsf/EditSession.h
@@ -1,5 +1,5 @@
 // VKey - Edit Session Helper
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/EngineController.cpp
+++ b/src/tsf/EngineController.cpp
@@ -1,5 +1,5 @@
 // VKey - Engine Controller Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "stdafx.h"
 #include "EngineController.h"

--- a/src/tsf/EngineController.h
+++ b/src/tsf/EngineController.h
@@ -1,5 +1,5 @@
 // VKey - Engine Controller Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/EscRestoreLastCommitSession.h
+++ b/src/tsf/EscRestoreLastCommitSession.h
@@ -1,5 +1,5 @@
 // VKey - ESC Restore Last Commit Edit Session
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Edit session that restores raw keys for the most recent commit when user
 // presses ESC after backspacing the commit trigger (design 2026-05-17).

--- a/src/tsf/Globals.cpp
+++ b/src/tsf/Globals.cpp
@@ -1,5 +1,5 @@
 // VKey - TSF Globals Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "stdafx.h"
 #include "Globals.h"

--- a/src/tsf/Globals.h
+++ b/src/tsf/Globals.h
@@ -1,5 +1,5 @@
 // VKey - TSF Global Definitions
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/InputScopeChecker.h
+++ b/src/tsf/InputScopeChecker.h
@@ -1,5 +1,5 @@
 // VKey - Input Scope Checker for TSF
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Checks if a TSF context should block Vietnamese input:
 // - GUID_COMPARTMENT_KEYBOARD_DISABLED compartment

--- a/src/tsf/KeyEventSink.cpp
+++ b/src/tsf/KeyEventSink.cpp
@@ -1,5 +1,5 @@
 // VKey - Key Event Sink Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "stdafx.h"
 #include "KeyEventSink.h"

--- a/src/tsf/KeyEventSink.h
+++ b/src/tsf/KeyEventSink.h
@@ -1,5 +1,5 @@
 // VKey - Key Event Sink Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/LanguageBarButton.cpp
+++ b/src/tsf/LanguageBarButton.cpp
@@ -1,5 +1,5 @@
 // VKey - TSF Language Bar Button Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "stdafx.h"
 #include "LanguageBarButton.h"

--- a/src/tsf/LanguageBarButton.h
+++ b/src/tsf/LanguageBarButton.h
@@ -1,5 +1,5 @@
 // VKey - TSF Language Bar Button
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Implements ITfLangBarItemButton to show V/E toggle icon in the system tray.
 // Windows automatically shows the button when the TIP is active and hides it

--- a/src/tsf/ReadonlyContextProvider.cpp
+++ b/src/tsf/ReadonlyContextProvider.cpp
@@ -1,5 +1,5 @@
 // VKey - Readonly Context Provider Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "stdafx.h"
 #include "ReadonlyContextProvider.h"

--- a/src/tsf/ReadonlyContextProvider.h
+++ b/src/tsf/ReadonlyContextProvider.h
@@ -1,5 +1,5 @@
 // VKey - Readonly Context Provider Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // When TSF_READONLY flag is set (foreground app uses Hook, not TSF full TIP),
 // this class observes document edits and publishes a HookContextAnchor via

--- a/src/tsf/Register.cpp
+++ b/src/tsf/Register.cpp
@@ -1,5 +1,5 @@
 // VKey - TSF DLL Registration
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "stdafx.h"
 #include "Globals.h"

--- a/src/tsf/TextService.cpp
+++ b/src/tsf/TextService.cpp
@@ -1,5 +1,5 @@
 // VKey - Text Service Implementation
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "stdafx.h"
 #include "TextService.h"

--- a/src/tsf/TextService.h
+++ b/src/tsf/TextService.h
@@ -1,5 +1,5 @@
 // VKey - Text Service Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/dllmain.cpp
+++ b/src/tsf/dllmain.cpp
@@ -1,5 +1,5 @@
 // VKey - TSF DLL Entry Point
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include "stdafx.h"
 #include "Globals.h"

--- a/src/tsf/resource.h
+++ b/src/tsf/resource.h
@@ -1,5 +1,5 @@
 // VKey TSF DLL - Resource IDs
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/tsf/stdafx.h
+++ b/src/tsf/stdafx.h
@@ -1,5 +1,5 @@
 // VKey - TSF Precompiled Header
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/src/watchdog/main.cpp
+++ b/src/watchdog/main.cpp
@@ -1,5 +1,5 @@
 // VKey Watchdog - Process Supervisor
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Monitors VKey.exe via Local\VKeyHeartbeat (30s pulse, 90s
 // timeout = 3 missed pulses). On crash detect (heartbeat stale +


### PR DESCRIPTION
## Summary

Two polish commits that finish the AGPL transition and submodule split.

### `9c78ebd` — Bump source-file SPDX headers GPL → AGPL
LICENSE was swapped to AGPL-3.0 in #181, but the 197 individual source files still carried \`SPDX-License-Identifier: GPL-3.0-only\` (or its dual-licensed variant). License auditors read per-file tags, so leaving them stale would create real ambiguity.

- \`GPL-3.0-only\` → \`AGPL-3.0-only\` across 197 files
- \`Dual-licensed: GPL-3.0\` comment → \`AGPL-3.0\` in 13 dual-licensed engine files
- 2 \`L"SPDX-License-Identifier: ..."\` string literals in \`src/core/Strings.cpp\` (About-dialog body, VN + EN) so end users see the correct license

### `fc7080a` — Bump internal/ pointer
Brings in [4688623](https://github.com/phatMT97/VKey-internal/commit/4688623) from VKey-internal — adds a README to the private companion repo documenting its role, contents, the two-step update workflow, and the license posture.

## Test plan
- [x] CMake configure passes
- [x] Build VKeyTests target succeeds
- [x] All 2129 unit tests pass on Linux

## Files

196 src/ files modified (SPDX header replacement), 1 submodule pointer bump.