### PR TITLE
chore: bump tests/ SPDX headers GPL-3.0 → AGPL-3.0 (43 files)

### DIFF
--- a/tests/AdaptiveTickBenchmark.cpp
+++ b/tests/AdaptiveTickBenchmark.cpp
@@ -1,5 +1,5 @@
 // Tests for the MarkActivity gate logic + hot-path budget (plan §3.6.1).
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // HookEngine.cpp is Win32-only and not linked into VKeyTests, so we mirror
 // the MarkActivity gate here as a freestanding mock — same atomics, same

--- a/tests/AdaptiveTickTest.cpp
+++ b/tests/AdaptiveTickTest.cpp
@@ -4,7 +4,7 @@
 // HookEngine::RetuneCadenceIfNeeded.
 //
 // Plan reference: docs/plans/2026-05-27-adaptive-tick-idle-backoff.md §3.1
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 

--- a/tests/AutoCapDecisionTest.cpp
+++ b/tests/AutoCapDecisionTest.cpp
@@ -1,5 +1,5 @@
 // VKey — ComputeShouldAutoCap unit tests (Linux-portable)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include <string>

--- a/tests/AutoCapStateTransitionTest.cpp
+++ b/tests/AutoCapStateTransitionTest.cpp
@@ -1,5 +1,5 @@
 // VKey — ComputeAutoCapStateTransition unit tests (Linux-portable)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Pinpoints the regression first surfaced in VKey_VKey_3404.log:
 // Ctrl+Enter armed ReadyToCapitalize → next plain 'c' was uppercased.

--- a/tests/CjkSwitchDecisionTest.cpp
+++ b/tests/CjkSwitchDecisionTest.cpp
@@ -1,7 +1,7 @@
 // Tests for DecideCjkSwitch — pure CJK auto-switch state machine.
 // Mirror pattern used by HookEngineAtomicTests: HookEngine.cpp is Windows-only,
 // so we test the extracted decision in isolation.
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 

--- a/tests/CodeTableConverterTest.cpp
+++ b/tests/CodeTableConverterTest.cpp
@@ -1,5 +1,5 @@
 // VKey - CodeTableConverter Unit Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include "core/engine/CodeTableConverter.h"

--- a/tests/CombinedEngineTest.cpp
+++ b/tests/CombinedEngineTest.cpp
@@ -1,5 +1,5 @@
 // VKey - Combined Mode (Telex + VNI) Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include "core/engine/TypingEngine.h"

--- a/tests/CommitUndoExemptionTest.cpp
+++ b/tests/CommitUndoExemptionTest.cpp
@@ -1,5 +1,5 @@
 // VKey — IsCommitUndoExemptKey unit tests (Linux-portable)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Pin contract for the exemption rule shared by HookEngine's
 // commit-undo Primed-branch cancel sites:

--- a/tests/ConfigEventTest.cpp
+++ b/tests/ConfigEventTest.cpp
@@ -1,5 +1,5 @@
 // VKey - ConfigEvent Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include "core/config/ConfigEvent.h"

--- a/tests/ConfigManagerTest.cpp
+++ b/tests/ConfigManagerTest.cpp
@@ -1,5 +1,5 @@
 // VKey - ConfigManager Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include "core/config/ConfigManager.h"

--- a/tests/ConfigReloadBurstTest.cpp
+++ b/tests/ConfigReloadBurstTest.cpp
@@ -1,5 +1,5 @@
 // ConfigReloadBurstTest.cpp
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Phase 4 — replay harness for concurrency invariants
 // (docs/plans/2026-05-19-architecture-review-design.md §Phase 4).

--- a/tests/ConfigSnapshotTest.cpp
+++ b/tests/ConfigSnapshotTest.cpp
@@ -1,5 +1,5 @@
 // ConfigSnapshotTest.cpp
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Phase 3a — single-publisher RCU semantics for `ConfigSnapshot`. See
 // docs/plans/2026-05-19-architecture-review-design.md §Phase 3.

--- a/tests/CustomKeyMapTest.cpp
+++ b/tests/CustomKeyMapTest.cpp
@@ -1,6 +1,6 @@
 // VKey - customKeyMap (G-4) Tests
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // Tests for the per-key user override layer added in Path G G-4.
 // Spec: docs/superpowers/specs/2026-05-07-path-g-g4-customkeymap-design.md

--- a/tests/DigitLedWordDecisionTest.cpp
+++ b/tests/DigitLedWordDecisionTest.cpp
@@ -7,7 +7,7 @@
 // step 5 / TSF EngineController WantKey step 1) early-returns on Ctrl/Alt/Win
 // before reaching DecideDigitLed. Only Shift is forwarded as an input field
 // because Shift+digit produces punctuation (!@#…) and must not arm.
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 

