### PR TITLE
chore: align LICENSE-COMMERCIAL with AGPL-3.0 dual-license posture

### DIFF
--- a/LICENSE-COMMERCIAL
+++ b/LICENSE-COMMERCIAL
@@ -5,14 +5,16 @@ Copyright (c) 2024-2026 PhatMT. All rights reserved.
 
 The VKey Engine (files under src/core/engine/) is dual-licensed:
 
-1. GNU General Public License v3.0 (GPL-3.0) — see LICENSE file.
-   You may use, modify, and redistribute the Engine under GPL-3.0 terms,
-   which requires derivative works to also be licensed under GPL-3.0.
+1. GNU Affero General Public License v3.0 (AGPL-3.0) — see LICENSE file.
+   You may use, modify, and redistribute the Engine under AGPL-3.0 terms,
+   which requires derivative works to also be licensed under AGPL-3.0
+   (including derivatives offered as a network service).
 
 2. Commercial License (this file).
-   For use in proprietary/closed-source software, or any use that is
-   incompatible with GPL-3.0, you must obtain a commercial license
-   from the copyright holder.
+   For use in proprietary/closed-source software, network/SaaS deployment
+   without source disclosure, or any use that is incompatible with
+   AGPL-3.0, you must obtain a commercial license from the copyright
+   holder.
 
 Commercial License Terms
 ------------------------
@@ -46,4 +48,4 @@ This commercial license applies to the following components:
   - src/core/engine/EngineFactory.h, EngineFactory.cpp
   - src/core/engine/CodeTableConverter.h, CodeTableConverter.cpp
 
-All other files in the VKey project remain under GPL-3.0-only.
+All other files in the VKey project remain under AGPL-3.0-only.


### PR DESCRIPTION
## Summary

Last GPL-3.0 holdout in the public tree. \`LICENSE-COMMERCIAL\` described the dual license as "GPL-3.0 or commercial", but the main \`LICENSE\` was swapped to AGPL-3.0 in #181 and every source file was bumped in #182. This brings the commercial-license document into alignment.

## Changes

- \`GNU General Public License v3.0 (GPL-3.0)\` → \`GNU Affero General Public License v3.0 (AGPL-3.0)\`
- Commercial-license trigger now also covers "network/SaaS deployment without source disclosure" — the loophole AGPL closes that plain GPL does not.
- \`All other files … remain under GPL-3.0-only\` → \`AGPL-3.0-only\`

## Test plan
- [x] grep "GPL" in repo root surfaces only AGPL references now