--- a/tests/EngineBenchmarkTest.cpp
+++ b/tests/EngineBenchmarkTest.cpp
@@ -1,5 +1,5 @@
 // VKey - Engine CPU Benchmark Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 // Measures per-keystroke latency and throughput for Telex and VNI input methods.
 
 #include <gtest/gtest.h>

--- a/tests/EngineFactoryTest.cpp
+++ b/tests/EngineFactoryTest.cpp
@@ -1,5 +1,5 @@
 // VKey - EngineFactory Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include "core/engine/EngineFactory.h"

--- a/tests/EnglishBypassTest.cpp
+++ b/tests/EnglishBypassTest.cpp
@@ -1,5 +1,5 @@
 // VKey - "Gõ tự do" / allowEnglishBypass tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Locks the contract for the `allowEnglishBypass` toggle (UI label "Gõ tự do",
 // TypingConfig.h: "Bypass English blocking, e.g. yes -> ýe").

--- a/tests/FeatureOptionsTest.cpp
+++ b/tests/FeatureOptionsTest.cpp
@@ -1,5 +1,5 @@
 // VKey - Feature Options Tests (modernOrtho, autoCaps, allowZwjf)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Tests for the 3 feature flags:
 //   1. modernOrtho  — Modern tone placement on diphthongs (ua→uá, ue→ué)

--- a/tests/FocusInterleavingTest.cpp
+++ b/tests/FocusInterleavingTest.cpp
@@ -1,5 +1,5 @@
 // FocusInterleavingTest.cpp
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Phase 2b — two-phase focus. See
 // docs/plans/2026-05-19-architecture-review-design.md §Phase 2.

--- a/tests/HeartbeatPublisherTest.cpp
+++ b/tests/HeartbeatPublisherTest.cpp
@@ -1,5 +1,5 @@
 // VKey — HeartbeatPublisher unit tests (Windows-only)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include "app/system/HeartbeatPublisher.h"

--- a/tests/HookCommandMailboxTest.cpp
+++ b/tests/HookCommandMailboxTest.cpp
@@ -1,5 +1,5 @@
 // HookCommandMailboxTest.cpp
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Phase 2a — single-writer composition state, mailbox infra. See
 // docs/plans/2026-05-19-architecture-review-design.md §Phase 2.

--- a/tests/HookContextAnchorTest.cpp
+++ b/tests/HookContextAnchorTest.cpp
@@ -1,5 +1,5 @@
 // VKey - HookContextAnchor Unit Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include <atomic>

--- a/tests/HotkeyConfigMigrationTest.cpp
+++ b/tests/HotkeyConfigMigrationTest.cpp
@@ -1,6 +1,6 @@
 // VKey — HotkeyConfig schema migration (wchar_t key → uint32_t vk).
 // Verifies the legacy-character → VK rule: clean (A-Z/0-9), nothing else.
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 

--- a/tests/HotkeyLabelTest.cpp
+++ b/tests/HotkeyLabelTest.cpp
@@ -1,5 +1,5 @@
 // VKey — HotkeyLabel formatter unit tests (Linux-portable, no Win32 deps).
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 

--- a/tests/HotkeyRegistryTest.cpp
+++ b/tests/HotkeyRegistryTest.cpp
@@ -1,5 +1,5 @@
 // VKey — HotkeyRegistry unit tests (Linux-portable, no Win32 deps)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 

--- a/tests/InjectorSwitchTest.cpp
+++ b/tests/InjectorSwitchTest.cpp
@@ -1,5 +1,5 @@
 // InjectorSwitchTest.cpp
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Phase 4 — replay harness for concurrency invariants
 // (docs/plans/2026-05-19-architecture-review-design.md §Phase 4).

--- a/tests/LoggerTest.cpp
+++ b/tests/LoggerTest.cpp
@@ -1,5 +1,5 @@
 // VKey - Logger tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Test scope:
 //  - Runtime gate: Log() is noop when disabled, writes when enabled.

--- a/tests/MacroCaseTest.cpp
+++ b/tests/MacroCaseTest.cpp
@@ -1,5 +1,5 @@
 // VKey - Macro expansion decision unit tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include "core/MacroCase.h"

--- a/tests/MacroPrefixTest.cpp
+++ b/tests/MacroPrefixTest.cpp
@@ -1,5 +1,5 @@
 // VKey - Multi-word Macro Prefix Matcher Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include "core/MacroPrefix.h"

--- a/tests/MainThreadWorkerTests.cpp
+++ b/tests/MainThreadWorkerTests.cpp
@@ -1,5 +1,5 @@
 // MainThreadWorkerTests.cpp
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Sprint 1 D8: scaffolding contract tests for MainThreadWorker.
 //

--- a/tests/ParseConfigLinesTest.cpp
+++ b/tests/ParseConfigLinesTest.cpp
@@ -1,5 +1,5 @@
 // VKey — ParseConfigLines helper unit tests (Linux-portable).
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Pins the line-filtering contract used by all dialog Import handlers
 // (ExcludedApps, TsfApps, SpellExclusions, MacroTable × Sciter+Classic).

--- a/tests/PerfHistogramTest.cpp
+++ b/tests/PerfHistogramTest.cpp
@@ -1,5 +1,5 @@
 // PerfHistogramTest.cpp
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Phase 1 (per-stage histogram) verification — see
 // docs/plans/2026-05-19-architecture-review-design.md §Phase 1.

--- a/tests/PhonotacticsTest.cpp
+++ b/tests/PhonotacticsTest.cpp
@@ -1,5 +1,5 @@
 // VKey - Phonotactics Unit Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Tests for IPhonotactics rule engine: tone position, syllable validity,
 // completability. Operates on rendered Vietnamese text (wstring_view).

--- a/tests/PhonotacticsValidatorTest.cpp
+++ b/tests/PhonotacticsValidatorTest.cpp
@@ -1,5 +1,5 @@
 // VKey - PhonotacticsValidator Unit Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Tests: Direct validator tests + engine integration tests
 

--- a/tests/SharedStateTest.cpp
+++ b/tests/SharedStateTest.cpp
@@ -1,5 +1,5 @@
 // VKey - SharedState Unit Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include "core/ipc/SharedState.h"

--- a/tests/TelexDictionaryTest.cpp
+++ b/tests/TelexDictionaryTest.cpp
@@ -1,5 +1,5 @@
 // VKey - Vietnamese Dictionary Coverage Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Data-driven tests covering common Vietnamese words.
 // Supplements existing scenario-based tests in TelexEngineTest.cpp.

--- a/tests/TelexEngineTest.cpp
+++ b/tests/TelexEngineTest.cpp
@@ -1,5 +1,5 @@
 // VKey - TelexEngine Unit Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 // Story 1.2: Comprehensive Telex transformation tests (50+ tests)
 
 #include <gtest/gtest.h>

--- a/tests/TestHelper.h
+++ b/tests/TestHelper.h
@@ -1,5 +1,5 @@
 // VKey - Shared Test Utilities
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #pragma once
 

--- a/tests/ThreadOwnershipTest.cpp
+++ b/tests/ThreadOwnershipTest.cpp
@@ -1,5 +1,5 @@
 // ThreadOwnershipTest.cpp
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // Phase 2d — single-writer thread-ownership invariants. See
 // docs/plans/2026-05-19-architecture-review-design.md §Phase 2.

--- a/tests/TypingActionTest.cpp
+++ b/tests/TypingActionTest.cpp
@@ -1,6 +1,6 @@
 // VKey - TypingAction Tests
 // Copyright (c) 2024-2026 PhatMT. All rights reserved.
-// SPDX-License-Identifier: GPL-3.0-only OR LicenseRef-VKey-Commercial
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-VKey-Commercial
 //
 // Unit tests for ClassifyKey — verifies key→action mapping per mode.
 

--- a/tests/UpdateSecurityTest.cpp
+++ b/tests/UpdateSecurityTest.cpp
@@ -1,5 +1,5 @@
 // VKey - UpdateSecurity Unit Tests
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include "app/system/UpdateSecurity.h"

--- a/tests/VniParityTest.cpp
+++ b/tests/VniParityTest.cpp
@@ -1,5 +1,5 @@
 // VKey - VNI Parity Tests (TypingEngine with InputMethod::VNI)
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 
 #include <gtest/gtest.h>
 #include "core/engine/TypingEngine.h"

--- a/tests/core/config/ConfigSnapshotBuilderTest.cpp
+++ b/tests/core/config/ConfigSnapshotBuilderTest.cpp
@@ -1,5 +1,5 @@
 // tests/core/config/ConfigSnapshotBuilderTest.cpp
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: AGPL-3.0-only
 //
 // TDD tests for ConfigSnapshotBuilder::BuildFromToml().
 // Phase 1 of docs/plans/2026-05-22-hookengine-degod-probe.md.


### PR DESCRIPTION
Follow-up to #182. Previous sed targeted only `src/` and missed `tests/`. With this, the tracked public tree has zero remaining `SPDX-License-Identifier: GPL-3.0-only` strings.

Build + 2129 tests verified locally.